### PR TITLE
Add auto-generate instructions button to new agent form

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,5 +1,7 @@
 # Progress
 
+[2026-04-03] Added "Auto-generate" button to the new agent form. When name and role are filled, clicking the button calls the headless Claude endpoint to generate tailored system prompt instructions and populates the Instructions textarea. Shows a loading spinner while generating and is disabled until name/role are provided.
+
 [2026-04-03] Rebuilt the agents experience around durable filesystem-backed conversations. Added a shared conversation store (`data/.agents/.conversations/*`), moved manual sessions/jobs/heartbeats onto the daemon PTY runtime, added conversations APIs, and replaced the old agent list/detail split with a three-pane agents workspace focused on live and replayable Claude sessions. Also added `scripts/launch-chrome-debug.sh` plus `npm run debug:chrome` for CDP-based Chrome debugging on port 9222.
 
 [2026-04-03] Major agent system refactor — removed "Plays" concept entirely: deleted play-manager.ts, trigger-engine.ts, api/plays/ routes, playbook-catalog.tsx, webhook/[slug] and triggers API routes. Unified all Claude invocations to use PTY via the cabinet daemon (heartbeat.ts runHeartbeat, daemon executeJob). Cleaned up all play references from 15+ components/types/API routes. Build passes clean with no play routes.

--- a/src/components/agents/agents-workspace.tsx
+++ b/src/components/agents/agents-workspace.tsx
@@ -232,6 +232,7 @@ export function AgentsWorkspace({
   const [savingSettings, setSavingSettings] = useState(false);
   const [creatingAgent, setCreatingAgent] = useState(false);
   const [deletingAgent, setDeletingAgent] = useState(false);
+  const [generatingInstructions, setGeneratingInstructions] = useState(false);
   const [newAgentDraft, setNewAgentDraft] = useState<NewAgentDraft>(DEFAULT_NEW_AGENT);
   const treeNodes = useTreeStore((state) => state.nodes);
   const selectPage = useTreeStore((state) => state.selectPage);
@@ -617,6 +618,48 @@ export function AgentsWorkspace({
       setSelectedConversationId(data.run.id as string);
       setMode("conversation");
       await refreshConversations();
+    }
+  }
+
+  async function generateInstructions() {
+    if (!newAgentDraft.name.trim() || !newAgentDraft.role.trim()) return;
+    setGeneratingInstructions(true);
+    try {
+      const prompt = `Generate system prompt instructions for a Cabinet AI agent. Output ONLY the instructions body — no YAML frontmatter, no preamble, no explanation.
+
+Agent details:
+- Name: ${newAgentDraft.name.trim()}
+- Role: ${newAgentDraft.role.trim()}
+- Department: ${newAgentDraft.department || "general"}
+- Type: ${newAgentDraft.type || "specialist"}
+
+Use this exact structure:
+
+# {Name} Agent
+
+You are the {Name}. Your role is to:
+
+1. **{Responsibility 1}** — one-line description
+2. **{Responsibility 2}** — one-line description
+3. **{Responsibility 3}** — one-line description
+4. **{Responsibility 4}** — one-line description
+
+## Working Style
+- Short, opinionated bullet (3-5 bullets)
+
+Derive 4 responsibilities and 3-5 working-style bullets directly from the name and role. Be specific and actionable. Output nothing outside the structure above.`;
+
+      const response = await fetch("/api/agents/headless", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt }),
+      });
+      const data = await response.json();
+      if (data.ok && data.output) {
+        setNewAgentDraft((current) => ({ ...current, body: data.output }));
+      }
+    } finally {
+      setGeneratingInstructions(false);
     }
   }
 
@@ -1118,8 +1161,28 @@ export function AgentsWorkspace({
                             ))}
                           </div>
                         </div>
-                        <label className="col-span-2 space-y-1 text-[11px] text-muted-foreground">
-                          <span>Instructions</span>
+                        <div className="col-span-2 space-y-1 text-[11px] text-muted-foreground">
+                          <div className="flex items-center justify-between">
+                            <span>Instructions</span>
+                            <button
+                              type="button"
+                              onClick={generateInstructions}
+                              disabled={generatingInstructions || !newAgentDraft.name.trim() || !newAgentDraft.role.trim()}
+                              className="flex items-center gap-1 rounded-md px-2 py-0.5 text-[11px] text-primary hover:bg-primary/10 disabled:cursor-not-allowed disabled:opacity-40 transition-colors"
+                            >
+                              {generatingInstructions ? (
+                                <>
+                                  <Loader2 className="h-3 w-3 animate-spin" />
+                                  Generating…
+                                </>
+                              ) : (
+                                <>
+                                  <Zap className="h-3 w-3" />
+                                  Auto-generate
+                                </>
+                              )}
+                            </button>
+                          </div>
                           <textarea
                             value={newAgentDraft.body}
                             onChange={(event) =>
@@ -1128,7 +1191,7 @@ export function AgentsWorkspace({
                             className="min-h-[220px] w-full rounded-lg border border-border bg-background px-3 py-2 text-[13px] text-foreground"
                             placeholder="Define how this agent should work inside Cabinet and the KB."
                           />
-                        </label>
+                        </div>
                       </div>
                       <div className="mt-4 flex items-center justify-between">
                         <label className="flex items-center gap-2 text-[12px] text-muted-foreground">


### PR DESCRIPTION
## Summary

- Adds an **Auto-generate** button next to the Instructions label in the new agent creation form
- When clicked, calls the headless Claude endpoint (`/api/agents/headless`) with the agent's name, role, department, and type to generate structured system prompt instructions
- Button is disabled until both Name and Role are filled in; shows a spinner while generating
- Generated output follows a consistent structure: `# {Name} Agent` heading, numbered bold responsibilities, and a `## Working Style` section

## Test plan

- [x] Open the Agents workspace → Settings → Add agent
- [x] Fill in Name and Role; confirm the Auto-generate button becomes enabled
- [x] Click Auto-generate and verify the spinner appears, then the Instructions textarea is populated with structured markdown
- [x] Confirm the generated content matches the expected format (heading, numbered responsibilities, Working Style bullets)
- [x] Verify the button is disabled when Name or Role is empty
- [x] Manually edit the generated instructions and confirm they can still be overridden before creating the agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)