### PR TITLE
Fix WebSocket terminal connection on WSL2

### DIFF
--- a/src/components/terminal/web-terminal.tsx
+++ b/src/components/terminal/web-terminal.tsx
@@ -164,7 +164,7 @@ export function WebTerminal({
               : window.location.protocol === "https:"
                 ? "wss"
                 : "ws";
-            const host = isLocalDev ? "127.0.0.1:3001" : window.location.host;
+            const host = isLocalDev ? "localhost:3001" : window.location.host;
             const wsUrl = `${protocol}://${host}/api/daemon/pty?${params.toString()}`;
 
             ws = new WebSocket(wsUrl);


### PR DESCRIPTION
## Summary
- Use `localhost` instead of `127.0.0.1` for the daemon WebSocket URL in local dev mode
- WSL2 NAT networking doesn't always forward `127.0.0.1` from the Windows host to the WSL2 VM, causing the terminal WebSocket connection to fail silently
- `localhost` resolves correctly in both native Linux and WSL2 environments

## Test plan
- [x] Tested on WSL2 (NAT mode) — terminal connects successfully with `localhost:3001`
- [ ] Verify no regression on native Linux / macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)