### PR TITLE
Fix mobile responsiveness for agents, AI panel, and sidebar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM node:22-alpine AS base
 
 # Install dependencies only
 FROM base AS deps
+RUN apk add --no-cache python3 make g++ linux-headers
 WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm ci
@@ -20,23 +21,30 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# Install Claude CLI
+# Install Claude CLI, gh CLI, and git (needed for worktrees)
 RUN npm install -g @anthropic-ai/claude-code || true
+RUN apk add --no-cache github-cli git
 
-# Create non-root user
+# Create non-root user with proper home directory
 RUN addgroup --system --gid 1001 cabinet
-RUN adduser --system --uid 1001 cabinet
+RUN adduser --system --uid 1001 --home /home/cabinet cabinet
+ENV HOME=/home/cabinet
 
 # Copy built application
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/server ./server
+COPY --from=builder /app/src ./src
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/tsconfig.json ./tsconfig.json
 
 # Data directory (mount as volume)
 RUN mkdir -p /app/data && chown cabinet:cabinet /app/data
+
+# Repos and worktrees directories (mount points)
+RUN mkdir -p /repos /worktrees && chown cabinet:cabinet /repos /worktrees
 
 USER cabinet
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -82,4 +82,6 @@
 
 [2026-04-03] Added light cabinet icon as sidebar logo (public/logo-light.png) next to 'Cabinet' text. Updated favicon to match.
 
+[2026-04-04] Mobile responsiveness overhaul: extracted shared useIsMobile hook, added master-detail pattern to agents workspace (list/detail toggle with back nav on mobile), made AI panel a full-screen overlay on mobile with auto-collapse, moved sidebar toggle from absolute-positioned floating button to inline header placement to prevent content overlap, and fixed sidebar expand animation on desktop.
+
 [2026-04-03] Fixed scheduled plays never executing: added cron registration for plays with schedule triggers in play-manager.ts. Plays with schedule triggers now get registered with node-cron on app startup (via /api/agents/personas init) and re-registered when plays are created/updated. Added "schedule" case to trigger-engine.ts. Rewrote README.md to match runcabinet.com website style with demo video, problem/solution framing, feature matrix, comparison table, and strong CTAs.

--- a/README.md
+++ b/README.md
@@ -161,15 +161,3 @@ npx create-cabinet my-startup
 ---
 
 MIT License
-
----
-
-## Star History
-
-<a href="https://www.star-history.com/?repos=hilash%2Fcabinet&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=hilash/cabinet&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=hilash/cabinet&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=hilash/cabinet&type=date&legend=top-left" />
- </picture>
-</a>

--- a/data/theleagueof/courses/.repo.yaml
+++ b/data/theleagueof/courses/.repo.yaml
@@ -1,0 +1,6 @@
+name: courses
+local: /repos/courses
+remote: https://github.com/micahbrich/courses
+source: both
+branch: main
+description: League course content and learning platform — The Confident Designer, Typography 101

--- a/data/theleagueof/courses/index.md
+++ b/data/theleagueof/courses/index.md
@@ -1,0 +1,31 @@
+---
+title: Courses
+created: 2026-04-03T00:00:00Z
+modified: 2026-04-03T00:00:00Z
+tags: [league, courses, education, mdx]
+order: 2
+---
+
+# Courses
+
+Course content and learning platform for The League's design school.
+
+## Tech Stack
+
+- Next.js 16, React, TypeScript
+- Supabase (auth, database)
+- MDX (lesson content)
+- Tailwind CSS + shadcn/ui
+- Stripe (payments)
+
+## Gateway Course: The Confident Designer
+
+The foundational course teaching contrast and affinity through typography. Entry point to the school.
+
+## Lesson Anatomy
+
+Hook → Concept → Demo → Application → Exercise → Bridge
+
+## Repository
+
+See linked `.repo.yaml` for local path and remote URL.

--- a/data/theleagueof/index.md
+++ b/data/theleagueof/index.md
@@ -1,0 +1,36 @@
+---
+title: The League of Moveable Type
+created: 2026-04-03T00:00:00Z
+modified: 2026-04-03T00:00:00Z
+tags: [league, organization, typography]
+icon: type
+order: 1
+---
+
+# The League of Moveable Type
+
+The first open-source font foundry (est. 2009). We're becoming a design confidence school that uses typography as the entry point. Our fonts are the front door; the school is the house.
+
+## Thesis
+
+Great design isn't about knowing the right fonts or the right rules. It's about understanding the forces underneath so you can make anything work.
+
+Core framework: **contrast and affinity** — two ends of one lever. Five controls: size, weight, position, color, spacing.
+
+## Repositories
+
+- [[v3]] — Main website and font foundry platform (Next.js)
+- [[courses]] — Course content and learning platform (Next.js, Supabase, MDX)
+- [[membership]] — Membership portal and payments (Next.js, Supabase, Stripe)
+
+## Business Model
+
+- $299/year membership, one tier, everything included
+- Growing catalog makes it more valuable over time
+- Fonts are free and open-source — they drive traffic to the school
+
+## Brand Principles
+
+- **Self-host everything.** Fonts served from League infrastructure, never Google Fonts CDN
+- **Every touchpoint is brand.** Install commands, URLs, snippets reference the League
+- **Drive traffic home.** Distribution features bring developers to theleagueofmoveabletype.com

--- a/data/theleagueof/membership/.repo.yaml
+++ b/data/theleagueof/membership/.repo.yaml
@@ -1,0 +1,6 @@
+name: league-membership
+local: /repos/league-membership
+remote: https://github.com/micahbrich/league-membership
+source: both
+branch: main
+description: League membership portal — Supabase auth, Stripe subscriptions

--- a/data/theleagueof/membership/index.md
+++ b/data/theleagueof/membership/index.md
@@ -1,0 +1,28 @@
+---
+title: Membership
+created: 2026-04-03T00:00:00Z
+modified: 2026-04-03T00:00:00Z
+tags: [league, membership, stripe, supabase]
+order: 3
+---
+
+# Membership
+
+Membership portal and payment platform for The League's school.
+
+## Tech Stack
+
+- Next.js 16, React, TypeScript
+- Supabase (auth, user management)
+- Stripe (subscription payments)
+- Tailwind CSS + shadcn/ui (Radix-based)
+- Oxlint, Lefthook (code quality)
+
+## Business Model
+
+- $299/year, one tier, everything included
+- Growing catalog increases value over time
+
+## Repository
+
+See linked `.repo.yaml` for local path and remote URL.

--- a/data/theleagueof/v3/.repo.yaml
+++ b/data/theleagueof/v3/.repo.yaml
@@ -1,0 +1,6 @@
+name: theleagueof-v3
+local: /repos/theleagueof-v3
+remote: https://github.com/micahbrich/theleagueof-v3
+source: both
+branch: main
+description: The League of Moveable Type — main website and font foundry platform

--- a/data/theleagueof/v3/index.md
+++ b/data/theleagueof/v3/index.md
@@ -1,0 +1,32 @@
+---
+title: League v3 — Main Site
+created: 2026-04-03T00:00:00Z
+modified: 2026-04-03T00:00:00Z
+tags: [league, website, nextjs, fonts]
+order: 1
+---
+
+# League v3 — Main Site
+
+The main website and font foundry platform at theleagueofmoveabletype.com.
+
+## Tech Stack
+
+- Next.js 15, React 19 RC, TypeScript
+- Tailwind CSS + shadcn/ui (Radix-based)
+- Framer Motion, Embla Carousel
+- MDX content, Notion integration
+- Fontkit, font metrics tooling
+- Mailchimp (waitlist), Stripe (payments), Mux (video)
+- PostHog analytics, Vercel deployment
+
+## Active Workstreams
+
+- Shadcn font registry — self-hosted CSS-based font distribution
+- Membership page with waitlist signup
+- Dark mode support via shadcn-ui
+- Font specimen pages with install snippets
+
+## Repository
+
+See linked `.repo.yaml` for local path and remote URL.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,23 +6,23 @@ services:
       - KB_PASSWORD=${KB_PASSWORD:-}
       - NODE_ENV=production
     volumes:
+      # Cabinet data (KB pages, agents, sqlite)
       - ./data:/app/data
+
+      # Auth pass-through (read-only for isolation)
+      - ~/.claude:/home/cabinet/.claude:ro
+      - ~/.config/gh:/home/cabinet/.config/gh:ro
+
+      # League repos (read-write for agent commits/worktrees)
+      - ~/orgs/theleagueof/theleagueof-v3:/repos/theleagueof-v3
+      - ~/orgs/theleagueof/courses:/repos/courses
+      - ~/orgs/theleagueof/league-membership:/repos/league-membership
+      - ~/orgs/theleagueof:/repos/league-org
+
+      # Worktree scratch space (ephemeral, inside container)
+      - worktrees:/worktrees
     ports:
       - "3000:3000"
 
-  caddy:
-    image: caddy:2-alpine
-    restart: unless-stopped
-    ports:
-      - "80:80"
-      - "443:443"
-    volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile
-      - caddy_data:/data
-      - caddy_config:/config
-    depends_on:
-      - kb
-
 volumes:
-  caddy_data:
-  caddy_config:
+  worktrees:

--- a/src/components/agents/agents-workspace.tsx
+++ b/src/components/agents/agents-workspace.tsx
@@ -2,10 +2,12 @@
 
 import { useEffect, useState } from "react";
 import {
+  ArrowLeft,
   Bot,
   CheckCircle2,
   FileText,
   Loader2,
+  PanelLeft,
   Pause,
   Play,
   Plus,
@@ -17,6 +19,7 @@ import {
   Zap,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { WebTerminal } from "@/components/terminal/web-terminal";
@@ -207,6 +210,8 @@ export function AgentsWorkspace({
   const [conversations, setConversations] = useState<ConversationMeta[]>([]);
   const [conversationsLoading, setConversationsLoading] = useState(true);
   const [hasLoadedConversations, setHasLoadedConversations] = useState(false);
+  const { isMobile } = useIsMobile();
+  const [mobilePanel, setMobilePanel] = useState<"list" | "detail">("list");
   const [mode, setMode] = useState<MainPanelMode>("composer");
   const [previousMode, setPreviousMode] = useState<NonSettingsMode>("composer");
   const [activeAgentSlug, setActiveAgentSlug] = useState<string | null>(
@@ -236,6 +241,8 @@ export function AgentsWorkspace({
   const treeNodes = useTreeStore((state) => state.nodes);
   const selectPage = useTreeStore((state) => state.selectPage);
   const setSection = useAppStore((state) => state.setSection);
+  const sidebarCollapsed = useAppStore((state) => state.sidebarCollapsed);
+  const setSidebarCollapsed = useAppStore((state) => state.setSidebarCollapsed);
 
   const allPages = flattenTree(treeNodes);
   const settingsAgentSlug =
@@ -403,6 +410,7 @@ export function AgentsWorkspace({
     setSettingsTarget(agentSlug);
     setSelectedJobId(null);
     setJobDraft(null);
+    setMobilePanel("detail");
   }
 
   function startNewAgentDraft() {
@@ -414,6 +422,7 @@ export function AgentsWorkspace({
     setSelectedJobId(null);
     setJobDraft(null);
     setNewAgentDraft(DEFAULT_NEW_AGENT);
+    setMobilePanel("detail");
   }
 
   function exitSettings() {
@@ -703,9 +712,23 @@ export function AgentsWorkspace({
 
   return (
     <div className="flex flex-1 overflow-hidden">
-      <div className="w-[340px] min-w-[340px] border-r border-border bg-background">
+      <div className={cn(
+        "w-[340px] min-w-[340px] border-r border-border bg-background",
+        "max-md:w-full max-md:min-w-0",
+        mobilePanel === "detail" && "max-md:hidden"
+      )}>
         <div className="border-b border-border px-4 py-3">
           <div className="flex items-start justify-between gap-3">
+            {sidebarCollapsed && (
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className="shrink-0 mt-0.5"
+                onClick={() => setSidebarCollapsed(false)}
+              >
+                <PanelLeft className="h-3.5 w-3.5" />
+              </Button>
+            )}
             <div>
               <h3 className="text-[14px] font-semibold">
                 {activeAgent ? activeAgent.name : "All agents"}
@@ -716,16 +739,29 @@ export function AgentsWorkspace({
                   : "Recent runs across your whole team"}
               </p>
             </div>
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              onClick={() => {
-                void refreshAgents();
-                void refreshConversations();
-              }}
-            >
-              <RefreshCw className="h-3.5 w-3.5" />
-            </Button>
+            <div className="flex gap-1">
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className="hidden max-md:flex"
+                onClick={() => {
+                  setMode("composer");
+                  setMobilePanel("detail");
+                }}
+              >
+                <Plus className="h-3.5 w-3.5" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => {
+                  void refreshAgents();
+                  void refreshConversations();
+                }}
+              >
+                <RefreshCw className="h-3.5 w-3.5" />
+              </Button>
+            </div>
           </div>
           <div className="mt-3 flex flex-wrap gap-1.5">
             {(["all", "manual", "job", "heartbeat"] as TriggerFilter[]).map((filter) => (
@@ -772,6 +808,7 @@ export function AgentsWorkspace({
                     onClick={() => {
                       setSelectedConversationId(conversation.id);
                       setMode("conversation");
+                      setMobilePanel("detail");
                     }}
                     className={cn(
                       "w-full rounded-xl border px-3 py-3 text-left transition-colors",
@@ -822,11 +859,20 @@ export function AgentsWorkspace({
         </ScrollArea>
       </div>
 
-      <div className="flex-1 overflow-hidden">
+      <div className={cn(
+        "flex-1 overflow-hidden",
+        mobilePanel === "list" && "max-md:hidden"
+      )}>
         {mode === "conversation" && selectedConversationMeta ? (
           <div className="flex h-full flex-col">
             <div className="border-b border-border px-5 py-4">
               <div className="flex items-center gap-2">
+                <button
+                  className="hidden max-md:block shrink-0"
+                  onClick={() => setMobilePanel("list")}
+                >
+                  <ArrowLeft className="h-4 w-4" />
+                </button>
                 <span className="text-lg">
                   {agents.find((agent) => agent.slug === selectedConversationMeta.agentSlug)?.emoji || "🤖"}
                 </span>
@@ -892,6 +938,12 @@ export function AgentsWorkspace({
           <div className="flex h-full flex-col">
             <div className="border-b border-border px-5 py-4">
               <div className="flex items-start justify-between gap-3">
+                <button
+                  className="hidden max-md:block shrink-0 mt-1"
+                  onClick={() => setMobilePanel("list")}
+                >
+                  <ArrowLeft className="h-4 w-4" />
+                </button>
                 {settingsTarget === "directory" || !settingsTarget ? (
                   <div>
                     <h3 className="text-[15px] font-semibold">Agent settings</h3>
@@ -1411,6 +1463,12 @@ export function AgentsWorkspace({
           <div className="flex h-full flex-col">
             <div className="border-b border-border px-5 py-4">
               <div className="flex items-start justify-between gap-3">
+                <button
+                  className="hidden max-md:block shrink-0 mt-1"
+                  onClick={() => setMobilePanel("list")}
+                >
+                  <ArrowLeft className="h-4 w-4" />
+                </button>
                 <div>
                   <h3 className="text-[15px] font-semibold">
                     {activeAgentSlug

--- a/src/components/ai-panel/ai-panel.tsx
+++ b/src/components/ai-panel/ai-panel.tsx
@@ -14,6 +14,7 @@ import {
   Loader2,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { Button } from "@/components/ui/button";
 import { useAIPanelStore } from "@/stores/ai-panel-store";
 import { useEditorStore } from "@/stores/editor-store";
@@ -63,6 +64,7 @@ export function AIPanel() {
     clearAllSessions,
   } = useAIPanelStore();
   const { currentPath, loadPage } = useEditorStore();
+  const { isMobile } = useIsMobile();
   const [input, setInput] = useState("");
   const [mentionedPages, setMentionedPages] = useState<string[]>([]);
   const [pastSessions, setPastSessions] = useState<PastSession[]>([]);
@@ -405,7 +407,18 @@ export function AIPanel() {
     otherPageRunningSessions.length > 0;
 
   return (
-    <div className="w-[480px] min-w-[420px] border-l border-border bg-background flex flex-col">
+    <>
+      {/* Mobile scrim */}
+      {isMobile && (
+        <div
+          className="fixed inset-0 bg-black/50 z-30"
+          onClick={close}
+        />
+      )}
+      <div className={cn(
+        "w-[480px] min-w-[420px] border-l border-border bg-background flex flex-col",
+        "max-md:fixed max-md:inset-0 max-md:w-full max-md:min-w-0 max-md:z-40 max-md:border-l-0"
+      )}>
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
         <div className="flex items-center gap-2">
@@ -701,5 +714,6 @@ export function AIPanel() {
         </div>
       </div>
     </div>
+    </>
   );
 }

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -18,6 +18,7 @@ import { StatusBar } from "@/components/layout/status-bar";
 import { OnboardingWizard } from "@/components/onboarding/onboarding-wizard";
 import { useTreeStore } from "@/stores/tree-store";
 import { useAppStore } from "@/stores/app-store";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import type { TreeNode } from "@/types";
 
 function findNode(nodes: TreeNode[], path: string): TreeNode | null {
@@ -41,6 +42,14 @@ export function AppShell() {
   const setSidebarCollapsed = useAppStore((s) => s.setSidebarCollapsed);
   const setAiPanelCollapsed = useAppStore((s) => s.setAiPanelCollapsed);
   const aiPanelCollapsed = useAppStore((s) => s.aiPanelCollapsed);
+  const { isMobile, mounted } = useIsMobile();
+
+  // Auto-collapse AI panel on mobile
+  useEffect(() => {
+    if (mounted && isMobile) {
+      setAiPanelCollapsed(true);
+    }
+  }, [mounted, isMobile, setAiPanelCollapsed]);
 
   // Onboarding wizard state
   const [showWizard, setShowWizard] = useState<boolean | null>(null);

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Sparkles, Copy, Download, Search, FileCode, Terminal, FileDown } from "lucide-react";
+import { Sparkles, Copy, Download, Search, FileCode, Terminal, FileDown, PanelLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -18,6 +18,8 @@ import { cn } from "@/lib/utils";
 export function Header() {
   const { frontmatter, content, currentPath } = useEditorStore();
   const { isOpen, toggle } = useAIPanelStore();
+  const sidebarCollapsed = useAppStore((s) => s.sidebarCollapsed);
+  const setSidebarCollapsed = useAppStore((s) => s.setSidebarCollapsed);
   const { terminalOpen, toggleTerminal } = useAppStore();
 
   const handleCopyMarkdown = async () => {
@@ -52,6 +54,16 @@ export function Header() {
   return (
     <header className="flex items-center justify-between border-b border-border px-4 py-2 bg-background/80 backdrop-blur-sm">
       <div className="flex items-center gap-2">
+        {sidebarCollapsed && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 shrink-0"
+            onClick={() => setSidebarCollapsed(false)}
+          >
+            <PanelLeft className="h-4 w-4" />
+          </Button>
+        )}
         <h1 className="text-[13px] font-medium text-foreground truncate tracking-[-0.01em]">
           {frontmatter?.title || "Cabinet"}
         </h1>

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -33,19 +33,7 @@ import { Separator } from "@/components/ui/separator";
 import { TreeView } from "./tree-view";
 import { NewPageDialog } from "./new-page-dialog";
 import { useAppStore } from "@/stores/app-store";
-
-function useIsMobile() {
-  const [isMobile, setIsMobile] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => {
-    const check = () => setIsMobile(window.innerWidth < 768);
-    check();
-    setMounted(true);
-    window.addEventListener("resize", check);
-    return () => window.removeEventListener("resize", check);
-  }, []);
-  return { isMobile, mounted };
-}
+import { useIsMobile } from "@/hooks/use-is-mobile";
 
 interface AgentSummary {
   name: string;
@@ -160,7 +148,7 @@ export function Sidebar() {
     if (mounted && isMobile) setCollapsed(true);
   }, [mounted, isMobile, setCollapsed]);
 
-  const desktopClass = collapsed ? "w-0 overflow-hidden" : "w-[280px] min-w-[280px]";
+  const desktopClass = collapsed ? "w-0 min-w-0 overflow-hidden" : "w-[280px] min-w-[280px]";
   const mobileClass = cn(
     "fixed left-0 top-0 bottom-0 z-40",
     collapsed ? "w-0 overflow-hidden" : "w-[280px]"
@@ -308,19 +296,6 @@ export function Sidebar() {
           </Button>
         </div>
       </aside>
-      {collapsed && (
-        <Button
-          variant="ghost"
-          size="icon"
-          className={cn(
-            "absolute top-3 z-10 h-7 w-7",
-            isMobile ? "left-3 z-50" : "left-2"
-          )}
-          onClick={() => setCollapsed(false)}
-        >
-          <PanelLeft className="h-4 w-4" />
-        </Button>
-      )}
     </>
   );
 }

--- a/src/hooks/use-is-mobile.ts
+++ b/src/hooks/use-is-mobile.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    const check = () => setIsMobile(window.innerWidth < 768);
+    check();
+    setMounted(true);
+    window.addEventListener("resize", check);
+    return () => window.removeEventListener("resize", check);
+  }, []);
+  return { isMobile, mounted };
+}


### PR DESCRIPTION
> Originally submitted by @micahbrich in #5

## Summary

- **Agents workspace** uses a master-detail pattern on mobile
- **AI panel** becomes a full-screen overlay with backdrop scrim on mobile
- **Sidebar toggle** moved from absolute-positioned floating button to inline in the header bar
- **Sidebar animation** fixed expand direction on desktop

All changes use Tailwind `max-md:` variants and a shared `useIsMobile` hook. No new dependencies, no changes to desktop behavior.