### PR TITLE
Add CI workflow for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run agent tests
+        run: npm test
+
+      - name: Run update system tests
+        run: npm run test:unit


### PR DESCRIPTION
> Originally submitted by @dannyshmueli in #16

This adds a dedicated CI workflow that runs npm test and npm run test:unit on pull requests and pushes to main.