### PR TITLE
feat: Multi-tenant auth, teams, and per-team KB isolation  

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,18 @@ DOMAIN=localhost
 # Defaults to ./data for source installs, or a managed app-data path in Electron.
 # CABINET_DATA_DIR=
 
+# OAuth authentication (better-auth) — leave empty to use KB_PASSWORD only
+BETTER_AUTH_SECRET=
+BETTER_AUTH_URL=http://localhost:3000
+
+# Google OAuth (optional)
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# GitHub OAuth (optional)
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+
 # Optional: release manifest URL for update checks.
 # CABINET_RELEASE_MANIFEST_URL=https://github.com/hilash/cabinet/releases/latest/download/cabinet-release.json
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,5 +1,7 @@
 # Progress
 
+[2026-04-09] Merged feat/improvments → feat/multi-tenant-auth (rebased onto origin/main). Added multi-tenant OAuth auth via better-auth (Google + GitHub), team management with per-team KB isolation, SQL migrations 002-004, agent session isolation (PTY sessions tagged by userId/teamSlug), ElectronDetector client component (React 19 fix), and updated next.config.ts and .env.example for better-auth.
+
 [2026-04-09] Fix pty.node macOS Gatekeeper warning: added xattr quarantine flag removal before ad-hoc codesigning of extracted native binaries in Electron main process.
 
 [2026-04-09] Added `export const dynamic = "force-dynamic"` to all `/api/system/*` route handlers. Without this, Next.js could cache these routes during production builds, potentially serving stale update check results and triggering a false "update available" popup on fresh installs.

--- a/ai/plans/2026-04-09-multi-team-multi-user.md
+++ b/ai/plans/2026-04-09-multi-team-multi-user.md
@@ -1,0 +1,844 @@
+# Multi-Team & Multi-User Support
+
+**Data de execução:** 2026-04-09  
+**Branch:** `main`  
+**Repo upstream:** `https://github.com/hilash/cabinet`  
+**Status:** Implementado, TypeScript limpo, testado em desenvolvimento com OAuth Google
+
+---
+
+## Contexto
+
+O Cabinet é uma base de conhecimento single-tenant: uma senha compartilhada (`KB_PASSWORD`) protege toda a instância e todos os usuários veem e editam o mesmo conjunto de dados. O objetivo desta feature é transformá-lo em multi-tenant com:
+
+1. **Autenticação OAuth** (Google + GitHub) como mecanismo principal, com fallback legado por senha
+2. **Times com controle de acesso** — cada time tem sua própria KB; usuários precisam ser membros para acessá-la
+3. **Isolamento de KB por time** — cada time tem seu próprio diretório de dados e repositório git independente
+4. **Isolamento de sessões de AI por usuário** — sessões PTY do daemon tagueadas por `userId`; workspaces separados por usuário
+
+---
+
+## Decisões de Design
+
+| Decisão | Escolha | Motivo |
+|---|---|---|
+| Auth | OAuth (Google + GitHub) via **better-auth** | Compatível com Next.js 16 + Turbopack; API estável e mantida ativamente |
+| Biblioteca auth | `better-auth` (não `next-auth@5 beta`) | `next-auth@5.0.0-beta.30` é incompatível com Next.js 16 + Turbopack: falha ao resolver `next/server` via ESM |
+| Sessões auth | Database sessions gerenciadas pelo better-auth | Tabelas `user`, `account`, `session`, `verification` criadas automaticamente via migration |
+| Middleware | `betterFetch` ao endpoint `/api/auth/get-session` | Evita importar `better-sqlite3` (Node.js nativo) no Edge Runtime do middleware |
+| Isolamento de KB | Pasta + git repo por time | Máximo isolamento; git history separado por time |
+| Isolamento de agentes | Workspace por usuário dentro do time | Sem conflito de sessões PTY; sem custo de processo extra |
+| Migração | Time "default" com `data_dir_override` | Zero movimentação de arquivos; backward compat total |
+| Detecção Electron | `useEffect` em client component | React 19 não executa `<script>` dentro de componentes React; `useEffect` é a alternativa correta |
+| `onSelect` → `onClick` | `onClick` padrão do React | `onSelect` é API exclusiva do Radix UI; o projeto usa base-ui que ignora `onSelect` silenciosamente |
+
+---
+
+## Histórico de Decisão: Por que better-auth em vez de next-auth?
+
+### Tentativa inicial: next-auth@5.0.0-beta.30
+
+A implementação original usou `next-auth@5` por ser a biblioteca mais conhecida. Funcionou parcialmente, mas ao clicar em "Continue with Google" o erro aparecia:
+
+```
+Failed to load external module next-auth-c77c3a03231bb629:
+Error [ERR_MODULE_NOT_FOUND]: Cannot find module
+'/path/node_modules/next/server'
+imported from /path/node_modules/next-auth/lib/env.js
+Did you mean to import "next/server.js"?
+```
+
+**Causa raiz:** `next-auth@5 beta` usa imports ESM sem extensão `.js` em alguns módulos internos. O Turbopack do Next.js 16 — ativo por padrão — usa resolução ESM estrita e requer extensões explícitas. Isso é um bug do `next-auth@5` que não foi corrigido nas versões beta disponíveis.
+
+**Soluções descartadas:**
+- Adicionar ao `serverExternalPackages`: tentado, não resolveu o erro de Turbopack
+- Desativar Turbopack (`--no-turbopack`): funcionaria, mas Turbopack é padrão no Next.js 16 e essa regressão seria inaceitável
+- Fixar em versão beta anterior: sem garantia de estabilidade
+
+**Solução adotada: migrar para `better-auth`**, que é compatível com Next.js 16 + Turbopack, tem API mais simples e é ativamente mantida.
+
+### Arquitetura da autenticação com better-auth
+
+```
+Cliente React                 Servidor Next.js           SQLite
+──────────────                ─────────────────          ──────
+authClient.signIn.social()    
+  → POST /api/auth/sign-in/social
+                              better-auth handler
+                                → OAuth redirect
+[OAuth provider]
+  → GET /api/auth/callback/google
+                              better-auth cria user +
+                              account na DB              INSERT INTO user ...
+                              databaseHooks.user.create  INSERT INTO account ...
+                                → maybeCreateDefaultTeam INSERT INTO teams ...
+                              Set-Cookie: session token
+  → redirect para /
+authClient.useSession()
+  → GET /api/auth/get-session
+                              better-auth valida session  SELECT FROM session ...
+                              retorna { user, session }
+```
+
+---
+
+## Impacto para Merge com Upstream
+
+### Arquivos novos (podem ser adicionados sem conflito)
+
+**Migrations:**
+- `server/migrations/002_auth_teams.sql` — tabelas `teams`, `team_members` (e tabelas `users`/`oauth_accounts` que foram descartadas na 003)
+- `server/migrations/003_better_auth.sql` — descarta tabelas do 002 e recria com FK corretos para tabela `user` do better-auth
+- `server/migrations/004_better_auth_schema.sql` — cria tabelas do better-auth: `user`, `session`, `account`, `verification`
+
+**Auth:**
+- `src/lib/auth.ts` — config completo do better-auth (Node.js)
+- `src/lib/auth-client.ts` — `createAuthClient()` para componentes React
+- `src/app/api/auth/[...all]/route.ts` — handler do better-auth
+
+**Teams:**
+- `src/lib/teams/team-fs.ts`
+- `src/lib/teams/team-context.ts`
+- `src/app/api/teams/route.ts`
+- `src/app/api/teams/[slug]/route.ts`
+- `src/app/api/teams/[slug]/members/route.ts`
+- `src/app/api/teams/[slug]/members/[userId]/route.ts`
+
+**KB scoped por time:**
+- `src/app/api/teams/[slug]/tree/route.ts`
+- `src/app/api/teams/[slug]/pages/[...path]/route.ts`
+- `src/app/api/teams/[slug]/search/route.ts`
+- `src/app/api/teams/[slug]/git/{log,diff,commit,pull,restore}/route.ts`
+
+**Frontend:**
+- `src/components/layout/team-switcher.tsx`
+- `src/components/layout/user-menu.tsx`
+- `src/components/layout/electron-detector.tsx`
+- `src/app/login/login-client.tsx`
+- `src/app/teams/new/page.tsx`
+- `src/app/teams/[slug]/settings/page.tsx`
+- `src/app/teams/[slug]/settings/settings-client.tsx`
+
+**Agentes:**
+- `src/lib/agents/user-workspace.ts`
+
+**Docs:**
+- `ai/plans/` (este arquivo)
+
+### Arquivos removidos (deletar no upstream ao fazer merge)
+
+- `src/lib/auth.config.ts` — era a config Edge-safe do next-auth; não necessária com better-auth
+- `src/types/next-auth.d.ts` — augmentação de tipos do next-auth; better-auth tipifica corretamente sem augmentação
+- `src/components/auth-provider.tsx` — era o `SessionProvider` do next-auth; better-auth não precisa de provider wrapper
+- `src/app/api/auth/[...nextauth]/route.ts` — substituído por `[...all]/route.ts`
+
+### Arquivos modificados (requer revisão de merge)
+
+| Arquivo | O que mudou |
+|---|---|
+| `src/middleware.ts` | Reescrito: usa `betterFetch` para validar sessão better-auth; mantém fallback legado KB_PASSWORD |
+| `src/app/login/page.tsx` | Server component que passa flags de auth para `login-client.tsx` |
+| `src/app/layout.tsx` | Removido `AuthProvider`/`SessionProvider`; removida tag `<script>`; adicionado `<ElectronDetector>` |
+| `src/app/teams/[slug]/settings/settings-client.tsx` | `useSession` (next-auth) → `authClient.useSession()` (better-auth) |
+| `src/lib/storage/path-utils.ts` | Parâmetro `rootDir?` em 2 funções |
+| `src/lib/storage/page-io.ts` | Parâmetro `dataDir?` em todas as funções |
+| `src/lib/storage/tree-builder.ts` | Parâmetro `dataDir?` em `buildTree` |
+| `src/lib/git/git-service.ts` | Singleton → Map por diretório; todas as funções aceitam `dataDir?` |
+| `src/lib/api/client.ts` | Reescrito para suportar `teamSlug?`; adicionado `fetchUserTeams()` |
+| `src/lib/agents/daemon-client.ts` | Tipos com `userId?`/`teamSlug?`; filtro por userId em `listDaemonSessions` |
+| `src/lib/teams/team-context.ts` | `auth()` → `auth.api.getSession({ headers })`; importa `headers` do next/headers |
+| `src/app/api/teams/route.ts` | `auth()` → `auth.api.getSession({ headers })`; importa `headers` do next/headers |
+| `src/app/api/teams/[slug]/members/route.ts` | SQL: `FROM users` → `FROM user`, `FROM users WHERE email` → `FROM user WHERE email` |
+| `src/stores/app-store.ts` | Adicionado `currentTeamSlug`, `teams`, ações de time |
+| `src/stores/tree-store.ts` | Usa `currentTeamSlug` em todas as chamadas de API |
+| `src/stores/editor-store.ts` | Usa `currentTeamSlug` em `loadPage`/`save` |
+| `src/components/sidebar/sidebar.tsx` | Header com `<TeamSwitcher>`; footer com `<UserMenu>` |
+| `src/components/layout/app-shell.tsx` | Carrega times no mount; recarrega tree ao trocar de time |
+| `server/cabinet-daemon.ts` | `PtySession` com `userId?`/`teamSlug?`; filtro por userId em GET /sessions |
+| `next.config.ts` | `next-auth` → `better-auth` em `serverExternalPackages` |
+| `.env.example` | `NEXTAUTH_*` → `BETTER_AUTH_*` |
+
+### Dependências
+
+**Removida:**
+```json
+"next-auth": "^5.0.0-beta.30"
+```
+
+**Adicionada:**
+```json
+"better-auth": "^1.x"
+```
+
+---
+
+## Fases de Implementação
+
+### Fase 1 — Banco de Dados e Autenticação
+
+#### Por que better-auth com database sessions?
+
+better-auth gerencia suas próprias tabelas de sessão no SQLite. Diferente de JWTs puros, sessões em banco permitem revogação imediata (logout real) e inspeção de sessões ativas. O custo é uma query a mais por request autenticado — aceitável em self-hosted.
+
+#### `server/migrations/002_auth_teams.sql` — CRIADO
+Criou tabelas `users`, `oauth_accounts`, `teams`, `team_members`. As duas primeiras foram descartadas na migration 003 ao migrar para better-auth (que usa seus próprios nomes: `user`, `account`).
+
+#### `server/migrations/003_better_auth.sql` — CRIADO
+```sql
+PRAGMA foreign_keys = OFF;
+
+-- Descarta tabelas customizadas do 002 (sem dados reais ainda)
+DROP TABLE IF EXISTS oauth_accounts;
+DROP TABLE IF EXISTS users;
+
+-- Recria teams/team_members sem FK para 'users' (que não existe mais)
+-- team_members.user_id referencia better-auth's 'user.id' (sem FK declarada
+-- para evitar problemas de ordem de criação entre migrations)
+DROP TABLE IF EXISTS team_members;
+DROP TABLE IF EXISTS teams;
+CREATE TABLE teams (...);
+CREATE TABLE team_members (...);
+
+PRAGMA foreign_keys = ON;
+```
+
+**Por que descartar e recriar `teams`/`team_members`?**  
+A declaração `REFERENCES users(id)` em `team_members` referencia uma tabela que deixou de existir. SQLite não permite modificar constraints de FK com `ALTER TABLE`, então é necessário recriar. Como não havia dados reais (nenhum login havia sido completado com sucesso), a operação é segura.
+
+#### `server/migrations/004_better_auth_schema.sql` — CRIADO
+```sql
+CREATE TABLE IF NOT EXISTS user (
+  id TEXT NOT NULL PRIMARY KEY,
+  name TEXT NOT NULL,
+  email TEXT NOT NULL UNIQUE,
+  emailVerified INTEGER NOT NULL DEFAULT 0,
+  image TEXT,
+  createdAt INTEGER NOT NULL DEFAULT (unixepoch()),
+  updatedAt INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE TABLE IF NOT EXISTS session (
+  id TEXT NOT NULL PRIMARY KEY,
+  expiresAt INTEGER NOT NULL,
+  token TEXT NOT NULL UNIQUE,
+  ...
+  userId TEXT NOT NULL REFERENCES user(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS account (
+  id TEXT NOT NULL PRIMARY KEY,
+  accountId TEXT NOT NULL,
+  providerId TEXT NOT NULL,
+  userId TEXT NOT NULL REFERENCES user(id) ON DELETE CASCADE,
+  ...
+);
+
+CREATE TABLE IF NOT EXISTS verification (
+  id TEXT NOT NULL PRIMARY KEY,
+  identifier TEXT NOT NULL,
+  value TEXT NOT NULL,
+  expiresAt INTEGER NOT NULL,
+  ...
+);
+```
+
+**Nota crítica:** better-auth usaria `session` (singular) para suas sessões de auth. Já existia a tabela `sessions` (plural) para sessões PTY de agentes — sem conflito de nome.
+
+**Por que adicionar ao sistema de migrations e não usar `auth.$migrate()`?**  
+O sistema de migrations do Cabinet (`runSqlMigrations`) é síncrono e roda automaticamente na inicialização via `getDb()`. A alternativa `auth.$migrate()` é assíncrona e precisaria ser chamada explicitamente. Usar o sistema existente é mais simples e consistente.
+
+#### `src/lib/auth.ts` — CRIADO (substituiu versão next-auth)
+```typescript
+import { betterAuth } from "better-auth";
+import { getDb } from "@/lib/db";
+
+export const auth = betterAuth({
+  database: getDb(),       // reutiliza conexão singleton — sem second connection
+  socialProviders: {
+    // providers condicionais: só ativados se CLIENT_ID está configurado
+    ...(process.env.GOOGLE_CLIENT_ID && { google: { ... } }),
+    ...(process.env.GITHUB_CLIENT_ID && { github: { ... } }),
+  },
+  databaseHooks: {
+    user: {
+      create: {
+        after: async (user) => {
+          await maybeCreateDefaultTeam(user.id);
+        },
+      },
+    },
+  },
+});
+```
+
+**`databaseHooks.user.create.after`**: executado toda vez que o better-auth cria um novo usuário (primeiro login via OAuth). É o ponto ideal para criar o time "default" na primeira vez.
+
+**`getDb()` compartilhado**: better-auth aceita uma instância `better-sqlite3` diretamente. Reusar o singleton de `getDb()` evita duas conexões abertas ao mesmo arquivo SQLite.
+
+#### `src/lib/auth-client.ts` — CRIADO
+```typescript
+"use client";
+import { createAuthClient } from "better-auth/react";
+export const authClient = createAuthClient();
+```
+
+`createAuthClient()` sem `baseURL` autodetecta `window.location.origin`. A diretiva `"use client"` garante que não seja importado em código de servidor.
+
+#### `src/app/api/auth/[...all]/route.ts` — CRIADO
+```typescript
+import { auth } from "@/lib/auth";
+import { toNextJsHandler } from "better-auth/next-js";
+export const { GET, POST } = toNextJsHandler(auth);
+```
+
+Substitui `[...nextauth]/route.ts`. O handler monta automaticamente todos os endpoints do better-auth:
+- `POST /api/auth/sign-in/social` — inicia fluxo OAuth
+- `GET /api/auth/callback/{provider}` — recebe callback do provider
+- `GET /api/auth/get-session` — retorna sessão atual (usado pelo middleware)
+- `POST /api/auth/sign-out` — invalida sessão
+
+**Nota:** os redirect URIs do Google/GitHub permanecem os mesmos (`/api/auth/callback/google`, `/api/auth/callback/github`). Nenhuma mudança necessária no console dos providers.
+
+#### `src/middleware.ts` — REESCRITO
+```typescript
+import { betterFetch } from "@better-fetch/fetch";
+
+export async function middleware(request: NextRequest) {
+  // 1. Paths públicos → passa sempre
+  if (isPublicPath(pathname)) return NextResponse.next();
+
+  // 2. Legacy: KB_PASSWORD sem OAuth → verifica cookie SHA-256
+  if (legacyPassword && !hasOAuth) { ... }
+
+  // 3. Sem auth configurado → acesso livre (modo dev)
+  if (!legacyPassword && !hasOAuth) return NextResponse.next();
+
+  // 4. OAuth: valida sessão better-auth via HTTP interno
+  const { data: session } = await betterFetch<{ user: { id: string } }>(
+    "/api/auth/get-session",
+    {
+      baseURL: request.nextUrl.origin,
+      headers: { cookie: request.headers.get("cookie") ?? "" },
+    }
+  );
+
+  if (!session?.user) { /* redirect /login ou 401 */ }
+  return NextResponse.next();
+}
+```
+
+**Por que `betterFetch` em vez de importar `auth` diretamente?**  
+O middleware roda no Edge Runtime (obrigatório no Next.js — não configurável). `better-sqlite3` usa binários Node.js nativos que não funcionam em Edge. `betterFetch` faz uma chamada HTTP ao próprio servidor — o custo é mínimo para uma aplicação self-hosted e essa é a abordagem oficial recomendada pelo better-auth para Next.js middleware.
+
+#### `src/lib/teams/team-context.ts` — ATUALIZADO
+```typescript
+// Antes (next-auth)
+const session = await auth();
+
+// Depois (better-auth)
+const session = await auth.api.getSession({
+  headers: await headers(),
+});
+```
+
+`auth.api.getSession` é a forma server-side de obter a sessão no better-auth. Requer os headers da request para ler o cookie de sessão.
+
+---
+
+### Fase 2 — Teams CRUD
+
+#### `src/lib/teams/team-fs.ts` — CRIADO
+Duas funções:
+- `getTeamDataDir(slug)`: consulta `data_dir_override` na DB; fallback para `data/teams/{slug}/`
+- `initTeamDirectory(slug)`: cria o diretório e inicializa um repo git (idempotente)
+
+**Por que `data_dir_override`?**  
+Para a instalação existente, o time "default" aponta para o `DATA_DIR` raiz (ex: `./data`), que já tem um `.git/` inicializado. Sem esse override, o sistema tentaria criar `data/teams/default/` como novo repo, ignorando todo o conteúdo existente.
+
+#### `src/lib/teams/team-context.ts` — CRIADO
+- `requireTeamContext(slug)`: valida sessão better-auth + membership na tabela; lança erro com status HTTP
+- `getUserTeams(userId)`: lista times de um usuário
+- `teamContextErrorResponse(err)`: converte erro em `Response` JSON com status correto
+
+Todas as rotas de API scoped chamam `requireTeamContext` como primeiro passo, garantindo que o usuário seja membro do time antes de qualquer operação.
+
+#### Rotas de API — CRIADAS
+
+**`/api/teams` (GET + POST)**
+- GET: lista times do usuário via `getUserTeams`
+- POST: cria time, slug gerado a partir do nome, adiciona criador como admin, chama `initTeamDirectory`
+
+**`/api/teams/[slug]` (GET + PATCH + DELETE)**
+- PATCH e DELETE requerem role `admin`
+
+**`/api/teams/[slug]/members` (GET + POST)**
+
+**SQL atualizado para tabela `user` do better-auth:**
+```sql
+-- Antes (tabela customizada 'users')
+SELECT id FROM users WHERE email = ?
+JOIN users u ON u.id = tm.user_id
+
+-- Depois (tabela do better-auth 'user')
+SELECT id FROM user WHERE email = ?
+JOIN user u ON u.id = tm.user_id
+```
+
+**`/api/teams/[slug]/members/[userId]` (PATCH + DELETE)**
+- PATCH muda role (admin only)
+- DELETE permite auto-remoção ou remoção por admin; valida que não está removendo o último admin
+
+---
+
+### Fase 3 — KB Isolation (Storage + Git + Rotas)
+
+#### `src/lib/storage/path-utils.ts` — MODIFICADO
+```typescript
+// Antes
+export function resolveContentPath(virtualPath: string): string
+export function virtualPathFromFs(fsPath: string): string
+
+// Depois
+export function resolveContentPath(virtualPath: string, rootDir?: string): string
+export function virtualPathFromFs(fsPath: string, rootDir?: string): string
+```
+Quando `rootDir` não é fornecido, usa o `DATA_DIR` global — zero breaking change para chamadas existentes.
+
+**Por que não mudar o `DATA_DIR` global?**  
+O `DATA_DIR` é calculado uma vez no import. Mudá-lo por request não seria thread-safe e quebraria o Electron. A abordagem de parâmetro opcional é mais limpa e compatível.
+
+#### `src/lib/storage/page-io.ts` — MODIFICADO
+Todas as funções exportadas recebem `dataDir?: string`:
+- `readPage(virtualPath, dataDir?)`
+- `writePage(virtualPath, content, frontmatter, dataDir?)`
+- `createPage(virtualPath, title, dataDir?)`
+- `deletePage(virtualPath, dataDir?)`
+- `movePage(fromPath, toParentPath, dataDir?)`
+- `renamePage(virtualPath, newName, dataDir?)`
+
+Todas passam `dataDir` para `resolveContentPath` e `virtualPathFromFs`.
+
+#### `src/lib/storage/tree-builder.ts` — MODIFICADO
+```typescript
+// Antes
+export async function buildTree(): Promise<TreeNode[]>
+
+// Depois
+export async function buildTree(dataDir?: string): Promise<TreeNode[]>
+```
+A função recursiva interna `buildTreeRecursive` recebe `rootDir` para calcular `virtualPathFromFs` corretamente em relação ao diretório do time.
+
+#### `src/lib/git/git-service.ts` — MODIFICADO (refatorado)
+**Antes:** singleton `let git: SimpleGit | null` e `let commitTimer`.  
+**Depois:** `Map<string, SimpleGit | null>` e `Map<string, ReturnType<typeof setTimeout>>` — um por `dataDir`.
+
+Todas as funções exportadas recebem `dataDir: string = DATA_DIR`:
+- `autoCommit(pagePath, action, dataDir?)`
+- `getPageHistory(virtualPath, dataDir?)`
+- `getDiff(hash, dataDir?)`
+- `manualCommit(message, dataDir?)`
+- `restoreFileFromCommit(hash, filePath, dataDir?)`
+- `gitPull(dataDir?)`
+- `getStatus(dataDir?)`
+
+**Por que Map em vez de chamar `simpleGit(dataDir)` em cada request?**  
+`simpleGit` tem overhead de inicialização. Reusar instâncias por diretório é mais eficiente. O Map é limpo por processo; em caso de restart o daemon recria as instâncias.
+
+**Por que um timer de commit por `dataDir`?**  
+Se dois times salvam páginas quase ao mesmo tempo, o timer compartilhado original cancelaria o commit de um deles. Um timer por diretório garante que cada time comite independentemente.
+
+#### Novas rotas de API scoped por time
+Criadas espelhando exatamente as rotas antigas, porém com `[slug]` no path e chamando `requireTeamContext` + `getTeamDataDir`:
+
+| Rota nova | Equivalente antigo |
+|---|---|
+| `/api/teams/[slug]/tree` | `/api/tree` |
+| `/api/teams/[slug]/pages/[...path]` | `/api/pages/[...path]` |
+| `/api/teams/[slug]/search` | `/api/search` |
+| `/api/teams/[slug]/git/log/[...path]` | `/api/git/log/[...path]` |
+| `/api/teams/[slug]/git/diff/[hash]` | `/api/git/diff/[hash]` |
+| `/api/teams/[slug]/git/commit` | `/api/git/commit` |
+| `/api/teams/[slug]/git/pull` | `/api/git/pull` |
+| `/api/teams/[slug]/git/restore` | `/api/git/restore` |
+
+**As rotas antigas foram mantidas** (não deletadas). Continuam funcionando apontando para `DATA_DIR`. Isso garante que componentes não migrados ainda funcionem.
+
+---
+
+### Fase 4 — Agent Isolation
+
+#### `src/lib/agents/user-workspace.ts` — CRIADO
+```typescript
+getUserWorkspaceDir(teamSlug, userId): string
+// → data/teams/{slug}/.agents/users/{userId}/workspace/
+
+ensureUserWorkspace(teamSlug, userId): Promise<string>
+// mkdir -p + retorna o path
+```
+
+**Por que dentro de `.agents/users/{userId}/`?**  
+Mantém toda a estrutura de agentes dentro do diretório do time. O `.` previne que apareça na tree de KB. Cada usuário tem seu próprio workspace isolado para o CLI do agente.
+
+#### `server/cabinet-daemon.ts` — MODIFICADO
+Campos adicionados à interface `PtySession`:
+```typescript
+userId?: string;
+teamSlug?: string;
+```
+
+`createDetachedSession` aceita `userId?` e `teamSlug?` e os armazena na sessão.
+
+`POST /sessions` aceita `userId` e `teamSlug` no body.
+
+`GET /sessions` aceita query param `?userId=` para filtrar sessões por usuário. Sessões de outros usuários não aparecem na lista.
+
+#### `src/lib/agents/daemon-client.ts` — MODIFICADO
+```typescript
+// Antes
+interface CreateDaemonSessionInput { id, prompt, providerId?, cwd?, timeoutSeconds? }
+listDaemonSessions(): Promise<...[]>
+
+// Depois
+interface CreateDaemonSessionInput { ..., userId?, teamSlug? }
+listDaemonSessions(userId?: string): Promise<...[]>
+```
+`listDaemonSessions` passa `?userId=` na query string quando fornecido.
+
+---
+
+### Fase 5 — Frontend
+
+#### `src/stores/app-store.ts` — MODIFICADO
+Adicionados ao estado:
+```typescript
+currentTeamSlug: string | null
+teams: TeamInfo[]
+setCurrentTeam(slug: string): void   // persiste em localStorage
+setTeams(teams: TeamInfo[]): void    // restaura último time usado de localStorage
+```
+
+**`setTeams`** restaura o último time usado de `localStorage` para que a experiência seja consistente entre reloads.
+
+#### `src/lib/api/client.ts` — MODIFICADO (reescrito)
+Todas as funções aceitam `teamSlug?: string | null`:
+```typescript
+fetchTree(teamSlug?)   → /api/teams/{slug}/tree  ou  /api/tree
+fetchPage(path, teamSlug?)
+savePage(path, content, fm, teamSlug?)
+createPageApi(parentPath, title, teamSlug?)
+deletePageApi(path, teamSlug?)
+movePageApi(fromPath, toParent, teamSlug?)
+renamePageApi(fromPath, newName, teamSlug?)
+fetchUserTeams()       → /api/teams
+```
+
+A função `teamBase(teamSlug?, resource?)` centraliza a construção da URL.
+
+#### `src/stores/tree-store.ts` — MODIFICADO
+Importa `useAppStore` e chama `useAppStore.getState().currentTeamSlug` (acesso fora de componentes React, via Zustand) antes de cada chamada de API.
+
+#### `src/stores/editor-store.ts` — MODIFICADO
+Mesmo padrão: lê `currentTeamSlug` antes de `fetchPage` e `savePage`.
+
+#### `src/components/layout/app-shell.tsx` — MODIFICADO
+```typescript
+// Carrega times ao montar
+useEffect(() => {
+  fetchUserTeams().then(setTeams).catch(() => {});
+}, [setTeams]);
+
+// Recarrega a tree quando o time muda
+useEffect(() => {
+  loadTree();
+}, [loadTree, currentTeamSlug]);
+```
+
+#### `src/components/layout/team-switcher.tsx` — CRIADO
+Dropdown que lista times do usuário. Marca o time ativo com um checkmark. Opção "New team" navega para `/teams/new`.
+
+**Atenção:** usa `onClick` (base-ui), não `onSelect` (Radix UI). Ver seção de correções.
+
+#### `src/components/layout/user-menu.tsx` — CRIADO
+Mostra avatar (imagem ou iniciais), nome e email do usuário. Opções:
+- "Team settings" → `/teams/{currentTeamSlug}/settings` (visível apenas quando há time ativo)
+- "Sign out" → `authClient.signOut()` do better-auth
+
+**Atenção:** usa `onClick` (base-ui), não `onSelect` (Radix UI). Ver seção de correções.
+
+#### `src/components/layout/electron-detector.tsx` — CRIADO
+```typescript
+"use client";
+import { useEffect } from "react";
+
+export function ElectronDetector() {
+  useEffect(() => {
+    if ((window as { CabinetDesktop?: boolean }).CabinetDesktop) {
+      document.documentElement.classList.add("electron-desktop");
+    }
+  }, []);
+  return null;
+}
+```
+
+**Por que substituir o `<script dangerouslySetInnerHTML>`?**  
+React 19 mudou o comportamento de tags `<script>` dentro de componentes React: elas são tratadas como recursos declarativos (hoisted para o `<head>`) mas não são executadas no cliente durante a hidratação. O erro de console era:
+
+> *"Encountered a script tag while rendering React component. Scripts inside React components are never executed when rendering on the client."*
+
+A solução React 19-correta é `useEffect` em um client component, que executa após a hidratação — exatamente o que se deseja para detecção de ambiente.
+
+#### `src/app/layout.tsx` — SIMPLIFICADO
+```typescript
+// Antes
+import Script from "next/script";
+import { AuthProvider } from "@/components/auth-provider";
+// ...
+<head>
+  <Script id="electron-detect" strategy="beforeInteractive" dangerouslySetInnerHTML={...} />
+</head>
+<body>
+  <ThemeProvider>
+    <ThemeInitializer />
+    <AuthProvider>{children}</AuthProvider>
+  </ThemeProvider>
+</body>
+
+// Depois
+import { ElectronDetector } from "@/components/layout/electron-detector";
+// ...
+<body>
+  <ThemeProvider>
+    <ThemeInitializer />
+    <ElectronDetector />
+    {children}
+  </ThemeProvider>
+</body>
+```
+
+`AuthProvider` (que era um wrapper de `SessionProvider` do next-auth) foi removido — o better-auth não precisa de provider global. O `authClient.useSession()` funciona em qualquer componente client diretamente.
+
+#### `/teams/new/page.tsx` — CRIADO
+Formulário de criação de time. POST para `/api/teams`, atualiza a lista de times no store, navega para `/` no time novo.
+
+#### `/teams/[slug]/settings/page.tsx` + `settings-client.tsx` — CRIADOS
+Página de configurações do time com três seções:
+1. **General** — renomear o time (admin only)
+2. **Members** — listar membros com roles, adicionar por email, trocar role, remover
+3. **Danger zone** — deletar time (admin only, com confirmação)
+
+Usa `authClient.useSession()` para mostrar/esconder ações baseadas no role do usuário atual.
+
+---
+
+### Fase 6 — Migração de Dados Existentes
+
+Implementada dentro de `src/lib/auth.ts` na função `maybeCreateDefaultTeam(userId)`.
+
+**Fluxo:**
+1. Chamada automaticamente via `databaseHooks.user.create.after` (melhor-auth chama no primeiro login)
+2. Verifica se a tabela `teams` está vazia (primeira execução)
+3. Se `DATA_DIR` tem conteúdo não-oculto além de `teams/`: cria time "default" com `data_dir_override = DATA_DIR`
+4. Se `DATA_DIR` está vazio: cria time "default" sem override (usará `data/teams/default/`)
+5. O usuário que fez o primeiro login vira admin do time "default"
+
+**Por que `data_dir_override` em vez de mover arquivos?**
+- Zero risco de perda de dados
+- Git history preservado (mesmo repo, mesmo `.git/`)
+- Reversível: remover o override e mover os arquivos depois, se quiser
+- Funciona mesmo se `data/` for um volume Docker montado
+
+---
+
+## Correções Pós-Implementação
+
+### Correção 1: `onSelect` → `onClick` nos DropdownMenuItems
+
+**Problema:** Ao clicar em "Team settings" e "New team", nada acontecia.
+
+**Causa raiz:** O projeto usa base-ui (não Radix UI). `onSelect` é um prop exclusivo do `DropdownMenuItem` do Radix UI que fecha o menu e executa a ação atomicamente. No base-ui, `MenuPrimitive.Item` aceita apenas `onClick` padrão do React. O prop `onSelect` era passado silenciosamente como atributo DOM desconhecido, sem efeito.
+
+**Arquivos corrigidos:**
+- `src/components/layout/user-menu.tsx` — 2 ocorrências
+- `src/components/layout/team-switcher.tsx` — 2 ocorrências
+
+```typescript
+// Errado (Radix UI API — ignorado no base-ui)
+<DropdownMenuItem onSelect={() => router.push("/teams/new")}>
+
+// Correto (padrão React — funciona com base-ui)
+<DropdownMenuItem onClick={() => router.push("/teams/new")}>
+```
+
+**Regra geral para este projeto:** Todo `DropdownMenuItem`, `ContextMenuItem`, `AlertDialogTrigger`, `DialogTrigger` e similares do shadcn/ui **não** têm prop `asChild` e usam `onClick`, nunca `onSelect`. Ver `CLAUDE.md` — "shadcn/ui uses base-ui (NOT Radix)".
+
+### Correção 2: Tabelas do better-auth ausentes no SQLite
+
+**Problema:** `SqliteError: no such table: verification` ao tentar fazer login OAuth.
+
+**Causa:** better-auth precisa criar suas tabelas (`user`, `account`, `session`, `verification`) antes do primeiro uso. Isso não acontecia automaticamente porque o sistema de migrations do Cabinet precisava ser informado sobre essas tabelas via arquivo SQL explícito.
+
+**Solução:** Migration `004_better_auth_schema.sql` com os `CREATE TABLE IF NOT EXISTS` para todas as tabelas do better-auth, aplicada automaticamente pelo `runSqlMigrations` na próxima inicialização do servidor.
+
+---
+
+## Estrutura de Diretórios Resultante
+
+```
+data/
+  teams/
+    {team-slug}/          ← git repo próprio (.git/ independente)
+      index.md
+      {páginas}/
+      .agents/
+        users/
+          {user-id}/
+            workspace/    ← cwd das sessões PTY deste usuário
+        {agent-slug}/
+          persona.md
+  .cabinet/               ← metadados internos (inalterado)
+  .cabinet.db             ← SQLite: user, account, session, verification (better-auth)
+                              + teams, team_members (multi-tenant)
+                              + sessions (agentes PTY), activity, job_runs, etc.
+
+# Para instalações existentes (time "default" com data_dir_override):
+data/                     ← É o próprio data dir do time "default"
+  index.md
+  {conteúdo existente}/
+  .agents/
+  .cabinet.db
+```
+
+---
+
+## Variáveis de Ambiente
+
+```bash
+# better-auth (multi-user mode)
+BETTER_AUTH_SECRET=<openssl rand -base64 32>  # obrigatório em produção
+BETTER_AUTH_URL=https://seu-dominio.com        # URL da aplicação
+
+# Google OAuth
+# Criar em: https://console.cloud.google.com/apis/credentials
+# Authorized redirect URI: {BETTER_AUTH_URL}/api/auth/callback/google
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# GitHub OAuth
+# Criar em: https://github.com/settings/applications/new
+# Authorization callback URL: {BETTER_AUTH_URL}/api/auth/callback/github
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+
+# Legacy (apenas quando sem OAuth — backward compat)
+KB_PASSWORD=
+```
+
+**Nota:** Os redirect URIs dos providers OAuth são idênticos aos que seriam usados com next-auth. Nenhuma mudança nas configurações dos providers ao fazer upgrade de next-auth para better-auth.
+
+---
+
+## Guia de Teste End-to-End
+
+### 1. Verificar migrations aplicadas
+```bash
+node -e "
+const db = require('better-sqlite3')('data/.cabinet.db');
+const tables = db.prepare(\"SELECT name FROM sqlite_master WHERE type='table'\").all();
+const versions = db.prepare('SELECT version FROM schema_version').all();
+console.log('tables:', tables.map(t => t.name));
+console.log('migrations:', versions.map(v => v.version));
+"
+# Esperado: tables inclui user, account, session, verification, teams, team_members
+# Esperado: migrations inclui [1, 2, 3, 4]
+```
+
+### 2. Auth OAuth
+```bash
+# Configure pelo menos um provider no .env.local
+BETTER_AUTH_SECRET=...
+GOOGLE_CLIENT_ID=...
+GOOGLE_CLIENT_SECRET=...
+
+# Inicie o servidor
+npm run dev:all
+
+# Acesse http://localhost:3000
+# → deve redirecionar para /login
+# → clique em "Continue with Google"
+# → autorize no popup do Google
+# → deve voltar para / com sidebar mostrando o time "default"
+```
+
+### 3. Backward compat (senha legada)
+```bash
+# .env com KB_PASSWORD e sem GOOGLE/GITHUB_CLIENT_ID
+KB_PASSWORD=minhasenha
+
+# Acesse /login → formulário de senha aparece (botões OAuth não aparecem)
+# → senha correta → acesso concedido
+```
+
+### 4. Sem auth configurado (modo dev)
+```bash
+# .env sem KB_PASSWORD e sem CLIENT_IDs
+# Acesse /login → redireciona diretamente para / sem auth
+```
+
+### 5. Criação de time e migração automática
+```bash
+# Primeiro login com conteúdo existente em data/
+# → time "default" criado automaticamente
+# → SELECT * FROM teams; deve mostrar data_dir_override = '/path/to/data'
+# → conteúdo aparece na sidebar normalmente
+```
+
+### 6. Isolamento de KB
+```bash
+# Login como usuário A → cria time "Engineering" via team switcher + New team
+# → conteúdo em data/teams/engineering/
+# Login como usuário B (email diferente)
+# → usuário B não é membro → GET /api/teams/engineering/tree → 403
+# Usuário A adiciona usuário B via /teams/engineering/settings → Members
+# → usuário B consegue ver o conteúdo
+```
+
+### 7. Team settings e New team
+```bash
+# Team settings: clicar no avatar → Team settings → navega para /teams/{slug}/settings
+# New team: clicar no nome do time (TeamSwitcher) → New team → navega para /teams/new
+# (ambos usam onClick, não onSelect — ver Correção 1)
+```
+
+---
+
+## Pontos de Atenção para Merge
+
+1. **`src/middleware.ts`**: reescrito completamente. O merge deve garantir que qualquer customização do middleware original seja incorporada na nova lógica de auth. Verificar se o upstream adicionou paths públicos não cobertos pela lista atual.
+
+2. **`src/app/login/page.tsx`**: convertido de client para server component. Se o upstream tiver mudanças no formulário de senha, aplicar em `login-client.tsx` (que é o client component filho).
+
+3. **`src/lib/git/git-service.ts`**: o singleton `git` foi substituído por um `Map`. Se o upstream adicionou novas funções usando o singleton, precisam ser migradas para aceitar `dataDir`.
+
+4. **`server/cabinet-daemon.ts`**: adições mínimas na interface `PtySession` e nos handlers HTTP. Baixo risco de conflito, mas verificar se o upstream modificou a mesma interface.
+
+5. **`src/lib/storage/path-utils.ts`**: parâmetros opcionais adicionados. Zero breaking change — todas as chamadas existentes continuam funcionando.
+
+6. **Migrations**: se o upstream criou migrations 002, 003 ou 004 próprias, renumerar as nossas. O sistema de migrations aplica por número de prefixo numérico (`001_`, `002_`, etc).
+
+7. **base-ui vs Radix**: verificar todo código novo do upstream que usa `DropdownMenuItem`, `ContextMenuItem` ou qualquer outro componente shadcn/ui — substituir `onSelect` por `onClick` e remover qualquer uso de `asChild`. Este é um footgun recorrente neste projeto.
+
+8. **better-auth vs next-auth**: o upstream usa `next-auth@4` (versão estável) ou `next-auth@5 beta`? Se usar `next-auth@4` estável, a migração para `better-auth` é a abordagem correta para Next.js 16+ independentemente.
+
+9. **Tabelas SQL**: em toda query que referenciava `users` (tabela customizada), foi atualizado para `user` (tabela do better-auth, singular). Revisar qualquer nova query do upstream que use `users`.
+
+---
+
+## Arquivos Não Modificados (mas relacionados)
+
+Os arquivos abaixo **não foram modificados** nesta feature, mas são relevantes para extensões futuras:
+
+- `src/lib/agents/persona-manager.ts` — personas ainda são globais por `DATA_DIR`; futuro: migrar para `teamDataDir`
+- `src/lib/agents/conversation-store.ts` — conversas ainda em `DATA_DIR/.agents/.conversations`; futuro: migrar para `teamDataDir`
+- `src/lib/agents/conversation-runner.ts` — não passou `teamDataDir` ainda
+- `src/app/api/agents/route.ts` — não extrai `userId` da sessão ainda para filtrar sessões
+- As rotas antigas `/api/tree`, `/api/pages/[...path]`, `/api/search`, `/api/git/*` — mantidas como shims; podem ser removidas após migração completa do frontend

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
-  serverExternalPackages: ["node-pty", "simple-git", "better-sqlite3"],
+  serverExternalPackages: ["node-pty", "simple-git", "better-sqlite3", "better-auth"],
   outputFileTracingExcludes: {
     "/*": [
       ".next/dev/**/*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@base-ui/react": "^1.3.0",
+        "@better-fetch/fetch": "^1.1.21",
         "@tailwindcss/typography": "^0.5.19",
         "@tiptap/extension-code-block-lowlight": "^3.20.4",
         "@tiptap/extension-image": "^3.20.4",
@@ -28,6 +29,7 @@
         "@xterm/addon-unicode11": "^0.9.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
+        "better-auth": "^1.6.2",
         "better-sqlite3": "^12.8.0",
         "chokidar": "^5.0.0",
         "class-variance-authority": "^0.7.1",
@@ -566,6 +568,147 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@better-auth/core": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.2.tgz",
+      "integrity": "sha512-nBftDp+eN1fwXor1O4KQorCXa0tJNDgpab7O1z4NcWUU+3faDpdzqLn5mbXZer2E8ZD4VhjqOfYZ041xnBF5NA==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.39.0",
+        "@standard-schema/spec": "^1.1.0",
+        "zod": "^4.3.6"
+      },
+      "peerDependencies": {
+        "@better-auth/utils": "0.4.0",
+        "@better-fetch/fetch": "1.1.21",
+        "@cloudflare/workers-types": ">=4",
+        "@opentelemetry/api": "^1.9.0",
+        "better-call": "1.3.5",
+        "jose": "^6.1.0",
+        "kysely": "^0.28.5",
+        "nanostores": "^1.0.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/drizzle-adapter": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.2.tgz",
+      "integrity": "sha512-KawrNNuhgmpcc5PgLs6HesMckxCscz5J+BQ99iRmU1cLzG/A87IcydrmYtep+K8WHPN0HmZ/i4z/nOBCtxE2qA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.2",
+        "@better-auth/utils": "0.4.0",
+        "drizzle-orm": ">=0.41.0"
+      },
+      "peerDependenciesMeta": {
+        "drizzle-orm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/kysely-adapter": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.2.tgz",
+      "integrity": "sha512-YMMm75jek/MNCAFWTAaq/U3VPmFnrwZW4NhBjjAwruHQJEIrSZZaOaUEXuUpFRRBhWqg7OOltQcHMwU/45CkuA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.2",
+        "@better-auth/utils": "0.4.0",
+        "kysely": "^0.27.0 || ^0.28.0"
+      },
+      "peerDependenciesMeta": {
+        "kysely": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/memory-adapter": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.2.tgz",
+      "integrity": "sha512-QvuK5m7NFgkzLPHyab+NORu3J683nj36Tix58qq6DPcniyY6KZk5gY2yyh4+z1wgSjrxwY5NFx/DC2qz8B8NJg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.2",
+        "@better-auth/utils": "0.4.0"
+      }
+    },
+    "node_modules/@better-auth/mongo-adapter": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.2.tgz",
+      "integrity": "sha512-IvR2Q+1pjzxA4JXI3ED76+6fsqervIpZ2K5MxoX/+miLQhLEmNcbqqcItg4O2kfkxN8h33/ev57sjTW8QH9Tuw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.2",
+        "@better-auth/utils": "0.4.0",
+        "mongodb": "^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "mongodb": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/prisma-adapter": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.2.tgz",
+      "integrity": "sha512-bQkXYTo1zPau+xAiMpo1yCjEDSy7i7oeYlkYO+fSfRDCo52DE/9oPOOuI+EStmFkPUNSk9L2rhk8Fulifi8WCg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.2",
+        "@better-auth/utils": "0.4.0",
+        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@prisma/client": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/telemetry": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.2.tgz",
+      "integrity": "sha512-o4gHKXqizUxVUUYChZZTowLEzdsz3ViBE/fKFzfHqNFUnF+aVt8QsbLSfipq1WpTIXyJVT/SnH0hgSdWxdssbQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.2",
+        "@better-auth/utils": "0.4.0",
+        "@better-fetch/fetch": "1.1.21"
+      }
+    },
+    "node_modules/@better-auth/utils": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.0.tgz",
+      "integrity": "sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^2.0.1"
+      }
+    },
+    "node_modules/@better-auth/utils/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@better-fetch/fetch": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
+      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
     },
     "node_modules/@dotenvx/dotenvx": {
       "version": "1.57.0",
@@ -5141,6 +5284,25 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "license": "MIT"
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@remirror/core-constants": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
@@ -5184,6 +5346,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -8024,6 +8192,155 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/better-auth": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.2.tgz",
+      "integrity": "sha512-5nqDAIj5xexmnk+GjjdrBknJCabi1mlvsVWJbxs4usHreao4vNdxIxINWDzCyDF9iDR1ildRZdXWSiYPAvTHhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@better-auth/core": "1.6.2",
+        "@better-auth/drizzle-adapter": "1.6.2",
+        "@better-auth/kysely-adapter": "1.6.2",
+        "@better-auth/memory-adapter": "1.6.2",
+        "@better-auth/mongo-adapter": "1.6.2",
+        "@better-auth/prisma-adapter": "1.6.2",
+        "@better-auth/telemetry": "1.6.2",
+        "@better-auth/utils": "0.4.0",
+        "@better-fetch/fetch": "1.1.21",
+        "@noble/ciphers": "^2.1.1",
+        "@noble/hashes": "^2.0.1",
+        "better-call": "1.3.5",
+        "defu": "^6.1.4",
+        "jose": "^6.1.3",
+        "kysely": "^0.28.14",
+        "nanostores": "^1.1.1",
+        "zod": "^4.3.6"
+      },
+      "peerDependencies": {
+        "@lynx-js/react": "*",
+        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "@sveltejs/kit": "^2.0.0",
+        "@tanstack/react-start": "^1.0.0",
+        "@tanstack/solid-start": "^1.0.0",
+        "better-sqlite3": "^12.0.0",
+        "drizzle-kit": ">=0.31.4",
+        "drizzle-orm": ">=0.41.0",
+        "mongodb": "^6.0.0 || ^7.0.0",
+        "mysql2": "^3.0.0",
+        "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
+        "pg": "^8.0.0",
+        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
+        "solid-js": "^1.0.0",
+        "svelte": "^4.0.0 || ^5.0.0",
+        "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0",
+        "vue": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@lynx-js/react": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "@tanstack/react-start": {
+          "optional": true
+        },
+        "@tanstack/solid-start": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "drizzle-kit": {
+          "optional": true
+        },
+        "drizzle-orm": {
+          "optional": true
+        },
+        "mongodb": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/better-auth/node_modules/@noble/ciphers": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.1.1.tgz",
+      "integrity": "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/better-auth/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/better-call": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.5.tgz",
+      "integrity": "sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@better-auth/utils": "^0.4.0",
+        "@better-fetch/fetch": "^1.1.21",
+        "rou3": "^0.7.12",
+        "set-cookie-parser": "^3.0.1"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/better-sqlite3": {
       "version": "12.8.0",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
@@ -9280,6 +9597,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "license": "MIT"
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -12980,6 +13303,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/kysely": {
+      "version": "0.28.15",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.15.tgz",
+      "integrity": "sha512-r2clcf7HLWvDXaVUEvQymXJY4i3bSOIV3xsL/Upy3ZfSv5HeKsk9tsqbBptLvth5qHEIhxeHTA2jNLyQABkLBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
@@ -15041,6 +15373,21 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nanostores": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.2.0.tgz",
+      "integrity": "sha512-F0wCzbsH80G7XXo0Jd9/AVQC7ouWY6idUCTnMwW5t/Rv9W8qmO6endavDwg7TNp5GbugwSukFMVZqzPSrSMndg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
       }
     },
     "node_modules/napi-build-utils": {
@@ -17147,6 +17494,12 @@
       "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
       "license": "MIT"
     },
+    "node_modules/rou3": {
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.7.12.tgz",
+      "integrity": "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==",
+      "license": "MIT"
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -17475,6 +17828,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
+    "@better-fetch/fetch": "^1.1.21",
     "@tailwindcss/typography": "^0.5.19",
     "@tiptap/extension-code-block-lowlight": "^3.20.4",
     "@tiptap/extension-image": "^3.20.4",
@@ -43,6 +44,7 @@
     "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
+    "better-auth": "^1.6.2",
     "better-sqlite3": "^12.8.0",
     "chokidar": "^5.0.0",
     "class-variance-authority": "^0.7.1",

--- a/server/cabinet-daemon.ts
+++ b/server/cabinet-daemon.ts
@@ -90,6 +90,9 @@ interface PtySession {
   resolvedStatus?: "completed" | "failed";
   resolvingStatus?: boolean;
   readyStrategy?: "claude";
+  // Multi-user isolation
+  userId?: string;
+  teamSlug?: string;
 }
 
 const sessions = new Map<string, PtySession>();
@@ -375,6 +378,8 @@ function createDetachedSession(input: {
   cwd?: string;
   timeoutSeconds?: number;
   onData?: (chunk: string) => void;
+  userId?: string;
+  teamSlug?: string;
 }): PtySession {
   const cwd = resolveSessionCwd(input.cwd);
   const launch = getSessionLaunchSpec({
@@ -413,6 +418,8 @@ function createDetachedSession(input: {
     promptSubmittedOutputLength: 0,
     autoExitRequested: false,
     readyStrategy: launch.readyStrategy,
+    userId: input.userId,
+    teamSlug: input.teamSlug,
   };
   sessions.set(input.sessionId, session);
 
@@ -781,12 +788,16 @@ const server = http.createServer(async (req, res) => {
           prompt,
           cwd,
           timeoutSeconds,
+          userId,
+          teamSlug,
         } = JSON.parse(body) as {
           id: string;
           providerId?: string;
           prompt?: string;
           cwd?: string;
           timeoutSeconds?: number;
+          userId?: string;
+          teamSlug?: string;
         };
         const sessionId = id || `session-${Date.now()}`;
 
@@ -803,6 +814,8 @@ const server = http.createServer(async (req, res) => {
             prompt,
             cwd,
             timeoutSeconds,
+            userId,
+            teamSlug,
           });
         } catch (err: unknown) {
           const errMsg = err instanceof Error ? err.message : String(err);
@@ -823,15 +836,20 @@ const server = http.createServer(async (req, res) => {
     return;
   }
 
-  // GET /sessions — list all active sessions
+  // GET /sessions — list all active sessions (optionally filtered by ?userId=)
   if (url.pathname === "/sessions" && req.method === "GET") {
-    const activeSessions = Array.from(sessions.values()).map((s) => ({
-      id: s.id,
-      createdAt: s.createdAt.toISOString(),
-      connected: s.ws !== null,
-      exited: s.exited,
-      exitCode: s.exitCode,
-    }));
+    const filterUserId = url.searchParams.get("userId") ?? undefined;
+    const activeSessions = Array.from(sessions.values())
+      .filter((s) => !filterUserId || s.userId === filterUserId)
+      .map((s) => ({
+        id: s.id,
+        createdAt: s.createdAt.toISOString(),
+        connected: s.ws !== null,
+        exited: s.exited,
+        exitCode: s.exitCode,
+        userId: s.userId,
+        teamSlug: s.teamSlug,
+      }));
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify(activeSessions));
     return;

--- a/server/migrations/002_auth_teams.sql
+++ b/server/migrations/002_auth_teams.sql
@@ -1,0 +1,49 @@
+-- Migration 002: Multi-user auth + teams
+-- Uses JWT sessions (no sessions table conflict with existing agent sessions table)
+
+-- Internal users table (email is the stable identifier across OAuth providers)
+CREATE TABLE IF NOT EXISTS users (
+  id TEXT NOT NULL PRIMARY KEY,
+  name TEXT,
+  email TEXT NOT NULL UNIQUE,
+  image TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+
+-- OAuth account links (allows same user to log in via multiple providers)
+CREATE TABLE IF NOT EXISTS oauth_accounts (
+  id TEXT NOT NULL PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  provider TEXT NOT NULL,
+  provider_account_id TEXT NOT NULL,
+  UNIQUE(provider, provider_account_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_oauth_accounts_user ON oauth_accounts(user_id);
+
+-- Teams
+CREATE TABLE IF NOT EXISTS teams (
+  id TEXT NOT NULL PRIMARY KEY,
+  name TEXT NOT NULL,
+  slug TEXT NOT NULL UNIQUE,
+  data_dir_override TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  created_by TEXT REFERENCES users(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_teams_slug ON teams(slug);
+
+-- Team memberships
+CREATE TABLE IF NOT EXISTS team_members (
+  id TEXT NOT NULL PRIMARY KEY,
+  team_id TEXT NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  role TEXT NOT NULL DEFAULT 'member' CHECK(role IN ('admin', 'member')),
+  joined_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(team_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_team_members_team ON team_members(team_id);
+CREATE INDEX IF NOT EXISTS idx_team_members_user ON team_members(user_id);

--- a/server/migrations/003_better_auth.sql
+++ b/server/migrations/003_better_auth.sql
@@ -1,0 +1,40 @@
+-- Migration 003: Replace custom user/account tables with better-auth schema
+-- better-auth auto-creates: user, account, session (singular), verification
+-- Our 'sessions' (plural) PTY table is unaffected (different name)
+-- No user data exists yet so tables can be safely dropped and recreated
+
+PRAGMA foreign_keys = OFF;
+
+-- Drop custom tables from migration 002
+DROP TABLE IF EXISTS oauth_accounts;
+DROP TABLE IF EXISTS users;
+
+-- Recreate teams without FK reference to dropped 'users' table
+DROP TABLE IF EXISTS team_members;
+DROP TABLE IF EXISTS teams;
+
+CREATE TABLE teams (
+  id TEXT NOT NULL PRIMARY KEY,
+  name TEXT NOT NULL,
+  slug TEXT NOT NULL UNIQUE,
+  data_dir_override TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  created_by TEXT  -- references better-auth's user.id (no FK to avoid boot-order issues)
+);
+
+CREATE INDEX IF NOT EXISTS idx_teams_slug ON teams(slug);
+
+-- Recreate team_members referencing better-auth's 'user' table
+CREATE TABLE team_members (
+  id TEXT NOT NULL PRIMARY KEY,
+  team_id TEXT NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  user_id TEXT NOT NULL,  -- references better-auth user.id
+  role TEXT NOT NULL DEFAULT 'member' CHECK(role IN ('admin', 'member')),
+  joined_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(team_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_team_members_team ON team_members(team_id);
+CREATE INDEX IF NOT EXISTS idx_team_members_user ON team_members(user_id);
+
+PRAGMA foreign_keys = ON;

--- a/server/migrations/004_better_auth_schema.sql
+++ b/server/migrations/004_better_auth_schema.sql
@@ -1,0 +1,53 @@
+-- Migration 004: Create better-auth tables
+-- better-auth requires: user, session (singular), account, verification
+-- Our PTY sessions table is 'sessions' (plural) — no conflict
+
+CREATE TABLE IF NOT EXISTS user (
+  id TEXT NOT NULL PRIMARY KEY,
+  name TEXT NOT NULL,
+  email TEXT NOT NULL UNIQUE,
+  emailVerified INTEGER NOT NULL DEFAULT 0,
+  image TEXT,
+  createdAt INTEGER NOT NULL DEFAULT (unixepoch()),
+  updatedAt INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE TABLE IF NOT EXISTS session (
+  id TEXT NOT NULL PRIMARY KEY,
+  expiresAt INTEGER NOT NULL,
+  token TEXT NOT NULL UNIQUE,
+  createdAt INTEGER NOT NULL DEFAULT (unixepoch()),
+  updatedAt INTEGER NOT NULL DEFAULT (unixepoch()),
+  ipAddress TEXT,
+  userAgent TEXT,
+  userId TEXT NOT NULL REFERENCES user(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS account (
+  id TEXT NOT NULL PRIMARY KEY,
+  accountId TEXT NOT NULL,
+  providerId TEXT NOT NULL,
+  userId TEXT NOT NULL REFERENCES user(id) ON DELETE CASCADE,
+  accessToken TEXT,
+  refreshToken TEXT,
+  idToken TEXT,
+  accessTokenExpiresAt INTEGER,
+  refreshTokenExpiresAt INTEGER,
+  scope TEXT,
+  password TEXT,
+  createdAt INTEGER NOT NULL DEFAULT (unixepoch()),
+  updatedAt INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE TABLE IF NOT EXISTS verification (
+  id TEXT NOT NULL PRIMARY KEY,
+  identifier TEXT NOT NULL,
+  value TEXT NOT NULL,
+  expiresAt INTEGER NOT NULL,
+  createdAt INTEGER DEFAULT (unixepoch()),
+  updatedAt INTEGER DEFAULT (unixepoch())
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_userId ON session(userId);
+CREATE INDEX IF NOT EXISTS idx_account_userId ON account(userId);
+CREATE INDEX IF NOT EXISTS idx_account_providerId ON account(providerId, accountId);

--- a/src/app/api/auth/[...all]/route.ts
+++ b/src/app/api/auth/[...all]/route.ts
@@ -1,0 +1,4 @@
+import { auth } from "@/lib/auth";
+import { toNextJsHandler } from "better-auth/next-js";
+
+export const { GET, POST } = toNextJsHandler(auth);

--- a/src/app/api/teams/[slug]/git/commit/route.ts
+++ b/src/app/api/teams/[slug]/git/commit/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { manualCommit, getStatus } from "@/lib/git/git-service";
+import { requireTeamContext, teamContextErrorResponse } from "@/lib/teams/team-context";
+import { getTeamDataDir } from "@/lib/teams/team-fs";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  try {
+    await requireTeamContext(slug);
+    const dataDir = getTeamDataDir(slug);
+    const body = await req.json();
+    const message = body.message || "Manual commit from KB";
+    const committed = await manualCommit(message, dataDir);
+    return NextResponse.json({ ok: true, committed });
+  } catch (err) {
+    return teamContextErrorResponse(err);
+  }
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  try {
+    await requireTeamContext(slug);
+    const dataDir = getTeamDataDir(slug);
+    const status = await getStatus(dataDir);
+    return NextResponse.json(status);
+  } catch (err) {
+    return teamContextErrorResponse(err);
+  }
+}

--- a/src/app/api/teams/[slug]/git/diff/[hash]/route.ts
+++ b/src/app/api/teams/[slug]/git/diff/[hash]/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDiff } from "@/lib/git/git-service";
+import { requireTeamContext, teamContextErrorResponse } from "@/lib/teams/team-context";
+import { getTeamDataDir } from "@/lib/teams/team-fs";
+
+type RouteParams = { params: Promise<{ slug: string; hash: string }> };
+
+export async function GET(_req: NextRequest, { params }: RouteParams) {
+  const { slug, hash } = await params;
+  try {
+    await requireTeamContext(slug);
+    const dataDir = getTeamDataDir(slug);
+    const diff = await getDiff(hash, dataDir);
+    return NextResponse.json({ diff });
+  } catch (err) {
+    return teamContextErrorResponse(err);
+  }
+}

--- a/src/app/api/teams/[slug]/git/log/[...path]/route.ts
+++ b/src/app/api/teams/[slug]/git/log/[...path]/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getPageHistory } from "@/lib/git/git-service";
+import { requireTeamContext, teamContextErrorResponse } from "@/lib/teams/team-context";
+import { getTeamDataDir } from "@/lib/teams/team-fs";
+
+type RouteParams = { params: Promise<{ slug: string; path: string[] }> };
+
+export async function GET(_req: NextRequest, { params }: RouteParams) {
+  const { slug, path: segments } = await params;
+  try {
+    await requireTeamContext(slug);
+    const dataDir = getTeamDataDir(slug);
+    const history = await getPageHistory(segments.join("/"), dataDir);
+    return NextResponse.json(history);
+  } catch (err) {
+    return teamContextErrorResponse(err);
+  }
+}

--- a/src/app/api/teams/[slug]/git/pull/route.ts
+++ b/src/app/api/teams/[slug]/git/pull/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { gitPull } from "@/lib/git/git-service";
+import { requireTeamContext, teamContextErrorResponse } from "@/lib/teams/team-context";
+import { getTeamDataDir } from "@/lib/teams/team-fs";
+
+export async function POST(
+  _req: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  try {
+    await requireTeamContext(slug);
+    const dataDir = getTeamDataDir(slug);
+    const result = await gitPull(dataDir);
+    return NextResponse.json(result);
+  } catch (err) {
+    return teamContextErrorResponse(err);
+  }
+}

--- a/src/app/api/teams/[slug]/git/restore/route.ts
+++ b/src/app/api/teams/[slug]/git/restore/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { restoreFileFromCommit } from "@/lib/git/git-service";
+import { requireTeamContext, teamContextErrorResponse } from "@/lib/teams/team-context";
+import { getTeamDataDir } from "@/lib/teams/team-fs";
+import path from "path";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  try {
+    await requireTeamContext(slug);
+    const dataDir = getTeamDataDir(slug);
+    const { hash, pagePath } = await req.json();
+    if (!hash || !pagePath) {
+      return NextResponse.json({ error: "hash and pagePath are required" }, { status: 400 });
+    }
+
+    const candidates = [
+      path.join(pagePath, "index.md"),
+      `${pagePath}.md`,
+    ];
+
+    let restored = false;
+    for (const candidate of candidates) {
+      restored = await restoreFileFromCommit(hash, candidate, dataDir);
+      if (restored) break;
+    }
+
+    if (!restored) {
+      return NextResponse.json(
+        { error: "Failed to restore — file may not exist at that commit" },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    return teamContextErrorResponse(err);
+  }
+}

--- a/src/app/api/teams/[slug]/members/[userId]/route.ts
+++ b/src/app/api/teams/[slug]/members/[userId]/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import {
+  requireTeamContext,
+  teamContextErrorResponse,
+} from "@/lib/teams/team-context";
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ slug: string; userId: string }> }
+) {
+  const { slug, userId } = await params;
+  try {
+    const ctx = await requireTeamContext(slug);
+    if (ctx.role !== "admin") {
+      return NextResponse.json({ error: "Admin required" }, { status: 403 });
+    }
+
+    const { role } = await req.json();
+    if (role !== "admin" && role !== "member") {
+      return NextResponse.json({ error: "Invalid role" }, { status: 400 });
+    }
+
+    const db = getDb();
+    const result = db
+      .prepare("UPDATE team_members SET role = ? WHERE team_id = ? AND user_id = ?")
+      .run(role, ctx.teamId, userId);
+
+    if (result.changes === 0) {
+      return NextResponse.json({ error: "Member not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    return teamContextErrorResponse(err);
+  }
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ slug: string; userId: string }> }
+) {
+  const { slug, userId } = await params;
+  try {
+    const ctx = await requireTeamContext(slug);
+
+    // Members can remove themselves; admins can remove anyone
+    if (ctx.role !== "admin" && ctx.userId !== userId) {
+      return NextResponse.json({ error: "Not allowed" }, { status: 403 });
+    }
+
+    const db = getDb();
+
+    // Prevent removing the last admin
+    if (ctx.role === "admin" || userId === ctx.userId) {
+      const adminCount = (
+        db
+          .prepare(
+            "SELECT COUNT(*) as c FROM team_members WHERE team_id = ? AND role = 'admin'"
+          )
+          .get(ctx.teamId) as { c: number }
+      ).c;
+
+      const targetRole = (
+        db
+          .prepare("SELECT role FROM team_members WHERE team_id = ? AND user_id = ?")
+          .get(ctx.teamId, userId) as { role: string } | undefined
+      )?.role;
+
+      if (targetRole === "admin" && adminCount <= 1) {
+        return NextResponse.json(
+          { error: "Cannot remove the last admin" },
+          { status: 409 }
+        );
+      }
+    }
+
+    db.prepare("DELETE FROM team_members WHERE team_id = ? AND user_id = ?").run(
+      ctx.teamId,
+      userId
+    );
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    return teamContextErrorResponse(err);
+  }
+}

--- a/src/app/api/teams/[slug]/members/route.ts
+++ b/src/app/api/teams/[slug]/members/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import {
+  requireTeamContext,
+  teamContextErrorResponse,
+} from "@/lib/teams/team-context";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  try {
+    await requireTeamContext(slug);
+    const db = getDb();
+    const team = db.prepare("SELECT id FROM teams WHERE slug = ?").get(slug) as
+      | { id: string }
+      | undefined;
+    if (!team) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+    const members = db
+      .prepare(`
+        SELECT u.id, u.name, u.email, u.image, tm.role, tm.joined_at
+        FROM team_members tm
+        JOIN user u ON u.id = tm.user_id
+        WHERE tm.team_id = ?
+        ORDER BY tm.joined_at
+      `)
+      .all(team.id);
+
+    return NextResponse.json({ members });
+  } catch (err) {
+    return teamContextErrorResponse(err);
+  }
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  try {
+    const ctx = await requireTeamContext(slug);
+    if (ctx.role !== "admin") {
+      return NextResponse.json({ error: "Admin required" }, { status: 403 });
+    }
+
+    const { email, role = "member" } = await req.json();
+    if (!email || typeof email !== "string") {
+      return NextResponse.json({ error: "Email required" }, { status: 400 });
+    }
+    if (role !== "admin" && role !== "member") {
+      return NextResponse.json({ error: "Invalid role" }, { status: 400 });
+    }
+
+    const db = getDb();
+    const user = db.prepare("SELECT id FROM user WHERE email = ?").get(email) as
+      | { id: string }
+      | undefined;
+
+    if (!user) {
+      return NextResponse.json(
+        { error: "User not found. They must sign in at least once before being added." },
+        { status: 404 }
+      );
+    }
+
+    const existing = db
+      .prepare("SELECT id FROM team_members WHERE team_id = ? AND user_id = ?")
+      .get(ctx.teamId, user.id);
+
+    if (existing) {
+      return NextResponse.json({ error: "User is already a member" }, { status: 409 });
+    }
+
+    db.prepare(`
+      INSERT INTO team_members (id, team_id, user_id, role)
+      VALUES (?, ?, ?, ?)
+    `).run(crypto.randomUUID(), ctx.teamId, user.id, role);
+
+    return NextResponse.json({ ok: true }, { status: 201 });
+  } catch (err) {
+    return teamContextErrorResponse(err);
+  }
+}

--- a/src/app/api/teams/[slug]/pages/[...path]/route.ts
+++ b/src/app/api/teams/[slug]/pages/[...path]/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from "next/server";
+import { readPage, writePage, createPage, deletePage, movePage, renamePage } from "@/lib/storage/page-io";
+import { autoCommit } from "@/lib/git/git-service";
+import { requireTeamContext, teamContextErrorResponse } from "@/lib/teams/team-context";
+import { getTeamDataDir } from "@/lib/teams/team-fs";
+
+type RouteParams = { params: Promise<{ slug: string; path: string[] }> };
+
+export async function GET(_req: NextRequest, { params }: RouteParams) {
+  const { slug, path: segments } = await params;
+  try {
+    await requireTeamContext(slug);
+    const dataDir = getTeamDataDir(slug);
+    const page = await readPage(segments.join("/"), dataDir);
+    return NextResponse.json(page);
+  } catch (err) {
+    const message = (err as Error).message ?? "Unknown error";
+    const status = (err as { status?: number }).status ?? (message.includes("not found") ? 404 : 500);
+    return NextResponse.json({ error: message }, { status });
+  }
+}
+
+export async function PUT(req: NextRequest, { params }: RouteParams) {
+  const { slug, path: segments } = await params;
+  try {
+    await requireTeamContext(slug);
+    const dataDir = getTeamDataDir(slug);
+    const virtualPath = segments.join("/");
+    const body = await req.json();
+    await writePage(virtualPath, body.content, body.frontmatter, dataDir);
+    autoCommit(virtualPath, "Update", dataDir);
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    return teamContextErrorResponse(err);
+  }
+}
+
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  const { slug, path: segments } = await params;
+  try {
+    await requireTeamContext(slug);
+    const dataDir = getTeamDataDir(slug);
+    const virtualPath = segments.join("/");
+    const body = await req.json();
+    await createPage(virtualPath, body.title, dataDir);
+    autoCommit(virtualPath, "Add", dataDir);
+    return NextResponse.json({ ok: true }, { status: 201 });
+  } catch (err) {
+    const message = (err as Error).message ?? "Unknown error";
+    const status = (err as { status?: number }).status ?? (message.includes("already exists") ? 409 : 500);
+    return NextResponse.json({ error: message }, { status });
+  }
+}
+
+export async function PATCH(req: NextRequest, { params }: RouteParams) {
+  const { slug, path: segments } = await params;
+  try {
+    await requireTeamContext(slug);
+    const dataDir = getTeamDataDir(slug);
+    const virtualPath = segments.join("/");
+    const body = await req.json();
+    if (body.rename) {
+      const newPath = await renamePage(virtualPath, body.rename, dataDir);
+      return NextResponse.json({ ok: true, newPath });
+    }
+    const newPath = await movePage(virtualPath, body.toParent || "", dataDir);
+    return NextResponse.json({ ok: true, newPath });
+  } catch (err) {
+    return teamContextErrorResponse(err);
+  }
+}
+
+export async function DELETE(_req: NextRequest, { params }: RouteParams) {
+  const { slug, path: segments } = await params;
+  try {
+    await requireTeamContext(slug);
+    const dataDir = getTeamDataDir(slug);
+    const virtualPath = segments.join("/");
+    await deletePage(virtualPath, dataDir);
+    autoCommit(virtualPath, "Delete", dataDir);
+    return new NextResponse(null, { status: 204 });
+  } catch (err) {
+    return teamContextErrorResponse(err);
+  }
+}

--- a/src/app/api/teams/[slug]/route.ts
+++ b/src/app/api/teams/[slug]/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import {
+  requireTeamContext,
+  teamContextErrorResponse,
+} from "@/lib/teams/team-context";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  try {
+    const ctx = await requireTeamContext(slug);
+    const db = getDb();
+    const team = db
+      .prepare("SELECT id, name, slug, created_at FROM teams WHERE id = ?")
+      .get(ctx.teamId);
+    return NextResponse.json({ team });
+  } catch (err) {
+    return teamContextErrorResponse(err);
+  }
+}
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  try {
+    const ctx = await requireTeamContext(slug);
+    if (ctx.role !== "admin") {
+      return NextResponse.json({ error: "Admin required" }, { status: 403 });
+    }
+
+    const { name } = await req.json();
+    if (!name || typeof name !== "string") {
+      return NextResponse.json({ error: "Name required" }, { status: 400 });
+    }
+
+    const db = getDb();
+    db.prepare("UPDATE teams SET name = ? WHERE id = ?").run(name.trim(), ctx.teamId);
+
+    const team = db
+      .prepare("SELECT id, name, slug, created_at FROM teams WHERE id = ?")
+      .get(ctx.teamId);
+    return NextResponse.json({ team });
+  } catch (err) {
+    return teamContextErrorResponse(err);
+  }
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  try {
+    const ctx = await requireTeamContext(slug);
+    if (ctx.role !== "admin") {
+      return NextResponse.json({ error: "Admin required" }, { status: 403 });
+    }
+
+    const db = getDb();
+    db.prepare("DELETE FROM teams WHERE id = ?").run(ctx.teamId);
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    return teamContextErrorResponse(err);
+  }
+}

--- a/src/app/api/teams/[slug]/search/route.ts
+++ b/src/app/api/teams/[slug]/search/route.ts
@@ -1,0 +1,126 @@
+import { NextRequest, NextResponse } from "next/server";
+import path from "path";
+import matter from "gray-matter";
+import { isHiddenEntry } from "@/lib/storage/path-utils";
+import { listDirectory, readFileContent, fileExists } from "@/lib/storage/fs-operations";
+import { requireTeamContext, teamContextErrorResponse } from "@/lib/teams/team-context";
+import { getTeamDataDir } from "@/lib/teams/team-fs";
+
+interface SearchResult {
+  path: string;
+  title: string;
+  snippet: string;
+  tags: string[];
+  modified?: string;
+}
+
+interface SearchOptions {
+  query: string;
+  tag?: string;
+  dataDir: string;
+}
+
+async function collectPages(
+  dirPath: string,
+  opts: SearchOptions,
+  results: SearchResult[]
+) {
+  const entries = await listDirectory(dirPath);
+  const lowerQuery = opts.query.toLowerCase();
+
+  for (const entry of entries) {
+    if (isHiddenEntry(entry.name)) continue;
+    if (entry.name === "CLAUDE.md") continue;
+    const fullPath = path.join(dirPath, entry.name);
+
+    if (entry.isDirectory) {
+      const indexMd = path.join(fullPath, "index.md");
+      if (await fileExists(indexMd)) {
+        const raw = await readFileContent(indexMd);
+        const { data, content } = matter(raw);
+        const title = (data.title as string) || entry.name;
+        const tags = (data.tags as string[]) || [];
+        const modified = data.modified as string | undefined;
+
+        if (opts.tag && !tags.some((t) => t.toLowerCase() === opts.tag!.toLowerCase())) {
+          await collectPages(fullPath, opts, results);
+          continue;
+        }
+
+        const matches =
+          !opts.query ||
+          title.toLowerCase().includes(lowerQuery) ||
+          content.toLowerCase().includes(lowerQuery) ||
+          tags.some((t) => t.toLowerCase().includes(lowerQuery));
+
+        if (matches) {
+          const vPath = fullPath.replace(opts.dataDir + "/", "");
+          const snippet = opts.query
+            ? extractSnippet(content, lowerQuery)
+            : content.slice(0, 120).trim() + "...";
+          results.push({ path: vPath, title, snippet, tags, modified });
+        }
+      }
+      await collectPages(fullPath, opts, results);
+    } else if (entry.name.endsWith(".md") && entry.name !== "index.md") {
+      const raw = await readFileContent(fullPath);
+      const { data, content } = matter(raw);
+      const title = (data.title as string) || entry.name.replace(/\.md$/, "");
+      const tags = (data.tags as string[]) || [];
+      const modified = data.modified as string | undefined;
+
+      if (opts.tag && !tags.some((t) => t.toLowerCase() === opts.tag!.toLowerCase())) {
+        continue;
+      }
+
+      const matches =
+        !opts.query ||
+        title.toLowerCase().includes(lowerQuery) ||
+        content.toLowerCase().includes(lowerQuery) ||
+        tags.some((t) => t.toLowerCase().includes(lowerQuery));
+
+      if (matches) {
+        const vPath = fullPath
+          .replace(opts.dataDir + "/", "")
+          .replace(/\.md$/, "");
+        const snippet = opts.query
+          ? extractSnippet(content, lowerQuery)
+          : content.slice(0, 120).trim() + "...";
+        results.push({ path: vPath, title, snippet, tags, modified });
+      }
+    }
+  }
+}
+
+function extractSnippet(content: string, query: string): string {
+  const lower = content.toLowerCase();
+  const idx = lower.indexOf(query);
+  if (idx === -1) return content.slice(0, 120).trim() + "...";
+  const start = Math.max(0, idx - 50);
+  const end = Math.min(content.length, idx + query.length + 70);
+  let snippet = content.slice(start, end).trim();
+  if (start > 0) snippet = "..." + snippet;
+  if (end < content.length) snippet += "...";
+  return snippet;
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  try {
+    await requireTeamContext(slug);
+    const dataDir = getTeamDataDir(slug);
+    const q = req.nextUrl.searchParams.get("q")?.trim() || "";
+    const tag = req.nextUrl.searchParams.get("tag")?.trim() || undefined;
+
+    if (!q && !tag) return NextResponse.json([]);
+
+    const results: SearchResult[] = [];
+    await collectPages(dataDir, { query: q, tag, dataDir }, results);
+    return NextResponse.json(results.slice(0, 20));
+  } catch (err) {
+    return teamContextErrorResponse(err);
+  }
+}

--- a/src/app/api/teams/[slug]/tree/route.ts
+++ b/src/app/api/teams/[slug]/tree/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { buildTree } from "@/lib/storage/tree-builder";
+import { requireTeamContext, teamContextErrorResponse } from "@/lib/teams/team-context";
+import { getTeamDataDir } from "@/lib/teams/team-fs";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  try {
+    await requireTeamContext(slug);
+    const dataDir = getTeamDataDir(slug);
+    const tree = await buildTree(dataDir);
+    return NextResponse.json(tree);
+  } catch (err) {
+    return teamContextErrorResponse(err);
+  }
+}

--- a/src/app/api/teams/route.ts
+++ b/src/app/api/teams/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { headers } from "next/headers";
+import { getDb } from "@/lib/db";
+import { getUserTeams } from "@/lib/teams/team-context";
+import { initTeamDirectory } from "@/lib/teams/team-fs";
+
+export async function GET() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const teams = getUserTeams(session.user.id);
+  return NextResponse.json({ teams });
+}
+
+export async function POST(req: Request) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { name } = await req.json();
+  if (!name || typeof name !== "string" || name.trim().length === 0) {
+    return NextResponse.json({ error: "Team name is required" }, { status: 400 });
+  }
+
+  const slug = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48);
+
+  if (!slug) {
+    return NextResponse.json({ error: "Invalid team name" }, { status: 400 });
+  }
+
+  const db = getDb();
+
+  const existing = db.prepare("SELECT id FROM teams WHERE slug = ?").get(slug);
+  if (existing) {
+    return NextResponse.json({ error: "A team with this name already exists" }, { status: 409 });
+  }
+
+  const teamId = crypto.randomUUID();
+
+  const createTeam = db.transaction(() => {
+    db.prepare(`
+      INSERT INTO teams (id, name, slug, created_by)
+      VALUES (?, ?, ?, ?)
+    `).run(teamId, name.trim(), slug, session.user.id);
+
+    db.prepare(`
+      INSERT INTO team_members (id, team_id, user_id, role)
+      VALUES (?, ?, ?, 'admin')
+    `).run(crypto.randomUUID(), teamId, session.user.id);
+  });
+
+  createTeam();
+
+  // Initialize filesystem + git repo
+  await initTeamDirectory(slug);
+
+  const team = db.prepare("SELECT id, name, slug, created_at FROM teams WHERE id = ?").get(teamId);
+  return NextResponse.json({ team }, { status: 201 });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter, JetBrains_Mono, Instrument_Serif } from "next/font/google";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ThemeInitializer } from "@/components/layout/theme-initializer";
+import { ElectronDetector } from "@/components/layout/electron-detector";
 import "./globals.css";
 
 const inter = Inter({
@@ -40,9 +41,6 @@ export default function RootLayout({
       className={`${inter.variable} ${jetbrainsMono.variable} ${instrumentSerif.variable} h-full antialiased`}
       suppressHydrationWarning
     >
-      <head>
-        <script dangerouslySetInnerHTML={{ __html: `if(window.CabinetDesktop)document.documentElement.classList.add("electron-desktop")` }} />
-      </head>
       <body className="min-h-full flex flex-col font-sans">
         <ThemeProvider
           attribute="class"
@@ -51,6 +49,7 @@ export default function RootLayout({
           disableTransitionOnChange
         >
           <ThemeInitializer />
+          <ElectronDetector />
           {children}
         </ThemeProvider>
       </body>

--- a/src/app/login/login-client.tsx
+++ b/src/app/login/login-client.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Github } from "lucide-react";
+import { authClient } from "@/lib/auth-client";
+
+interface Props {
+  hasGoogle: boolean;
+  hasGitHub: boolean;
+  hasLegacy: boolean;
+}
+
+export default function LoginClient({ hasGoogle, hasGitHub, hasLegacy }: Props) {
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [passwordLoading, setPasswordLoading] = useState(false);
+  const [oauthLoading, setOAuthLoading] = useState<string | null>(null);
+  const router = useRouter();
+
+  const handlePasswordSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setPasswordLoading(true);
+
+    try {
+      const res = await fetch("/api/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password }),
+      });
+
+      if (res.ok) {
+        router.push("/");
+        router.refresh();
+      } else {
+        setError("Wrong password");
+      }
+    } catch {
+      setError("Connection error");
+    }
+    setPasswordLoading(false);
+  };
+
+  const handleOAuth = async (provider: "github" | "google") => {
+    setOAuthLoading(provider);
+    await authClient.signIn.social({ provider, callbackURL: "/" });
+  };
+
+  const hasAnyAuth = hasGoogle || hasGitHub || hasLegacy;
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      <div className="w-full max-w-sm mx-auto p-6">
+        <div className="text-center mb-8">
+          <h1 className="text-2xl font-bold tracking-[-0.03em]">Cabinet</h1>
+          <p className="text-sm text-muted-foreground mt-1">Sign in to continue</p>
+        </div>
+
+        {!hasAnyAuth && (
+          <p className="text-sm text-muted-foreground text-center">
+            No authentication configured.
+          </p>
+        )}
+
+        {/* OAuth buttons */}
+        {(hasGitHub || hasGoogle) && (
+          <div className="space-y-3 mb-6">
+            {hasGitHub && (
+              <button
+                onClick={() => handleOAuth("github")}
+                disabled={!!oauthLoading}
+                className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-md border border-border bg-background text-[14px] hover:bg-accent transition-colors disabled:opacity-50"
+              >
+                <Github className="h-4 w-4" />
+                {oauthLoading === "github" ? "Redirecting..." : "Continue with GitHub"}
+              </button>
+            )}
+            {hasGoogle && (
+              <button
+                onClick={() => handleOAuth("google")}
+                disabled={!!oauthLoading}
+                className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-md border border-border bg-background text-[14px] hover:bg-accent transition-colors disabled:opacity-50"
+              >
+                <GoogleIcon />
+                {oauthLoading === "google" ? "Redirecting..." : "Continue with Google"}
+              </button>
+            )}
+          </div>
+        )}
+
+        {/* Legacy password form */}
+        {hasLegacy && (
+          <form onSubmit={handlePasswordSubmit} className="space-y-4">
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="Password"
+              autoFocus
+              className="w-full px-3 py-2 rounded-md border border-border bg-background text-[14px] focus:outline-none focus:ring-2 focus:ring-primary/50"
+            />
+            {error && <p className="text-[12px] text-red-400">{error}</p>}
+            <button
+              type="submit"
+              disabled={passwordLoading || !password}
+              className="w-full px-3 py-2 rounded-md bg-primary text-primary-foreground text-[14px] font-medium hover:bg-primary/90 transition-colors disabled:opacity-50"
+            >
+              {passwordLoading ? "..." : "Sign in"}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function GoogleIcon() {
+  return (
+    <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+        fill="#4285F4"
+      />
+      <path
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+        fill="#34A853"
+      />
+      <path
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+        fill="#FBBC05"
+      />
+      <path
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+        fill="#EA4335"
+      />
+    </svg>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,68 +1,14 @@
-"use client";
+import LoginClient from "./login-client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
-
+// Server component: reads env vars and passes auth mode to client
 export default function LoginPage() {
-  const [password, setPassword] = useState("");
-  const [error, setError] = useState("");
-  const [loading, setLoading] = useState(false);
-  const router = useRouter();
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError("");
-    setLoading(true);
-
-    try {
-      const res = await fetch("/api/auth/login", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ password }),
-      });
-
-      if (res.ok) {
-        router.push("/");
-        router.refresh();
-      } else {
-        setError("Wrong password");
-      }
-    } catch {
-      setError("Connection error");
-    }
-    setLoading(false);
-  };
+  const hasGoogle = !!process.env.GOOGLE_CLIENT_ID;
+  const hasGitHub = !!process.env.GITHUB_CLIENT_ID;
+  const hasOAuth = hasGoogle || hasGitHub;
+  // Legacy password mode only when no OAuth providers are configured
+  const hasLegacy = !!process.env.KB_PASSWORD && !hasOAuth;
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background">
-      <div className="w-full max-w-sm mx-auto p-6">
-        <div className="text-center mb-8">
-          <h1 className="text-2xl font-bold tracking-[-0.03em]">Cabinet</h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            Enter password to continue
-          </p>
-        </div>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            placeholder="Password"
-            autoFocus
-            className="w-full px-3 py-2 rounded-md border border-border bg-background text-[14px] focus:outline-none focus:ring-2 focus:ring-primary/50"
-          />
-          {error && (
-            <p className="text-[12px] text-red-400">{error}</p>
-          )}
-          <button
-            type="submit"
-            disabled={loading || !password}
-            className="w-full px-3 py-2 rounded-md bg-primary text-primary-foreground text-[14px] font-medium hover:bg-primary/90 transition-colors disabled:opacity-50"
-          >
-            {loading ? "..." : "Sign in"}
-          </button>
-        </form>
-      </div>
-    </div>
+    <LoginClient hasGoogle={hasGoogle} hasGitHub={hasGitHub} hasLegacy={hasLegacy} />
   );
 }

--- a/src/app/teams/[slug]/settings/page.tsx
+++ b/src/app/teams/[slug]/settings/page.tsx
@@ -1,0 +1,10 @@
+import { TeamSettingsClient } from "./settings-client";
+
+export default async function TeamSettingsPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  return <TeamSettingsClient slug={slug} />;
+}

--- a/src/app/teams/[slug]/settings/settings-client.tsx
+++ b/src/app/teams/[slug]/settings/settings-client.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { authClient } from "@/lib/auth-client";
+import { Trash2, UserMinus, Shield, User } from "lucide-react";
+import { fetchUserTeams } from "@/lib/api/client";
+import { useAppStore } from "@/stores/app-store";
+
+interface Member {
+  id: string;
+  name: string | null;
+  email: string;
+  image: string | null;
+  role: "admin" | "member";
+  joined_at: string;
+}
+
+interface TeamSettingsClientProps {
+  slug: string;
+}
+
+export function TeamSettingsClient({ slug }: TeamSettingsClientProps) {
+  const { data: session } = authClient.useSession();
+  const router = useRouter();
+  const setTeams = useAppStore((s) => s.setTeams);
+  const setCurrentTeam = useAppStore((s) => s.setCurrentTeam);
+
+  const [team, setTeam] = useState<{ id: string; name: string; slug: string } | null>(null);
+  const [members, setMembers] = useState<Member[]>([]);
+  const [name, setName] = useState("");
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteRole, setInviteRole] = useState<"admin" | "member">("member");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [inviting, setInviting] = useState(false);
+
+  const myRole = members.find((m) => m.id === session?.user?.id)?.role;
+  const isAdmin = myRole === "admin";
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const [teamRes, membersRes] = await Promise.all([
+          fetch(`/api/teams/${slug}`),
+          fetch(`/api/teams/${slug}/members`),
+        ]);
+        if (!teamRes.ok) {
+          router.push("/");
+          return;
+        }
+        const { team: t } = await teamRes.json();
+        const { members: m } = await membersRes.json();
+        setTeam(t);
+        setName(t.name);
+        setMembers(m);
+      } catch {
+        router.push("/");
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [slug, router]);
+
+  const handleRename = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim() || name === team?.name) return;
+    setSaving(true);
+    setError("");
+    try {
+      const res = await fetch(`/api/teams/${slug}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: name.trim() }),
+      });
+      if (!res.ok) {
+        const d = await res.json();
+        setError(d.error ?? "Failed to rename");
+        return;
+      }
+      const { team: t } = await res.json();
+      setTeam(t);
+      const teams = await fetchUserTeams();
+      setTeams(teams);
+    } catch {
+      setError("Connection error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleInvite = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!inviteEmail.trim()) return;
+    setInviting(true);
+    setError("");
+    try {
+      const res = await fetch(`/api/teams/${slug}/members`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: inviteEmail.trim(), role: inviteRole }),
+      });
+      const d = await res.json();
+      if (!res.ok) {
+        setError(d.error ?? "Failed to add member");
+        return;
+      }
+      setInviteEmail("");
+      // Reload members
+      const membersRes = await fetch(`/api/teams/${slug}/members`);
+      const { members: m } = await membersRes.json();
+      setMembers(m);
+    } catch {
+      setError("Connection error");
+    } finally {
+      setInviting(false);
+    }
+  };
+
+  const handleRemoveMember = async (userId: string) => {
+    try {
+      await fetch(`/api/teams/${slug}/members/${userId}`, { method: "DELETE" });
+      setMembers((prev) => prev.filter((m) => m.id !== userId));
+    } catch {
+      setError("Failed to remove member");
+    }
+  };
+
+  const handleChangeRole = async (userId: string, role: "admin" | "member") => {
+    try {
+      await fetch(`/api/teams/${slug}/members/${userId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ role }),
+      });
+      setMembers((prev) => prev.map((m) => m.id === userId ? { ...m, role } : m));
+    } catch {
+      setError("Failed to change role");
+    }
+  };
+
+  const handleDeleteTeam = async () => {
+    if (!confirm(`Delete team "${team?.name}"? This cannot be undone.`)) return;
+    try {
+      await fetch(`/api/teams/${slug}`, { method: "DELETE" });
+      const teams = await fetchUserTeams();
+      setTeams(teams);
+      if (teams.length > 0) setCurrentTeam(teams[0].slug);
+      router.push("/");
+    } catch {
+      setError("Failed to delete team");
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-sm text-muted-foreground">Loading...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="max-w-2xl mx-auto px-6 py-10 space-y-10">
+        {/* Header */}
+        <div className="flex items-center gap-4">
+          <button
+            onClick={() => router.push("/")}
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            ← Back
+          </button>
+          <h1 className="text-xl font-bold tracking-[-0.02em]">Team settings</h1>
+        </div>
+
+        {error && (
+          <p className="text-sm text-red-400 px-3 py-2 rounded-md border border-red-400/30 bg-red-400/10">
+            {error}
+          </p>
+        )}
+
+        {/* General */}
+        <section className="space-y-4">
+          <h2 className="text-sm font-semibold">General</h2>
+          <form onSubmit={handleRename} className="flex gap-2">
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              disabled={!isAdmin}
+              className="flex-1 px-3 py-2 rounded-md border border-border bg-background text-[14px] focus:outline-none focus:ring-2 focus:ring-primary/50 disabled:opacity-50"
+            />
+            {isAdmin && (
+              <button
+                type="submit"
+                disabled={saving || name === team?.name || !name.trim()}
+                className="px-4 py-2 rounded-md bg-primary text-primary-foreground text-[14px] font-medium hover:bg-primary/90 transition-colors disabled:opacity-50"
+              >
+                {saving ? "Saving..." : "Rename"}
+              </button>
+            )}
+          </form>
+        </section>
+
+        {/* Members */}
+        <section className="space-y-4">
+          <h2 className="text-sm font-semibold">Members ({members.length})</h2>
+          <div className="divide-y divide-border rounded-md border border-border">
+            {members.map((member) => (
+              <div key={member.id} className="flex items-center gap-3 px-3 py-2.5">
+                <div className="h-7 w-7 rounded-full bg-muted flex items-center justify-center text-[11px] font-medium shrink-0">
+                  {(member.name ?? member.email)[0].toUpperCase()}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-[13px] font-medium truncate">{member.name ?? member.email}</p>
+                  <p className="text-[11px] text-muted-foreground truncate">{member.email}</p>
+                </div>
+                <div className="flex items-center gap-1">
+                  {isAdmin && member.id !== session?.user?.id && (
+                    <>
+                      <button
+                        onClick={() =>
+                          handleChangeRole(
+                            member.id,
+                            member.role === "admin" ? "member" : "admin"
+                          )
+                        }
+                        title={`Change to ${member.role === "admin" ? "member" : "admin"}`}
+                        className="p-1.5 rounded hover:bg-accent transition-colors text-muted-foreground"
+                      >
+                        {member.role === "admin" ? (
+                          <Shield className="h-3.5 w-3.5 text-primary" />
+                        ) : (
+                          <User className="h-3.5 w-3.5" />
+                        )}
+                      </button>
+                      <button
+                        onClick={() => handleRemoveMember(member.id)}
+                        title="Remove member"
+                        className="p-1.5 rounded hover:bg-accent transition-colors text-muted-foreground"
+                      >
+                        <UserMinus className="h-3.5 w-3.5" />
+                      </button>
+                    </>
+                  )}
+                  {!isAdmin || member.id === session?.user?.id ? (
+                    <span className="text-[11px] text-muted-foreground px-1.5 py-0.5 rounded-sm bg-muted">
+                      {member.role}
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {isAdmin && (
+            <form onSubmit={handleInvite} className="flex gap-2">
+              <input
+                type="email"
+                value={inviteEmail}
+                onChange={(e) => setInviteEmail(e.target.value)}
+                placeholder="user@example.com"
+                className="flex-1 px-3 py-2 rounded-md border border-border bg-background text-[14px] focus:outline-none focus:ring-2 focus:ring-primary/50"
+              />
+              <select
+                value={inviteRole}
+                onChange={(e) => setInviteRole(e.target.value as "admin" | "member")}
+                className="px-2 py-2 rounded-md border border-border bg-background text-[14px]"
+              >
+                <option value="member">Member</option>
+                <option value="admin">Admin</option>
+              </select>
+              <button
+                type="submit"
+                disabled={inviting || !inviteEmail.trim()}
+                className="px-4 py-2 rounded-md bg-primary text-primary-foreground text-[14px] font-medium hover:bg-primary/90 transition-colors disabled:opacity-50"
+              >
+                {inviting ? "Adding..." : "Add"}
+              </button>
+            </form>
+          )}
+        </section>
+
+        {/* Danger zone */}
+        {isAdmin && (
+          <section className="space-y-4 border border-red-400/30 rounded-md p-4">
+            <h2 className="text-sm font-semibold text-red-400">Danger zone</h2>
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-[13px] font-medium">Delete this team</p>
+                <p className="text-[12px] text-muted-foreground">
+                  Permanently remove the team and all its data.
+                </p>
+              </div>
+              <button
+                onClick={handleDeleteTeam}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-red-400/50 text-red-400 text-[13px] hover:bg-red-400/10 transition-colors"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+                Delete
+              </button>
+            </div>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/teams/new/page.tsx
+++ b/src/app/teams/new/page.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAppStore } from "@/stores/app-store";
+import { fetchUserTeams } from "@/lib/api/client";
+
+export default function NewTeamPage() {
+  const [name, setName] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const router = useRouter();
+  const setTeams = useAppStore((s) => s.setTeams);
+  const setCurrentTeam = useAppStore((s) => s.setCurrentTeam);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+    setError("");
+    setLoading(true);
+
+    try {
+      const res = await fetch("/api/teams", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: name.trim() }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error ?? "Failed to create team");
+        return;
+      }
+
+      const { team } = await res.json();
+
+      // Refresh teams list and switch to new team
+      const teams = await fetchUserTeams();
+      setTeams(teams);
+      setCurrentTeam(team.slug);
+      router.push("/");
+    } catch {
+      setError("Connection error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      <div className="w-full max-w-sm mx-auto p-6">
+        <div className="mb-6">
+          <h1 className="text-xl font-bold tracking-[-0.02em]">New team</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Each team has its own knowledge base and members.
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="text-sm font-medium block mb-1.5">Team name</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Engineering, Marketing"
+              autoFocus
+              className="w-full px-3 py-2 rounded-md border border-border bg-background text-[14px] focus:outline-none focus:ring-2 focus:ring-primary/50"
+            />
+          </div>
+          {error && <p className="text-[12px] text-red-400">{error}</p>}
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => router.back()}
+              className="flex-1 px-3 py-2 rounded-md border border-border text-[14px] hover:bg-accent transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={loading || !name.trim()}
+              className="flex-1 px-3 py-2 rounded-md bg-primary text-primary-foreground text-[14px] font-medium hover:bg-primary/90 transition-colors disabled:opacity-50"
+            >
+              {loading ? "Creating..." : "Create team"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -18,9 +18,9 @@ import { StatusBar } from "@/components/layout/status-bar";
 import { OnboardingWizard } from "@/components/onboarding/onboarding-wizard";
 import { UpdateDialog } from "@/components/layout/update-dialog";
 import { useCabinetUpdate } from "@/hooks/use-cabinet-update";
-import { useHashRoute } from "@/hooks/use-hash-route";
 import { useTreeStore } from "@/stores/tree-store";
 import { useAppStore } from "@/stores/app-store";
+import { fetchUserTeams } from "@/lib/api/client";
 import type { TreeNode } from "@/types";
 
 const DISMISSED_UPDATE_STORAGE_KEY = "cabinet.dismissed-update-version";
@@ -42,8 +42,9 @@ export function AppShell() {
   const selectedPath = useTreeStore((s) => s.selectedPath);
   const section = useAppStore((s) => s.section);
   const setSection = useAppStore((s) => s.setSection);
+  const setTeams = useAppStore((s) => s.setTeams);
+  const currentTeamSlug = useAppStore((s) => s.currentTeamSlug);
   const terminalOpen = useAppStore((s) => s.terminalOpen);
-  const sidebarCollapsed = useAppStore((s) => s.sidebarCollapsed);
   const setSidebarCollapsed = useAppStore((s) => s.setSidebarCollapsed);
   const setAiPanelCollapsed = useAppStore((s) => s.setAiPanelCollapsed);
   const aiPanelCollapsed = useAppStore((s) => s.aiPanelCollapsed);
@@ -60,9 +61,6 @@ export function AppShell() {
     applyUpdate,
   } = useCabinetUpdate({ autoRefresh: true });
 
-  // Sync navigation state with URL hash + localStorage
-  useHashRoute();
-
   // Onboarding wizard state
   const [showWizard, setShowWizard] = useState<boolean | null>(null);
   const [updateDialogOpen, setUpdateDialogOpen] = useState(false);
@@ -75,9 +73,17 @@ export function AppShell() {
     }
   });
 
+  // Load user's teams on mount; team selection triggers tree reload
+  useEffect(() => {
+    fetchUserTeams()
+      .then((teams) => setTeams(teams))
+      .catch(() => {/* no teams (legacy mode) */});
+  }, [setTeams]);
+
+  // Reload tree whenever active team changes
   useEffect(() => {
     loadTree();
-  }, [loadTree]);
+  }, [loadTree, currentTeamSlug]);
 
   // Auto-refresh sidebar when /data changes (detected via SSE)
   useEffect(() => {
@@ -237,10 +243,7 @@ export function AppShell() {
   return (
     <div className="flex h-screen bg-background text-foreground">
       <Sidebar />
-      <div
-        className="flex-1 flex flex-col overflow-hidden"
-        style={{ '--sidebar-toggle-offset': sidebarCollapsed ? '2.25rem' : '0px' } as React.CSSProperties}
-      >
+      <div className="flex-1 flex flex-col overflow-hidden">
         <main className="flex-1 flex flex-col overflow-hidden">
           {renderContent()}
         </main>

--- a/src/components/layout/electron-detector.tsx
+++ b/src/components/layout/electron-detector.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function ElectronDetector() {
+  useEffect(() => {
+    if ((window as { CabinetDesktop?: boolean }).CabinetDesktop) {
+      document.documentElement.classList.add("electron-desktop");
+    }
+  }, []);
+  return null;
+}

--- a/src/components/layout/team-switcher.tsx
+++ b/src/components/layout/team-switcher.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { ChevronDown, Plus, Check } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useAppStore } from "@/stores/app-store";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+export function TeamSwitcher() {
+  const router = useRouter();
+  const teams = useAppStore((s) => s.teams);
+  const currentTeamSlug = useAppStore((s) => s.currentTeamSlug);
+  const setCurrentTeam = useAppStore((s) => s.setCurrentTeam);
+
+  if (teams.length === 0) return null;
+
+  const current = teams.find((t) => t.slug === currentTeamSlug) ?? teams[0];
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger className="flex items-center gap-1.5 px-2 py-1 rounded-md hover:bg-accent transition-colors text-[13px] font-medium max-w-[160px] truncate">
+        <span className="truncate">{current?.name ?? "Cabinet"}</span>
+        <ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-48">
+        <DropdownMenuGroup>
+          {teams.map((team) => (
+            <DropdownMenuItem
+              key={team.id}
+              onClick={() => setCurrentTeam(team.slug)}
+              className="flex items-center gap-2"
+            >
+              <Check
+                className={cn(
+                  "h-3.5 w-3.5",
+                  team.slug === currentTeamSlug ? "opacity-100" : "opacity-0"
+                )}
+              />
+              <span className="truncate">{team.name}</span>
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onClick={() => router.push("/teams/new")}
+          className="flex items-center gap-2 text-muted-foreground"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          New team
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/layout/user-menu.tsx
+++ b/src/components/layout/user-menu.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { LogOut, Settings } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { authClient } from "@/lib/auth-client";
+import { useAppStore } from "@/stores/app-store";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+export function UserMenu() {
+  const { data: session } = authClient.useSession();
+  const router = useRouter();
+  const currentTeamSlug = useAppStore((s) => s.currentTeamSlug);
+
+  if (!session?.user) return null;
+
+  const name = session.user.name ?? session.user.email ?? "User";
+  const initials = name
+    .split(" ")
+    .map((n: string) => n[0])
+    .slice(0, 2)
+    .join("")
+    .toUpperCase();
+
+  const handleSignOut = () =>
+    authClient.signOut({
+      fetchOptions: { onSuccess: () => router.push("/login") },
+    });
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-accent transition-colors w-full text-left">
+        {session.user.image ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={session.user.image}
+            alt={name}
+            className="h-6 w-6 rounded-full object-cover shrink-0"
+          />
+        ) : (
+          <div className="h-6 w-6 rounded-full bg-primary/20 text-primary flex items-center justify-center text-[10px] font-bold shrink-0">
+            {initials}
+          </div>
+        )}
+        <span className="text-[12px] text-muted-foreground truncate flex-1">{name}</span>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-48" side="top">
+        <div className="px-2 py-1.5">
+          <p className="text-[12px] font-medium truncate">{name}</p>
+          <p className="text-[11px] text-muted-foreground truncate">{session.user.email}</p>
+        </div>
+        <DropdownMenuSeparator />
+        <DropdownMenuGroup>
+          {currentTeamSlug && (
+            <DropdownMenuItem
+              onClick={() => router.push(`/teams/${currentTeamSlug}/settings`)}
+              className="flex items-center gap-2"
+            >
+              <Settings className="h-3.5 w-3.5" />
+              Team settings
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onClick={handleSignOut}
+          className="flex items-center gap-2 text-red-500 focus:text-red-500"
+        >
+          <LogOut className="h-3.5 w-3.5" />
+          Sign out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -59,6 +59,8 @@ import { Separator } from "@/components/ui/separator";
 import { TreeView } from "./tree-view";
 import { NewPageDialog } from "./new-page-dialog";
 import { LinkRepoDialog } from "./link-repo-dialog";
+import { TeamSwitcher } from "@/components/layout/team-switcher";
+import { UserMenu } from "@/components/layout/user-menu";
 import { useAppStore } from "@/stores/app-store";
 import { useTreeStore } from "@/stores/tree-store";
 
@@ -265,18 +267,12 @@ export function Sidebar() {
         )}
         style={!isMobile && !collapsed ? { width: sidebarWidth } : undefined}
       >
-        <div className="sidebar-header flex items-center justify-between px-4 py-3">
-          <div className="flex items-center gap-2">
-            <span
-              className="font-logo text-[22px] italic tracking-[-0.01em] text-foreground"
-            >
-              cabinet
-            </span>
-          </div>
+        <div className="sidebar-header flex items-center justify-between px-3 py-2">
+          <TeamSwitcher />
           <Button
             variant="ghost"
             size="icon"
-            className="h-7 w-7"
+            className="h-7 w-7 shrink-0"
             onClick={() => setCollapsed(true)}
           >
             <PanelLeftClose className="h-4 w-4" />
@@ -449,21 +445,24 @@ export function Sidebar() {
         <TreeView />
         <LinkRepoDialog open={linkRepoOpen} onOpenChange={setLinkRepoOpen} />
 
-        <div className="p-2 flex items-center gap-1">
-          <div className="flex-1">
-            <NewPageDialog />
+        <div className="p-2 flex flex-col gap-1">
+          <div className="flex items-center gap-1">
+            <div className="flex-1">
+              <NewPageDialog />
+            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              className={cn(
+                "h-7 w-7 shrink-0",
+                (section.type === "settings") && "bg-accent text-foreground"
+              )}
+              onClick={() => setSection({ type: "settings" })}
+            >
+              <Settings className="h-3.5 w-3.5" />
+            </Button>
           </div>
-          <Button
-            variant="ghost"
-            size="icon"
-            className={cn(
-              "h-7 w-7 shrink-0",
-              (section.type === "settings") && "bg-accent text-foreground"
-            )}
-            onClick={() => setSection({ type: "settings" })}
-          >
-            <Settings className="h-3.5 w-3.5" />
-          </Button>
+          <UserMenu />
         </div>
       </aside>
       {!isMobile && !collapsed && (
@@ -482,8 +481,8 @@ export function Sidebar() {
           variant="ghost"
           size="icon"
           className={cn(
-            "absolute top-3 h-7 w-7",
-            isMobile ? "left-3 z-50" : "left-2 z-20"
+            "absolute top-3 z-10 h-7 w-7",
+            isMobile ? "left-3 z-50" : "left-2"
           )}
           onClick={() => setCollapsed(false)}
         >

--- a/src/lib/agents/daemon-client.ts
+++ b/src/lib/agents/daemon-client.ts
@@ -6,6 +6,8 @@ interface CreateDaemonSessionInput {
   providerId?: string;
   cwd?: string;
   timeoutSeconds?: number;
+  userId?: string;
+  teamSlug?: string;
 }
 
 async function daemonFetch(path: string, init?: RequestInit): Promise<Response> {
@@ -44,15 +46,16 @@ export async function getDaemonSessionOutput(id: string): Promise<{
   return response.json() as Promise<{ status: string; output: string }>;
 }
 
-export async function listDaemonSessions(): Promise<
-  { id: string; createdAt: string; connected: boolean; exited: boolean; exitCode: number | null }[]
+export async function listDaemonSessions(userId?: string): Promise<
+  { id: string; createdAt: string; connected: boolean; exited: boolean; exitCode: number | null; userId?: string; teamSlug?: string }[]
 > {
-  const response = await daemonFetch("/sessions");
+  const qs = userId ? `?userId=${encodeURIComponent(userId)}` : "";
+  const response = await daemonFetch(`/sessions${qs}`);
   if (!response.ok) {
     throw new Error(`Failed to list daemon sessions (${response.status})`);
   }
   return response.json() as Promise<
-    { id: string; createdAt: string; connected: boolean; exited: boolean; exitCode: number | null }[]
+    { id: string; createdAt: string; connected: boolean; exited: boolean; exitCode: number | null; userId?: string; teamSlug?: string }[]
   >;
 }
 

--- a/src/lib/agents/user-workspace.ts
+++ b/src/lib/agents/user-workspace.ts
@@ -1,0 +1,23 @@
+import path from "path";
+import fs from "fs/promises";
+import { getTeamDataDir } from "@/lib/teams/team-fs";
+
+/**
+ * Returns the path to a user's personal workspace within a team's data dir.
+ * Each user gets an isolated directory so their agent sessions don't conflict.
+ */
+export function getUserWorkspaceDir(teamSlug: string, userId: string): string {
+  return path.join(getTeamDataDir(teamSlug), ".agents", "users", userId, "workspace");
+}
+
+/**
+ * Ensures the user workspace directory exists and returns its path.
+ */
+export async function ensureUserWorkspace(
+  teamSlug: string,
+  userId: string
+): Promise<string> {
+  const dir = getUserWorkspaceDir(teamSlug, userId);
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -1,13 +1,19 @@
 import type { TreeNode, PageData, FrontMatter } from "@/types";
 
-export async function fetchTree(): Promise<TreeNode[]> {
-  const res = await fetch("/api/tree");
+/** Build a base URL for a team-scoped route, or fall back to legacy route. */
+function teamBase(teamSlug?: string | null, resource?: string): string {
+  if (teamSlug) return `/api/teams/${teamSlug}${resource ? `/${resource}` : ""}`;
+  return resource ? `/api/${resource}` : "/api";
+}
+
+export async function fetchTree(teamSlug?: string | null): Promise<TreeNode[]> {
+  const res = await fetch(`${teamBase(teamSlug, "tree")}`);
   if (!res.ok) throw new Error("Failed to fetch tree");
   return res.json();
 }
 
-export async function fetchPage(path: string): Promise<PageData> {
-  const res = await fetch(`/api/pages/${path}`);
+export async function fetchPage(path: string, teamSlug?: string | null): Promise<PageData> {
+  const res = await fetch(`${teamBase(teamSlug, "pages")}/${path}`);
   if (!res.ok) throw new Error(`Failed to fetch page: ${path}`);
   return res.json();
 }
@@ -15,9 +21,10 @@ export async function fetchPage(path: string): Promise<PageData> {
 export async function savePage(
   path: string,
   content: string,
-  frontmatter: Partial<FrontMatter>
+  frontmatter: Partial<FrontMatter>,
+  teamSlug?: string | null
 ): Promise<void> {
-  const res = await fetch(`/api/pages/${path}`, {
+  const res = await fetch(`${teamBase(teamSlug, "pages")}/${path}`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ content, frontmatter }),
@@ -27,9 +34,10 @@ export async function savePage(
 
 export async function createPageApi(
   parentPath: string,
-  title: string
+  title: string,
+  teamSlug?: string | null
 ): Promise<void> {
-  const res = await fetch(`/api/pages/${parentPath}`, {
+  const res = await fetch(`${teamBase(teamSlug, "pages")}/${parentPath}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ title }),
@@ -37,16 +45,17 @@ export async function createPageApi(
   if (!res.ok) throw new Error(`Failed to create page: ${parentPath}`);
 }
 
-export async function deletePageApi(path: string): Promise<void> {
-  const res = await fetch(`/api/pages/${path}`, { method: "DELETE" });
+export async function deletePageApi(path: string, teamSlug?: string | null): Promise<void> {
+  const res = await fetch(`${teamBase(teamSlug, "pages")}/${path}`, { method: "DELETE" });
   if (!res.ok) throw new Error(`Failed to delete page: ${path}`);
 }
 
 export async function movePageApi(
   fromPath: string,
-  toParent: string
+  toParent: string,
+  teamSlug?: string | null
 ): Promise<string> {
-  const res = await fetch(`/api/pages/${fromPath}`, {
+  const res = await fetch(`${teamBase(teamSlug, "pages")}/${fromPath}`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ toParent }),
@@ -58,9 +67,10 @@ export async function movePageApi(
 
 export async function renamePageApi(
   fromPath: string,
-  newName: string
+  newName: string,
+  teamSlug?: string | null
 ): Promise<string> {
-  const res = await fetch(`/api/pages/${fromPath}`, {
+  const res = await fetch(`${teamBase(teamSlug, "pages")}/${fromPath}`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ rename: newName }),
@@ -68,4 +78,13 @@ export async function renamePageApi(
   if (!res.ok) throw new Error(`Failed to rename page: ${fromPath}`);
   const data = await res.json();
   return data.newPath;
+}
+
+export async function fetchUserTeams(): Promise<
+  { id: string; name: string; slug: string; role: string }[]
+> {
+  const res = await fetch("/api/teams");
+  if (!res.ok) throw new Error("Failed to fetch teams");
+  const data = await res.json();
+  return data.teams ?? [];
 }

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -1,0 +1,5 @@
+"use client";
+
+import { createAuthClient } from "better-auth/react";
+
+export const authClient = createAuthClient();

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,66 @@
+import { betterAuth } from "better-auth";
+import { getDb } from "@/lib/db";
+
+export const auth = betterAuth({
+  database: getDb(),
+  socialProviders: {
+    ...(process.env.GOOGLE_CLIENT_ID && {
+      google: {
+        clientId: process.env.GOOGLE_CLIENT_ID,
+        clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+      },
+    }),
+    ...(process.env.GITHUB_CLIENT_ID && {
+      github: {
+        clientId: process.env.GITHUB_CLIENT_ID,
+        clientSecret: process.env.GITHUB_CLIENT_SECRET!,
+      },
+    }),
+  },
+  databaseHooks: {
+    user: {
+      create: {
+        after: async (user) => {
+          await maybeCreateDefaultTeam(user.id);
+        },
+      },
+    },
+  },
+});
+
+async function maybeCreateDefaultTeam(userId: string): Promise<void> {
+  const db = getDb();
+
+  const teamCount = (
+    db.prepare("SELECT COUNT(*) as c FROM teams").get() as { c: number }
+  ).c;
+  if (teamCount > 0) return;
+
+  const { getManagedDataDir } = await import("@/lib/runtime/runtime-config");
+  const { existsSync, readdirSync } = await import("fs");
+  const dataDir = getManagedDataDir();
+
+  const hasContent =
+    existsSync(dataDir) &&
+    readdirSync(dataDir).some((f) => !f.startsWith(".") && f !== "teams");
+
+  const teamId = crypto.randomUUID();
+  const slug = "default";
+
+  if (hasContent) {
+    db.prepare(`
+      INSERT INTO teams (id, name, slug, data_dir_override, created_by)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(teamId, "Default", slug, dataDir, userId);
+  } else {
+    db.prepare(`
+      INSERT INTO teams (id, name, slug, created_by)
+      VALUES (?, ?, ?, ?)
+    `).run(teamId, "Default", slug, userId);
+  }
+
+  db.prepare(`
+    INSERT INTO team_members (id, team_id, user_id, role)
+    VALUES (?, ?, ?, 'admin')
+  `).run(crypto.randomUUID(), teamId, userId);
+}

--- a/src/lib/git/git-service.ts
+++ b/src/lib/git/git-service.ts
@@ -3,37 +3,47 @@ import { DATA_DIR } from "@/lib/storage/path-utils";
 import { fileExists } from "@/lib/storage/fs-operations";
 import path from "path";
 
-let git: SimpleGit | null = null;
+// Per-directory git instances and commit timers
+const gitInstances = new Map<string, SimpleGit | null>();
+const commitTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
-async function getGit(): Promise<SimpleGit | null> {
-  if (git) return git;
+async function getGit(dataDir: string): Promise<SimpleGit | null> {
+  if (gitInstances.has(dataDir)) return gitInstances.get(dataDir)!;
 
-  const gitDir = path.join(DATA_DIR, ".git");
+  const gitDir = path.join(dataDir, ".git");
   if (await fileExists(gitDir)) {
-    git = simpleGit(DATA_DIR);
-    return git;
+    const instance = simpleGit(dataDir);
+    gitInstances.set(dataDir, instance);
+    return instance;
   }
 
-  // Initialize git in data dir if not exists
+  // Initialize git in dir if not exists
   try {
-    git = simpleGit(DATA_DIR);
-    await git.init();
-    await git.addConfig("user.email", "kb@cabinet.dev");
-    await git.addConfig("user.name", "Cabinet");
-    return git;
+    const instance = simpleGit(dataDir);
+    await instance.init();
+    await instance.addConfig("user.email", "kb@cabinet.dev");
+    await instance.addConfig("user.name", "Cabinet");
+    gitInstances.set(dataDir, instance);
+    return instance;
   } catch {
+    gitInstances.set(dataDir, null);
     return null;
   }
 }
 
-let commitTimer: ReturnType<typeof setTimeout> | null = null;
+export async function autoCommit(
+  pagePath: string,
+  action: "Update" | "Add" | "Delete",
+  dataDir: string = DATA_DIR
+) {
+  // Debounce commits per dataDir — batch within 5 seconds
+  const existing = commitTimers.get(dataDir);
+  if (existing) clearTimeout(existing);
 
-export async function autoCommit(pagePath: string, action: "Update" | "Add" | "Delete") {
-  // Debounce commits — batch within 5 seconds
-  if (commitTimer) clearTimeout(commitTimer);
-  commitTimer = setTimeout(async () => {
+  const timer = setTimeout(async () => {
+    commitTimers.delete(dataDir);
     try {
-      const g = await getGit();
+      const g = await getGit(dataDir);
       if (!g) return;
 
       await g.add(".");
@@ -45,6 +55,8 @@ export async function autoCommit(pagePath: string, action: "Update" | "Add" | "D
       console.error("Auto-commit failed:", error);
     }
   }, 5000);
+
+  commitTimers.set(dataDir, timer);
 }
 
 export interface GitLogEntry {
@@ -54,12 +66,14 @@ export interface GitLogEntry {
   author: string;
 }
 
-export async function getPageHistory(virtualPath: string): Promise<GitLogEntry[]> {
-  const g = await getGit();
+export async function getPageHistory(
+  virtualPath: string,
+  dataDir: string = DATA_DIR
+): Promise<GitLogEntry[]> {
+  const g = await getGit(dataDir);
   if (!g) return [];
 
   try {
-    // Try both directory and file paths
     const candidates = [
       path.join(virtualPath, "index.md"),
       `${virtualPath}.md`,
@@ -87,15 +101,14 @@ export async function getPageHistory(virtualPath: string): Promise<GitLogEntry[]
   }
 }
 
-export async function getDiff(hash: string): Promise<string> {
-  const g = await getGit();
+export async function getDiff(hash: string, dataDir: string = DATA_DIR): Promise<string> {
+  const g = await getGit(dataDir);
   if (!g) return "";
 
   try {
     return await g.diff([`${hash}~1`, hash]);
   } catch {
     try {
-      // First commit case
       return await g.diff([hash]);
     } catch {
       return "";
@@ -103,8 +116,11 @@ export async function getDiff(hash: string): Promise<string> {
   }
 }
 
-export async function manualCommit(message: string): Promise<boolean> {
-  const g = await getGit();
+export async function manualCommit(
+  message: string,
+  dataDir: string = DATA_DIR
+): Promise<boolean> {
+  const g = await getGit(dataDir);
   if (!g) return false;
 
   try {
@@ -126,15 +142,14 @@ export async function manualCommit(message: string): Promise<boolean> {
 
 export async function restoreFileFromCommit(
   hash: string,
-  filePath: string
+  filePath: string,
+  dataDir: string = DATA_DIR
 ): Promise<boolean> {
-  const g = await getGit();
+  const g = await getGit(dataDir);
   if (!g) return false;
 
   try {
-    // Restore file to state at the given commit
     await g.checkout([hash, "--", filePath]);
-    // Commit the restoration
     await g.add(filePath);
     await g.commit(`Restore ${filePath} to version ${hash.slice(0, 8)}`);
     return true;
@@ -144,12 +159,13 @@ export async function restoreFileFromCommit(
   }
 }
 
-export async function gitPull(): Promise<{ pulled: boolean; summary: string }> {
-  const g = await getGit();
+export async function gitPull(
+  dataDir: string = DATA_DIR
+): Promise<{ pulled: boolean; summary: string }> {
+  const g = await getGit(dataDir);
   if (!g) return { pulled: false, summary: "Git not available" };
 
   try {
-    // Check if remote exists
     const remotes = await g.getRemotes(true);
     if (remotes.length === 0) {
       return { pulled: false, summary: "No remote configured" };
@@ -168,8 +184,10 @@ export async function gitPull(): Promise<{ pulled: boolean; summary: string }> {
   }
 }
 
-export async function getStatus(): Promise<{ uncommitted: number }> {
-  const g = await getGit();
+export async function getStatus(
+  dataDir: string = DATA_DIR
+): Promise<{ uncommitted: number }> {
+  const g = await getGit(dataDir);
   if (!g) return { uncommitted: 0 };
 
   try {

--- a/src/lib/storage/page-io.ts
+++ b/src/lib/storage/page-io.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import matter from "gray-matter";
 import type { PageData, FrontMatter } from "@/types";
-import { resolveContentPath } from "./path-utils";
+import { resolveContentPath, virtualPathFromFs } from "./path-utils";
 import {
   readFileContent,
   writeFileContent,
@@ -15,8 +15,8 @@ function defaultFrontmatter(title: string): FrontMatter {
   return { title, created: now, modified: now, tags: [] };
 }
 
-export async function readPage(virtualPath: string): Promise<PageData> {
-  const resolved = resolveContentPath(virtualPath);
+export async function readPage(virtualPath: string, dataDir?: string): Promise<PageData> {
+  const resolved = resolveContentPath(virtualPath, dataDir);
 
   // Try directory with index.md first
   const indexPath = path.join(resolved, "index.md");
@@ -53,9 +53,10 @@ export async function readPage(virtualPath: string): Promise<PageData> {
 export async function writePage(
   virtualPath: string,
   content: string,
-  frontmatter: Partial<FrontMatter>
+  frontmatter: Partial<FrontMatter>,
+  dataDir?: string
 ): Promise<void> {
-  const resolved = resolveContentPath(virtualPath);
+  const resolved = resolveContentPath(virtualPath, dataDir);
 
   const indexPath = path.join(resolved, "index.md");
   const mdPath = resolved.endsWith(".md") ? resolved : `${resolved}.md`;
@@ -84,9 +85,10 @@ export async function writePage(
 
 export async function createPage(
   virtualPath: string,
-  title: string
+  title: string,
+  dataDir?: string
 ): Promise<void> {
-  const resolved = resolveContentPath(virtualPath);
+  const resolved = resolveContentPath(virtualPath, dataDir);
   const dirPath = resolved;
   const filePath = path.join(dirPath, "index.md");
 
@@ -100,20 +102,21 @@ export async function createPage(
   await writeFileContent(filePath, output);
 }
 
-export async function deletePage(virtualPath: string): Promise<void> {
-  const resolved = resolveContentPath(virtualPath);
+export async function deletePage(virtualPath: string, dataDir?: string): Promise<void> {
+  const resolved = resolveContentPath(virtualPath, dataDir);
   await deleteFileOrDir(resolved);
 }
 
 export async function movePage(
   fromPath: string,
-  toParentPath: string
+  toParentPath: string,
+  dataDir?: string
 ): Promise<string> {
-  const fromResolved = resolveContentPath(fromPath);
+  const fromResolved = resolveContentPath(fromPath, dataDir);
   const name = path.basename(fromResolved);
   const toDir = toParentPath
-    ? resolveContentPath(toParentPath)
-    : resolveContentPath("");
+    ? resolveContentPath(toParentPath, dataDir)
+    : resolveContentPath("", dataDir);
   const toResolved = path.join(toDir, name);
 
   if (fromResolved === toResolved) return fromPath;
@@ -125,14 +128,16 @@ export async function movePage(
   const fs = await import("fs/promises");
   await fs.rename(fromResolved, toResolved);
 
-  return toParentPath ? `${toParentPath}/${name}` : name;
+  const newVirtualPath = virtualPathFromFs(toResolved, dataDir);
+  return newVirtualPath;
 }
 
 export async function renamePage(
   virtualPath: string,
-  newName: string
+  newName: string,
+  dataDir?: string
 ): Promise<string> {
-  const fromResolved = resolveContentPath(virtualPath);
+  const fromResolved = resolveContentPath(virtualPath, dataDir);
   const parentDir = path.dirname(fromResolved);
   const slug = newName
     .toLowerCase()
@@ -159,6 +164,5 @@ export async function renamePage(
     await writeFileContent(indexMd, output);
   }
 
-  const parentVirtual = virtualPath.split("/").slice(0, -1).join("/");
-  return parentVirtual ? `${parentVirtual}/${slug}` : slug;
+  return virtualPathFromFs(toResolved, dataDir);
 }

--- a/src/lib/storage/path-utils.ts
+++ b/src/lib/storage/path-utils.ts
@@ -12,16 +12,18 @@ export const BACKUP_ROOT = isElectronRuntime()
   ? path.join(path.dirname(DATA_DIR), "cabinet-backups")
   : path.resolve(PROJECT_ROOT, "..", ".cabinet-backups", path.basename(PROJECT_ROOT));
 
-export function resolveContentPath(virtualPath: string): string {
-  const resolved = path.resolve(DATA_DIR, virtualPath);
-  if (!resolved.startsWith(DATA_DIR)) {
+export function resolveContentPath(virtualPath: string, rootDir?: string): string {
+  const base = rootDir ?? DATA_DIR;
+  const resolved = path.resolve(base, virtualPath);
+  if (!resolved.startsWith(base)) {
     throw new Error("Path traversal detected");
   }
   return resolved;
 }
 
-export function virtualPathFromFs(fsPath: string): string {
-  return fsPath.replace(DATA_DIR, "").replace(/^\//, "");
+export function virtualPathFromFs(fsPath: string, rootDir?: string): string {
+  const base = rootDir ?? DATA_DIR;
+  return fsPath.replace(base, "").replace(/^\//, "");
 }
 
 export function sanitizeFilename(name: string): string {

--- a/src/lib/storage/tree-builder.ts
+++ b/src/lib/storage/tree-builder.ts
@@ -3,6 +3,7 @@ import path from "path";
 import matter from "gray-matter";
 import type { TreeNode } from "@/types";
 import { DATA_DIR, virtualPathFromFs, isHiddenEntry } from "./path-utils";
+
 import { listDirectory, readFileContent, fileExists } from "./fs-operations";
 
 async function readFrontmatter(
@@ -19,6 +20,7 @@ async function readFrontmatter(
 
 async function buildTreeRecursive(
   dirPath: string,
+  rootDir: string,
   ancestorRealPaths = new Set<string>()
 ): Promise<TreeNode[]> {
   let realDirPath = dirPath;
@@ -43,7 +45,7 @@ async function buildTreeRecursive(
     if (entry.name === "CLAUDE.md") continue;
 
     const fullPath = path.join(dirPath, entry.name);
-    const vPath = virtualPathFromFs(fullPath);
+    const vPath = virtualPathFromFs(fullPath, rootDir);
 
     if (entry.isDirectory) {
       const indexMd = path.join(fullPath, "index.md");
@@ -71,7 +73,7 @@ async function buildTreeRecursive(
       }
 
       const fm = hasIndexMd ? await readFrontmatter(indexMd) : {};
-      const children = await buildTreeRecursive(fullPath, nextAncestorRealPaths);
+      const children = await buildTreeRecursive(fullPath, rootDir, nextAncestorRealPaths);
 
       nodes.push({
         name: entry.name,
@@ -131,6 +133,7 @@ async function buildTreeRecursive(
   return nodes;
 }
 
-export async function buildTree(): Promise<TreeNode[]> {
-  return buildTreeRecursive(DATA_DIR);
+export async function buildTree(dataDir?: string): Promise<TreeNode[]> {
+  const root = dataDir ?? DATA_DIR;
+  return buildTreeRecursive(root, root);
 }

--- a/src/lib/teams/team-context.ts
+++ b/src/lib/teams/team-context.ts
@@ -1,0 +1,71 @@
+import { auth } from "@/lib/auth";
+import { headers } from "next/headers";
+import { getDb } from "@/lib/db";
+
+export interface TeamContext {
+  teamId: string;
+  teamSlug: string;
+  userId: string;
+  role: "admin" | "member";
+}
+
+/**
+ * Validates that the current user is authenticated and is a member of the team.
+ * Throws an error with an HTTP-friendly status on failure.
+ */
+export async function requireTeamContext(teamSlug: string): Promise<TeamContext> {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+  if (!session?.user?.id) {
+    throw Object.assign(new Error("Unauthenticated"), { status: 401 });
+  }
+
+  const db = getDb();
+  const row = db
+    .prepare(`
+      SELECT t.id, t.slug, tm.role
+      FROM teams t
+      JOIN team_members tm ON tm.team_id = t.id
+      WHERE t.slug = ? AND tm.user_id = ?
+    `)
+    .get(teamSlug, session.user.id) as
+    | { id: string; slug: string; role: string }
+    | undefined;
+
+  if (!row) {
+    throw Object.assign(new Error("Not a team member"), { status: 403 });
+  }
+
+  return {
+    teamId: row.id,
+    teamSlug: row.slug,
+    userId: session.user.id,
+    role: row.role as "admin" | "member",
+  };
+}
+
+/**
+ * Returns all teams the given user belongs to.
+ */
+export function getUserTeams(userId: string) {
+  const db = getDb();
+  return db
+    .prepare(`
+      SELECT t.id, t.name, t.slug, tm.role
+      FROM teams t
+      JOIN team_members tm ON tm.team_id = t.id
+      WHERE tm.user_id = ?
+      ORDER BY t.name
+    `)
+    .all(userId) as Array<{ id: string; name: string; slug: string; role: string }>;
+}
+
+/**
+ * Helper to build a standard error response from a context error.
+ */
+export function teamContextErrorResponse(err: unknown): Response {
+  const status = (err as { status?: number }).status ?? 500;
+  const message = (err as Error).message ?? "Internal error";
+  return Response.json({ error: message }, { status });
+}

--- a/src/lib/teams/team-fs.ts
+++ b/src/lib/teams/team-fs.ts
@@ -1,0 +1,38 @@
+import path from "path";
+import fs from "fs/promises";
+import { existsSync } from "fs";
+import simpleGit from "simple-git";
+import { getManagedDataDir } from "@/lib/runtime/runtime-config";
+import { getDb } from "@/lib/db";
+
+/**
+ * Returns the filesystem path for a team's data directory.
+ * If the team has a data_dir_override (e.g. the legacy "default" team),
+ * that path is used instead of the default teams/{slug} location.
+ */
+export function getTeamDataDir(teamSlug: string): string {
+  const db = getDb();
+  const row = db
+    .prepare("SELECT data_dir_override FROM teams WHERE slug = ?")
+    .get(teamSlug) as { data_dir_override: string | null } | undefined;
+
+  if (row?.data_dir_override) return row.data_dir_override;
+  return path.join(getManagedDataDir(), "teams", teamSlug);
+}
+
+/**
+ * Ensures the team's data directory exists and has a git repo initialised.
+ * Safe to call multiple times (idempotent).
+ */
+export async function initTeamDirectory(teamSlug: string): Promise<void> {
+  const teamDir = getTeamDataDir(teamSlug);
+  await fs.mkdir(teamDir, { recursive: true });
+
+  const gitDir = path.join(teamDir, ".git");
+  if (!existsSync(gitDir)) {
+    const git = simpleGit(teamDir);
+    await git.init();
+    await git.addConfig("user.email", "kb@cabinet.dev");
+    await git.addConfig("user.name", "Cabinet");
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,12 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { betterFetch } from "@better-fetch/fetch";
+
+const PUBLIC_PREFIXES = ["/login", "/api/auth", "/api/health", "/_next", "/favicon"];
+
+function isPublicPath(pathname: string): boolean {
+  return PUBLIC_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+}
 
 async function hashToken(password: string): Promise<string> {
   const encoder = new TextEncoder();
@@ -8,45 +16,49 @@ async function hashToken(password: string): Promise<string> {
   return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
-export async function middleware(req: NextRequest) {
-  const password = process.env.KB_PASSWORD || "";
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
 
-  // Auth disabled — no password set
-  if (!password) {
+  if (isPublicPath(pathname)) return NextResponse.next();
+
+  const hasOAuth = !!(process.env.GOOGLE_CLIENT_ID || process.env.GITHUB_CLIENT_ID);
+  const legacyPassword = process.env.KB_PASSWORD ?? "";
+
+  // Legacy mode: KB_PASSWORD set, no OAuth configured
+  if (legacyPassword && !hasOAuth) {
+    const token = request.cookies.get("kb-auth")?.value;
+    const expected = await hashToken(legacyPassword);
+    if (token !== expected) {
+      if (pathname.startsWith("/api/")) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      }
+      return NextResponse.redirect(new URL("/login", request.url));
+    }
     return NextResponse.next();
   }
 
-  const { pathname } = req.nextUrl;
+  // No auth configured — open access
+  if (!legacyPassword && !hasOAuth) return NextResponse.next();
 
-  // Allow login page and login API
-  if (pathname === "/login" || pathname === "/api/auth/login" || pathname === "/api/auth/check") {
-    return NextResponse.next();
-  }
+  // OAuth mode: validate better-auth session via lightweight fetch to own endpoint
+  const { data: session } = await betterFetch<{ user: { id: string } }>(
+    "/api/auth/get-session",
+    {
+      baseURL: request.nextUrl.origin,
+      headers: { cookie: request.headers.get("cookie") ?? "" },
+    }
+  );
 
-  // Allow health check
-  if (pathname === "/api/health") {
-    return NextResponse.next();
-  }
-
-  // Check auth cookie
-  const token = req.cookies.get("kb-auth")?.value;
-  const expected = await hashToken(password);
-
-  if (token !== expected) {
-    // API routes return 401
+  if (!session?.user) {
     if (pathname.startsWith("/api/")) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
-    // Pages redirect to login
-    return NextResponse.redirect(new URL("/login", req.url));
+    return NextResponse.redirect(new URL("/login", request.url));
   }
 
   return NextResponse.next();
 }
 
 export const config = {
-  matcher: [
-    // Protect all routes except static files and Next.js internals
-    "/((?!_next/static|_next/image|favicon.ico).*)",
-  ],
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
 };

--- a/src/stores/app-store.ts
+++ b/src/stores/app-store.ts
@@ -13,6 +13,13 @@ interface TerminalTab {
   prompt?: string;
 }
 
+interface TeamInfo {
+  id: string;
+  name: string;
+  slug: string;
+  role: string;
+}
+
 interface AppState {
   section: SelectedSection;
   terminalOpen: boolean;
@@ -20,6 +27,9 @@ interface AppState {
   activeTerminalTab: string | null;
   sidebarCollapsed: boolean;
   aiPanelCollapsed: boolean;
+  // Multi-team
+  currentTeamSlug: string | null;
+  teams: TeamInfo[];
   setSection: (section: SelectedSection) => void;
   toggleTerminal: () => void;
   closeTerminal: () => void;
@@ -29,6 +39,8 @@ interface AppState {
   openAgentTab: (taskTitle: string, prompt: string) => void;
   setSidebarCollapsed: (collapsed: boolean) => void;
   setAiPanelCollapsed: (collapsed: boolean) => void;
+  setCurrentTeam: (slug: string) => void;
+  setTeams: (teams: TeamInfo[]) => void;
 }
 
 export const useAppStore = create<AppState>((set, get) => ({
@@ -38,6 +50,8 @@ export const useAppStore = create<AppState>((set, get) => ({
   activeTerminalTab: null,
   sidebarCollapsed: false,
   aiPanelCollapsed: false,
+  currentTeamSlug: null,
+  teams: [],
 
   setSection: (section) => set({ section }),
 
@@ -89,6 +103,28 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: collapsed }),
   setAiPanelCollapsed: (collapsed) => set({ aiPanelCollapsed: collapsed }),
+
+  setCurrentTeam: (slug) => {
+    set({ currentTeamSlug: slug });
+    if (typeof window !== "undefined") {
+      localStorage.setItem("kb-current-team", slug);
+    }
+  },
+
+  setTeams: (teams) => {
+    set({ teams });
+    // Restore last used team or default to first
+    const stored =
+      typeof window !== "undefined" ? localStorage.getItem("kb-current-team") : null;
+    const { currentTeamSlug } = get();
+    if (!currentTeamSlug) {
+      const slug =
+        (stored && teams.find((t) => t.slug === stored)?.slug) ||
+        teams[0]?.slug ||
+        null;
+      if (slug) set({ currentTeamSlug: slug });
+    }
+  },
 
   openAgentTab: (taskTitle: string, prompt: string) => {
     const id = `agent-${Date.now()}`;

--- a/src/stores/editor-store.ts
+++ b/src/stores/editor-store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import type { FrontMatter, SaveStatus } from "@/types";
 import { fetchPage, savePage } from "@/lib/api/client";
+import { useAppStore } from "./app-store";
 
 interface EditorState {
   currentPath: string | null;
@@ -31,8 +32,9 @@ export const useEditorStore = create<EditorState>((set, get) => ({
     if (saveTimer) clearTimeout(saveTimer);
     if (statusTimer) clearTimeout(statusTimer);
 
+    const teamSlug = useAppStore.getState().currentTeamSlug;
     try {
-      const page = await fetchPage(path);
+      const page = await fetchPage(path, teamSlug);
       set({
         currentPath: path,
         content: page.content,
@@ -77,7 +79,8 @@ export const useEditorStore = create<EditorState>((set, get) => ({
 
     set({ saveStatus: "saving" });
     try {
-      await savePage(currentPath, content, frontmatter || {});
+      const teamSlug = useAppStore.getState().currentTeamSlug;
+      await savePage(currentPath, content, frontmatter || {}, teamSlug);
       set({ saveStatus: "saved", isDirty: false });
 
       if (statusTimer) clearTimeout(statusTimer);

--- a/src/stores/tree-store.ts
+++ b/src/stores/tree-store.ts
@@ -7,6 +7,11 @@ import {
   movePageApi,
   renamePageApi,
 } from "@/lib/api/client";
+import { useAppStore } from "./app-store";
+
+function getTeamSlug(): string | null {
+  return useAppStore.getState().currentTeamSlug;
+}
 
 interface TreeState {
   nodes: TreeNode[];
@@ -51,7 +56,7 @@ export const useTreeStore = create<TreeState>((set, get) => ({
   loadTree: async () => {
     set({ loading: true });
     try {
-      const nodes = await fetchTree();
+      const nodes = await fetchTree(getTeamSlug());
       set({ nodes, loading: false });
     } catch {
       set({ loading: false });
@@ -90,7 +95,7 @@ export const useTreeStore = create<TreeState>((set, get) => ({
       .replace(/[^a-z0-9]+/g, "-")
       .replace(/^-|-$/g, "");
     const fullPath = parentPath ? `${parentPath}/${slug}` : slug;
-    await createPageApi(fullPath, title);
+    await createPageApi(fullPath, title, getTeamSlug());
     if (parentPath) {
       get().expandPath(parentPath);
     }
@@ -99,7 +104,7 @@ export const useTreeStore = create<TreeState>((set, get) => ({
   },
 
   deletePage: async (path: string) => {
-    await deletePageApi(path);
+    await deletePageApi(path, getTeamSlug());
     const { selectedPath } = get();
     if (selectedPath === path) {
       set({ selectedPath: null });
@@ -109,7 +114,7 @@ export const useTreeStore = create<TreeState>((set, get) => ({
 
   movePage: async (fromPath: string, toParentPath: string) => {
     try {
-      const newPath = await movePageApi(fromPath, toParentPath);
+      const newPath = await movePageApi(fromPath, toParentPath, getTeamSlug());
       if (toParentPath) {
         get().expandPath(toParentPath);
       }
@@ -125,7 +130,7 @@ export const useTreeStore = create<TreeState>((set, get) => ({
 
   renamePage: async (pagePath: string, newName: string) => {
     try {
-      const newPath = await renamePageApi(pagePath, newName);
+      const newPath = await renamePageApi(pagePath, newName, getTeamSlug());
       await get().loadTree();
       const { selectedPath } = get();
       if (selectedPath === pagePath) {


### PR DESCRIPTION
## Summary
                                                                                                                                                                                                                                                                                                                          
Transforms Cabinet from a single-tenant password-protected app into a                                                                                                                                                                                                                                                    
multi-tenant platform with OAuth authentication, team management, and                                                                                                                                                                                                                                                    
full data isolation between teams.                                                                                                                                                                                                                                                                                       
                                                                
### What changed                                                                                                                                                                                                                                                                                                         
  
**Authentication**                                                                                                                                                                                                                                                                                                       
- Replaced the shared `KB_PASSWORD` model with OAuth via **better-auth**
  (Google and GitHub providers), while keeping `KB_PASSWORD` as a                                                                                                                                                                                                                                                        
  legacy fallback for self-hosted setups without OAuth                                                                                                                                                                                                                                                                   
- Middleware now validates sessions via a lightweight `betterFetch` call                                                                                                                                                                                                                                                 
  to `/api/auth/get-session` — avoids importing `better-sqlite3` in the                                                                                                                                                                                                                                                  
  Edge Runtime                                                                                                                                                                                                                                                                                                           
- Added SQL migrations 002–004 for teams, members, and better-auth                                                                                                                                                                                                                                                       
  tables (`user`, `session`, `account`, `verification`)                                                                                                                                                                                                                                                                  
                                                                
> **Note:** `next-auth@5.0.0-beta.30` was evaluated and discarded. It                                                                                                                                                                                                                                                    
> fails to resolve `next/server` under Turbopack (Next.js 16 default)
> due to missing ESM `.js` extensions in its internal modules.                                                                                                                                                                                                                                                           
> `better-auth` is fully compatible and actively maintained.                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                          
**Teams**                                                                                                                                                                                                                                                                                                                
- Each team has its own KB directory (`data/teams/{slug}/`) and an
  independent git repository                                                                                                                                                                                                                                                                                             
- On first OAuth login, a `default` team is automatically created                                                                                                                                                                                                                                                        
  pointing to the existing `DATA_DIR` — zero file migration required                                                                                                                                                                                                                                                     
- Team switcher and user menu added to the sidebar                                                                                                                                                                                                                                                                       
- `/teams/new` and `/teams/{slug}/settings` pages for team management                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                          
**Scoped APIs**                                                                                                                                                                                                                                                                                                          
- All KB operations (tree, pages, search, git log/diff/commit/pull/                                                                                                                                                                                                                                                      
  restore) now have team-scoped routes under                                                                                                                                                                                                                                                                             
  `/api/teams/[slug]/`
                                                                                                                                                                                                                                                                                                                          
**Agent session isolation**                                                                                                                                                                                                                                                                                              
- PTY sessions in the daemon are tagged with `userId` and `teamSlug`
- `GET /sessions` supports `?userId=` filter for per-user session lists                                                                                                                                                                                                                                                  
- Per-user agent workspaces under `src/lib/agents/user-workspace.ts`                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                          
**Minor fixes (discovered during implementation)**                                                                                                                                                                                                                                                                       
- React 19: replaced `<script dangerouslySetInnerHTML>` in layout with                                                                                                                                                                                                                                                   
  an `ElectronDetector` client component using `useEffect`                                                                                                                                                                                                                                                               
- base-ui: replaced all `onSelect` with `onClick` in `TeamSwitcher` and                                                                                                                                                                                                                                                  
  `UserMenu` — `onSelect` is Radix UI-only and silently ignored by                                                                                                                                                                                                                                                       
  base-ui                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                          
## Backward compatibility                                                                                                                                                                                                                                                                                                
                                                                
Existing single-tenant deployments are fully supported:                                                                                                                                                                                                                                                                  
- `KB_PASSWORD` still works with no OAuth configured            
- No auth configured → open access (same as before)                                                                                                                                                                                                                                                                      
- The `default` team uses `data_dir_override` to point to the existing                                                                                                                                                                                                                                                   
  data directory without moving any files                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                          
## Dependencies added                                           
                                                                                                                                                                                                                                                                                                                          
- `better-auth` — auth framework                                
- `@better-fetch/fetch` — used in middleware for Edge-safe session
  validation                                                                                                                                                                                                                                                                                                             
  
## Test plan                                                                                                                                                                                                                                                                                                             
                                                                
- [ ] `npx tsc --noEmit` — zero errors introduced by this PR                                                                                                                                                                                                                                                             
- [ ] `npm run dev:all` starts without errors                   
- [ ] Unauthenticated request → redirects to `/login`                                                                                                                                                                                                                                                                    
- [ ] "Continue with Google" → OAuth flow completes, `default` team                                                                                                                                                                                                                                                      
      created, sidebar shows KB content                                                                                                                                                                                                                                                                                  
- [ ] Team switcher shows available teams, click navigates correctly                                                                                                                                                                                                                                                     
- [ ] `/teams/new` creates a new team with an isolated KB directory                                                                                                                                                                                                                                                      
- [ ] `/teams/{slug}/settings` lists members, invite by email works
- [ ] Legacy `KB_PASSWORD` mode still works (set password, no OAuth vars)                                                                                                                                                                                                                                                
- [ ] Open access still works (no `KB_PASSWORD`, no OAuth vars)                                                                                                                                                                                                                                                          
                                                                    