### PR TITLE
Add Windows Electron support

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,5 +1,7 @@
 # Progress
 
+[2026-04-21] Rebased PR #32 (Windows Electron support) onto origin/main (80ca3df, 35+ commits ahead). Re-homed Windows path/command resolution into `adapters/utils.ts` to fit main's adapter architecture, fixed CodeRabbit's shell-injection and process-tree termination concerns, extended postinstall.mjs for darwin-x64, and force-pushed to the fork. All PR-specific tests pass; 6 pre-existing Windows failures remain.
+
 [2026-04-16] Claude Code model labels now include version numbers in the runtime picker ("Claude Opus 4.7", "Claude Sonnet 4.6", "Claude Haiku 4.5"), with Opus listed first.
 
 [2026-04-16] Runtime picker: fixed gap between tabs and model table by wrapping the TabsList in a flex container, eliminating the CSS inline-flex baseline descender space that was adding ~4px below the tab buttons. Inactive tabs now use bg-muted/60 so the active tab stands out clearly.

--- a/README.md
+++ b/README.md
@@ -181,7 +181,8 @@ cabinet/
 - At least one supported CLI provider:
   - **Claude Code CLI** (`npm install -g @anthropic-ai/claude-code`)
   - **Codex CLI** (`npm install -g @openai/codex` or `brew install --cask codex`)
-- macOS or Linux (Windows via WSL)
+- **Source mode:** macOS, Linux, or Windows
+- **Electron desktop packaging:** macOS and Windows
 
 ## Configuration
 
@@ -200,8 +201,10 @@ cp .env.example .env.local
 npm run dev          # Next.js dev server (port 3000)
 npm run dev:daemon   # Unified daemon: structured runs, terminal sessions, WebSockets, scheduler (port 3001)
 npm run dev:all      # Both servers
+npm run electron:start   # Launch Electron desktop against the local dev servers
 npm run build        # Production build
 npm run start        # Production mode (both servers)
+npm run electron:make:win  # Build a portable Windows zip
 ```
 
 ---

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -23,6 +23,14 @@ let mainWindow = null;
 let backendChildren = [];
 const DEV_APP_DISCOVERY_TIMEOUT_MS = 45_000;
 
+function getElectronInstallKind() {
+  return process.platform === "win32" ? "electron-windows" : "electron-macos";
+}
+
+function getBundledNodeBinaryName() {
+  return process.platform === "win32" ? "node.exe" : "node";
+}
+
 function writeUpdateStatus(status) {
   fs.mkdirSync(path.dirname(updateStatusPath), { recursive: true });
   fs.writeFileSync(updateStatusPath, JSON.stringify(status, null, 2), "utf8");
@@ -95,7 +103,7 @@ function spawnNodeBackend(args, env) {
     ".next",
     "standalone",
     "bin",
-    "node"
+    getBundledNodeBinaryName()
   );
 
   if (fs.existsSync(bundledNodePath)) {
@@ -120,6 +128,10 @@ function packagedStandalonePath(...parts) {
  * can execute, and return the external node_modules path for NODE_PATH.
  */
 function extractNativeModules() {
+  if (process.platform !== "darwin") {
+    return packagedStandalonePath(".native");
+  }
+
   const externalModulesDir = path.join(app.getPath("userData"), "native-modules");
   const externalNodePty = path.join(externalModulesDir, "node-pty");
   const bundledNodePty = packagedStandalonePath(".native", "node-pty");
@@ -266,7 +278,7 @@ async function startEmbeddedCabinet() {
     NODE_ENV: "production",
     PORT: String(appPort),
     CABINET_RUNTIME: "electron",
-    CABINET_INSTALL_KIND: "electron-macos",
+    CABINET_INSTALL_KIND: getElectronInstallKind(),
     CABINET_DATA_DIR: managedDataDir,
     CABINET_APP_PORT: String(appPort),
     CABINET_DAEMON_PORT: String(daemonPort),
@@ -306,7 +318,7 @@ function configureAutoUpdates() {
     writeUpdateStatus({
       state: "failed",
       completedAt: new Date().toISOString(),
-      installKind: "electron-macos",
+      installKind: getElectronInstallKind(),
       message: "Electron update setup failed.",
       error: error instanceof Error ? error.message : String(error),
     });
@@ -316,7 +328,7 @@ function configureAutoUpdates() {
     writeUpdateStatus({
       state: "checking",
       startedAt: new Date().toISOString(),
-      installKind: "electron-macos",
+      installKind: getElectronInstallKind(),
       message: "Checking for a newer Cabinet desktop release...",
     });
   });
@@ -325,7 +337,7 @@ function configureAutoUpdates() {
     writeUpdateStatus({
       state: "available",
       startedAt: new Date().toISOString(),
-      installKind: "electron-macos",
+      installKind: getElectronInstallKind(),
       message: "A new Cabinet desktop release is downloading in the background.",
     });
   });
@@ -334,7 +346,7 @@ function configureAutoUpdates() {
     writeUpdateStatus({
       state: "idle",
       completedAt: new Date().toISOString(),
-      installKind: "electron-macos",
+      installKind: getElectronInstallKind(),
       message: "Cabinet desktop is up to date.",
     });
   });
@@ -343,7 +355,7 @@ function configureAutoUpdates() {
     writeUpdateStatus({
       state: "failed",
       completedAt: new Date().toISOString(),
-      installKind: "electron-macos",
+      installKind: getElectronInstallKind(),
       message: "Cabinet desktop update failed.",
       error: error instanceof Error ? error.message : String(error),
     });
@@ -353,7 +365,7 @@ function configureAutoUpdates() {
     writeUpdateStatus({
       state: "restart-required",
       completedAt: new Date().toISOString(),
-      installKind: "electron-macos",
+      installKind: getElectronInstallKind(),
       message: "Restart Cabinet to finish applying the desktop update.",
     });
 

--- a/forge.config.cjs
+++ b/forge.config.cjs
@@ -150,6 +150,7 @@ module.exports = {
     asar: {
       unpackDir: ".next/standalone",
     },
+    derefSymlinks: true,
     prune: true,
     ignore: PACKAGER_IGNORE,
     afterComplete: [codesignNativeBinaries, pruneMacLocales],
@@ -168,6 +169,7 @@ module.exports = {
   },
   makers: [
     new MakerZIP({}, ["darwin"]),
+    new MakerZIP({}, ["win32"]),
     new MakerDMG({
       format: "ULFO",
       icon: "./electron/assets/cabinet-icon.icns",

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,7 +3,6 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   allowedDevOrigins: ["127.0.0.1", "localhost"],
   output: "standalone",
-  allowedDevOrigins: ["127.0.0.1", "localhost"],
   serverExternalPackages: ["node-pty", "simple-git", "better-sqlite3"],
   outputFileTracingExcludes: {
     "/*": [

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   allowedDevOrigins: ["127.0.0.1", "localhost"],
   output: "standalone",
+  allowedDevOrigins: ["127.0.0.1", "localhost"],
   serverExternalPackages: ["node-pty", "simple-git", "better-sqlite3"],
   outputFileTracingExcludes: {
     "/*": [

--- a/package.json
+++ b/package.json
@@ -15,13 +15,16 @@
     "start": "npm run start:next & npm run start:daemon",
     "start:next": "next start",
     "start:daemon": "tsx server/cabinet-daemon.ts",
-    "electron:start": "electron-forge start",
+    "electron:start": "node scripts/start-electron-dev.mjs",
+    "electron:start:forge": "electron-forge start",
     "electron:package": "npm run build && npm run electron:prep && electron-forge package",
+    "electron:package:win": "npm run build && npm run electron:prep && electron-forge package --platform win32",
     "electron:make": "npm run build && npm run electron:prep && electron-forge make",
+    "electron:make:win": "npm run build && npm run electron:prep && electron-forge make --platform win32",
     "lint": "eslint",
     "test:unit": "tsx --test test/update-system.test.ts",
-    "test": "tsx --test test/*.test.ts",
-    "postinstall": "chmod +x node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper 2>/dev/null; xattr -d com.apple.provenance node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper 2>/dev/null; xattr -d com.apple.provenance node_modules/node-pty/prebuilds/darwin-arm64/pty.node 2>/dev/null; true"
+    "test": "tsx --test --test-concurrency=1 test/*.test.ts src/lib/agents/**/*.test.ts",
+    "postinstall": "node scripts/postinstall.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,0 +1,34 @@
+import { execFileSync } from "child_process";
+import fs from "fs";
+import path from "path";
+
+if (process.platform !== "darwin") {
+  process.exit(0);
+}
+
+const darwinArm64Dir = path.join(
+  process.cwd(),
+  "node_modules",
+  "node-pty",
+  "prebuilds",
+  "darwin-arm64"
+);
+
+for (const fileName of ["spawn-helper", "pty.node"]) {
+  const target = path.join(darwinArm64Dir, fileName);
+  if (!fs.existsSync(target)) {
+    continue;
+  }
+
+  if (fileName === "spawn-helper") {
+    try {
+      fs.chmodSync(target, 0o755);
+    } catch {}
+  }
+
+  try {
+    execFileSync("xattr", ["-d", "com.apple.provenance", target], {
+      stdio: "ignore",
+    });
+  } catch {}
+}

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -6,29 +6,28 @@ if (process.platform !== "darwin") {
   process.exit(0);
 }
 
-const darwinArm64Dir = path.join(
-  process.cwd(),
-  "node_modules",
-  "node-pty",
-  "prebuilds",
-  "darwin-arm64"
-);
+const prebuildsBase = path.join(process.cwd(), "node_modules", "node-pty", "prebuilds");
+const darwinDirs = ["darwin-arm64", "darwin-x64"]
+  .map((arch) => path.join(prebuildsBase, arch))
+  .filter((dir) => fs.existsSync(dir));
 
-for (const fileName of ["spawn-helper", "pty.node"]) {
-  const target = path.join(darwinArm64Dir, fileName);
-  if (!fs.existsSync(target)) {
-    continue;
-  }
+for (const darwinDir of darwinDirs) {
+  for (const fileName of ["spawn-helper", "pty.node"]) {
+    const target = path.join(darwinDir, fileName);
+    if (!fs.existsSync(target)) {
+      continue;
+    }
 
-  if (fileName === "spawn-helper") {
+    if (fileName === "spawn-helper") {
+      try {
+        fs.chmodSync(target, 0o755);
+      } catch {}
+    }
+
     try {
-      fs.chmodSync(target, 0o755);
+      execFileSync("xattr", ["-d", "com.apple.provenance", target], {
+        stdio: "ignore",
+      });
     } catch {}
   }
-
-  try {
-    execFileSync("xattr", ["-d", "com.apple.provenance", target], {
-      stdio: "ignore",
-    });
-  } catch {}
 }

--- a/scripts/prepare-electron-package.mjs
+++ b/scripts/prepare-electron-package.mjs
@@ -1,5 +1,4 @@
 import { build as bundle } from "esbuild";
-import { execFileSync } from "child_process";
 import fs from "fs/promises";
 import path from "path";
 
@@ -15,7 +14,8 @@ const daemonMigrationsDir = path.join(standaloneServerDir, "migrations");
 const stagedNativeDir = path.join(standaloneDir, ".native");
 const stagedNodePtyDir = path.join(stagedNativeDir, "node-pty");
 const stagedSeedDir = path.join(standaloneDir, ".seed");
-const bundledNodeBinaryPath = path.join(standaloneBinDir, "node");
+const bundledNodeBinaryName = process.platform === "win32" ? "node.exe" : "node";
+const bundledNodeBinaryPath = path.join(standaloneBinDir, bundledNodeBinaryName);
 const rootNodePtyDir = path.join(projectRoot, "node_modules", "node-pty");
 const dataDir = path.join(projectRoot, "data");
 const agentLibraryDir = path.join(projectRoot, "src", "lib", "agents", "library");
@@ -122,18 +122,33 @@ async function stageDaemonRuntime() {
   await copyDirectory(path.join(projectRoot, "server", "migrations"), daemonMigrationsDir);
 
   // Stage node-pty into .native/ (NOT node_modules/) so it ships inside the
-  // app bundle but is not resolvable by require().  At runtime, main.cjs
-  // copies it to userData where macOS allows execution.
+  // app bundle but is not resolvable by require(). On macOS main.cjs copies it
+  // to userData for Gatekeeper; on Windows the packaged .native directory is
+  // used directly via NODE_PATH.
+  const prebuildDirs =
+    process.platform === "win32"
+      ? ["win32-x64", "win32-arm64"]
+      : ["darwin-arm64", "darwin-x64"];
+
   await Promise.all([
     copyDirectory(path.join(rootNodePtyDir, "lib"), path.join(stagedNodePtyDir, "lib")),
-    copyDirectory(
-      path.join(rootNodePtyDir, "prebuilds", "darwin-arm64"),
-      path.join(stagedNodePtyDir, "prebuilds", "darwin-arm64")
+    ...prebuildDirs.map((dirName) =>
+      copyDirectory(
+        path.join(rootNodePtyDir, "prebuilds", dirName),
+        path.join(stagedNodePtyDir, "prebuilds", dirName)
+      )
     ),
     copyFile(path.join(rootNodePtyDir, "package.json"), path.join(stagedNodePtyDir, "package.json")),
   ]);
 
-  await fs.chmod(path.join(stagedNodePtyDir, "prebuilds", "darwin-arm64", "spawn-helper"), 0o755);
+  if (process.platform === "darwin") {
+    for (const dirName of ["darwin-arm64", "darwin-x64"]) {
+      const helperPath = path.join(stagedNodePtyDir, "prebuilds", dirName, "spawn-helper");
+      if (await pathExists(helperPath)) {
+        await fs.chmod(helperPath, 0o755);
+      }
+    }
+  }
 }
 
 async function stageBundledNodeRuntime() {

--- a/scripts/start-electron-dev.mjs
+++ b/scripts/start-electron-dev.mjs
@@ -1,0 +1,80 @@
+import { spawn } from "child_process";
+import net from "net";
+import path from "path";
+
+const appUrl = (process.env.ELECTRON_START_URL || "http://127.0.0.1:3000").trim();
+const daemonUrl = (process.env.CABINET_DAEMON_URL || "http://127.0.0.1:3001").trim();
+
+function parseUrlPort(url) {
+  try {
+    const parsed = new URL(url);
+    return Number(parsed.port || (parsed.protocol === "https:" ? 443 : 80));
+  } catch {
+    return null;
+  }
+}
+
+function waitForPort(port, host = "127.0.0.1", timeoutMs = 30_000) {
+  const startedAt = Date.now();
+
+  return new Promise((resolve, reject) => {
+    const attempt = () => {
+      const socket = net.connect({ port, host });
+      socket.once("connect", () => {
+        socket.end();
+        resolve();
+      });
+      socket.once("error", () => {
+        socket.destroy();
+        if (Date.now() - startedAt >= timeoutMs) {
+          reject(new Error(`Timed out waiting for ${host}:${port}`));
+          return;
+        }
+        setTimeout(attempt, 500);
+      });
+    };
+
+    attempt();
+  });
+}
+
+const appPort = parseUrlPort(appUrl);
+const daemonPort = parseUrlPort(daemonUrl);
+
+if (!appPort || !daemonPort) {
+  throw new Error("Invalid dev URLs. Check ELECTRON_START_URL and CABINET_DAEMON_URL.");
+}
+
+await Promise.all([waitForPort(appPort), waitForPort(daemonPort)]);
+
+const electronBin =
+  process.platform === "win32"
+    ? path.join(process.cwd(), "node_modules", ".bin", "electron.cmd")
+    : path.join(process.cwd(), "node_modules", ".bin", "electron");
+
+const child =
+  process.platform === "win32"
+    ? spawn(`"${electronBin}" .`, {
+        stdio: "inherit",
+        shell: true,
+        env: {
+          ...process.env,
+          ELECTRON_START_URL: appUrl,
+        },
+      })
+    : spawn(electronBin, ["."], {
+        stdio: "inherit",
+        env: {
+          ...process.env,
+          ELECTRON_START_URL: appUrl,
+        },
+      });
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exit(code ?? 0);
+});

--- a/server/cabinet-daemon.ts
+++ b/server/cabinet-daemon.ts
@@ -43,7 +43,8 @@ import {
   flushClaudeStreamJson,
   type ClaudeStreamAccumulator,
 } from "../src/lib/agents/adapters/claude-stream";
-import { getNvmNodeBin } from "../src/lib/agents/nvm-path";
+import { buildPtyCliInvocation } from "../src/lib/agents/provider-cli";
+import { ADAPTER_RUNTIME_PATH } from "../src/lib/agents/adapters/utils";
 import {
   appendConversationTranscript,
   finalizeConversation,
@@ -113,14 +114,7 @@ console.log("Initializing Cabinet database...");
 getDb();
 console.log("Database ready.");
 
-const nvmBin = getNvmNodeBin();
-const enrichedPath = [
-  `${process.env.HOME}/.local/bin`,
-  "/usr/local/bin",
-  "/opt/homebrew/bin",
-  ...(nvmBin ? [nvmBin] : []),
-  process.env.PATH,
-].join(":");
+const enrichedPath = ADAPTER_RUNTIME_PATH;
 
 // ===== PTY Terminal Server =====
 
@@ -586,7 +580,9 @@ function createDetachedSession(input: {
     };
   }
 
-  const term = pty.spawn(launch.command, launch.args, {
+  const invocation = buildPtyCliInvocation(launch.command, launch.args);
+
+  const term = pty.spawn(invocation.command, invocation.args, {
     name: "xterm-256color",
     cols: 120,
     rows: 30,

--- a/server/terminal-server.ts
+++ b/server/terminal-server.ts
@@ -1,10 +1,14 @@
 import { WebSocketServer, WebSocket } from "ws";
 import * as pty from "node-pty";
-import path from "path";
 import http from "http";
-import { execSync } from "child_process";
 import { DATA_DIR } from "../src/lib/storage/path-utils";
 import { getDaemonPort } from "../src/lib/runtime/runtime-config";
+import {
+  buildPtyCliInvocation,
+  buildCommandCandidates,
+  resolveCliCommand,
+  RUNTIME_PATH,
+} from "../src/lib/agents/provider-cli";
 
 const PORT = getDaemonPort();
 
@@ -84,34 +88,25 @@ function submitInitialPrompt(session: Session): void {
 
 // Resolve the claude binary path at startup
 function resolveClaudePath(): string {
-  const candidates = [
-    path.join(process.env.HOME || "", ".local", "bin", "claude"),
-    "/usr/local/bin/claude",
-    "/opt/homebrew/bin/claude",
-  ];
-
-  for (const candidate of candidates) {
-    try {
-      const fs = require("fs");
-      if (fs.existsSync(candidate)) {
-        console.log(`Found claude at: ${candidate}`);
-        return candidate;
-      }
-    } catch {}
-  }
-
   try {
-    const resolved = execSync("which claude", {
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        PATH: `${process.env.HOME}/.local/bin:${process.env.PATH}`,
+    return resolveCliCommand({
+      id: "claude-code",
+      name: "Claude Code Max",
+      type: "cli",
+      icon: "sparkles",
+      command: "claude",
+      commandCandidates: buildCommandCandidates("claude"),
+      async isAvailable() {
+        return true;
       },
-    }).trim();
-    if (resolved) {
-      console.log(`Resolved claude via which: ${resolved}`);
-      return resolved;
-    }
+      async healthCheck() {
+        return {
+          available: true,
+          authenticated: true,
+          version: "Claude Code Max",
+        };
+      },
+    });
   } catch {}
 
   console.warn("Could not resolve claude path, using 'claude' directly");
@@ -120,10 +115,7 @@ function resolveClaudePath(): string {
 
 const CLAUDE_PATH = resolveClaudePath();
 
-const enrichedPath = [
-  `${process.env.HOME}/.local/bin`,
-  process.env.PATH,
-].join(":");
+const enrichedPath = RUNTIME_PATH;
 
 // Create HTTP server to handle both WebSocket upgrades and REST endpoints
 const server = http.createServer((req, res) => {
@@ -247,17 +239,15 @@ wss.on("connection", (ws, req) => {
   }
 
   // New session — spawn PTY
-  let shell: string;
-  let args: string[];
-
-  shell = CLAUDE_PATH;
-  args = prompt
+  const shell = CLAUDE_PATH;
+  const args = prompt
     ? ["--dangerously-skip-permissions", prompt]
     : ["--dangerously-skip-permissions"];
 
   let term: pty.IPty;
   try {
-    term = pty.spawn(shell, args, {
+    const invocation = buildPtyCliInvocation(shell, args);
+    term = pty.spawn(invocation.command, invocation.args, {
       name: "xterm-256color",
       cols: 120,
       rows: 30,

--- a/src/lib/agents/adapters/utils.ts
+++ b/src/lib/agents/adapters/utils.ts
@@ -1,15 +1,29 @@
-import { execSync, spawn } from "child_process";
+import fs from "fs";
+import { execFileSync, spawn } from "child_process";
 import { getNvmNodeBin } from "../nvm-path";
 
-const nvmBin = getNvmNodeBin();
+const nvmBin = process.platform !== "win32" ? getNvmNodeBin() : null;
 
-export const ADAPTER_RUNTIME_PATH = [
-  `${process.env.HOME || ""}/.local/bin`,
-  "/usr/local/bin",
-  "/opt/homebrew/bin",
-  ...(nvmBin ? [nvmBin] : []),
-  process.env.PATH || "",
-].filter(Boolean).join(":");
+function buildAdapterRuntimePath(): string {
+  if (process.platform === "win32") {
+    const home = process.env.USERPROFILE || process.env.HOME || "";
+    return [
+      process.env.APPDATA ? `${process.env.APPDATA}\\npm` : "",
+      `${home}\\AppData\\Local\\Microsoft\\WinGet\\Links`,
+      process.env.PATH || "",
+    ].filter(Boolean).join(";");
+  }
+
+  return [
+    `${process.env.HOME || ""}/.local/bin`,
+    "/usr/local/bin",
+    "/opt/homebrew/bin",
+    ...(nvmBin ? [nvmBin] : []),
+    process.env.PATH || "",
+  ].filter(Boolean).join(":");
+}
+
+export const ADAPTER_RUNTIME_PATH = buildAdapterRuntimePath();
 
 export interface RunChildProcessOptions {
   cwd: string;
@@ -43,35 +57,55 @@ export function withAdapterRuntimeEnv(
   };
 }
 
+const SAFE_COMMAND_NAME_RE = /^[\w.+/-]+$/;
+
 export function resolveCommandFromCandidates(
   candidates: string[],
   env: NodeJS.ProcessEnv = process.env
 ): string | null {
+  const resolvedEnv = withAdapterRuntimeEnv(env);
+
   for (const candidate of candidates) {
     if (!candidate) continue;
-    if (candidate.includes("/")) {
+
+    const isAbsolute = candidate.includes("/") || candidate.includes("\\") || /^[A-Za-z]:/.test(candidate);
+
+    if (isAbsolute) {
       try {
-        const resolved = execSync(`test -x ${JSON.stringify(candidate)} && printf '%s' ${JSON.stringify(candidate)}`, {
+        fs.accessSync(candidate, fs.constants.X_OK);
+        return candidate;
+      } catch {
+        // not executable — keep trying
+      }
+      continue;
+    }
+
+    if (!SAFE_COMMAND_NAME_RE.test(candidate)) continue;
+
+    if (process.platform === "win32") {
+      try {
+        const output = execFileSync("where.exe", [candidate], {
           encoding: "utf8",
-          env: withAdapterRuntimeEnv(env),
+          env: resolvedEnv,
           stdio: ["ignore", "pipe", "ignore"],
         }).trim();
-        if (resolved) return resolved;
+        const first = output.split(/\r?\n/).find(Boolean);
+        if (first) return first;
       } catch {
-        // Ignore and keep trying.
+        // keep trying
       }
       continue;
     }
 
     try {
-      const resolved = execSync(`command -v ${candidate}`, {
+      const output = execFileSync("/bin/sh", ["-c", "command -v \"$C\""], {
         encoding: "utf8",
-        env: withAdapterRuntimeEnv(env),
+        env: { ...resolvedEnv, C: candidate },
         stdio: ["ignore", "pipe", "ignore"],
       }).trim();
-      if (resolved) return resolved;
+      if (output) return output;
     } catch {
-      // Ignore and keep trying.
+      // keep trying
     }
   }
 
@@ -89,6 +123,9 @@ export async function runChildProcess(
   options: RunChildProcessOptions
 ): Promise<RunChildProcessResult> {
   const startedAt = new Date().toISOString();
+  const isWindows = process.platform === "win32";
+  const useShell = isWindows && !command.includes("/") && !command.includes("\\");
+
   const child = spawn(command, args, {
     cwd: options.cwd,
     env: withAdapterRuntimeEnv({
@@ -96,6 +133,8 @@ export async function runChildProcess(
       ...(options.env || {}),
     }),
     stdio: ["pipe", "pipe", "pipe"],
+    ...(isWindows ? { windowsHide: true, detached: false } : {}),
+    ...(useShell ? { shell: true } : {}),
   });
 
   const processGroupId = resolveProcessGroupId(child.pid);
@@ -119,7 +158,7 @@ export async function runChildProcess(
   };
 
   const signalChild = (signal: NodeJS.Signals) => {
-    if (process.platform !== "win32" && processGroupId && processGroupId > 0) {
+    if (!isWindows && processGroupId && processGroupId > 0) {
       try {
         process.kill(-processGroupId, signal);
         return;
@@ -186,4 +225,3 @@ export async function runChildProcess(
     });
   });
 }
-

--- a/src/lib/agents/agent-manager.ts
+++ b/src/lib/agents/agent-manager.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcess } from "child_process";
 import path from "path";
 import { DATA_DIR } from "@/lib/storage/path-utils";
+import { buildWindowsShellCommand, RUNTIME_PATH } from "./provider-cli";
 import { getOneShotLaunchSpec } from "./provider-runtime";
 
 export interface AgentSession {
@@ -85,14 +86,23 @@ export async function runAgent(
     prompt,
     workdir: cwd,
   });
-  const proc = spawn(launch.command, launch.args, {
-    cwd,
-    env: {
-      ...process.env,
-      PATH: `${process.env.HOME || ""}/.local/bin:${process.env.PATH || ""}`,
-    },
-    stdio: ["ignore", "pipe", "pipe"],
-  });
+  const env = {
+    ...process.env,
+    PATH: RUNTIME_PATH,
+  };
+  const proc =
+    process.platform === "win32"
+      ? spawn(buildWindowsShellCommand(launch.command, launch.args), {
+          cwd,
+          env,
+          shell: true,
+          stdio: ["ignore", "pipe", "pipe"],
+        })
+      : spawn(launch.command, launch.args, {
+          cwd,
+          env,
+          stdio: ["ignore", "pipe", "pipe"],
+        });
 
   session.process = proc;
   sessions.set(id, session);

--- a/src/lib/agents/agent-manager.ts
+++ b/src/lib/agents/agent-manager.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { DATA_DIR } from "@/lib/storage/path-utils";
 import { buildWindowsShellCommand, RUNTIME_PATH } from "./provider-cli";
 import { getOneShotLaunchSpec } from "./provider-runtime";
+import { terminateChildProcess } from "./process-utils";
 
 export interface AgentSession {
   id: string;
@@ -159,7 +160,7 @@ export function stopAgent(id: string): boolean {
   const session = sessions.get(id);
   if (!session || !session.process) return false;
 
-  session.process.kill();
+  void terminateChildProcess(session.process);
   session.status = "failed";
   session.completedAt = new Date().toISOString();
   delete session.process;

--- a/src/lib/agents/process-utils.test.ts
+++ b/src/lib/agents/process-utils.test.ts
@@ -1,0 +1,86 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { ChildProcess } from "node:child_process";
+import { terminateChildProcess } from "./process-utils";
+
+test("terminateChildProcess uses taskkill on Windows when pid exists", async () => {
+  const proc = {
+    pid: 4321,
+    killCalled: false,
+    kill() {
+      this.killCalled = true;
+      return true;
+    },
+  } as unknown as ChildProcess & { killCalled: boolean };
+
+  const calls: Array<{ command: string; args: string[] }> = [];
+  await terminateChildProcess(proc, {
+    platform: "win32",
+    taskkill(command, args) {
+      calls.push({ command, args });
+      return Promise.resolve();
+    },
+  });
+
+  assert.deepEqual(calls, [
+    { command: "taskkill.exe", args: ["/PID", "4321", "/T", "/F"] },
+  ]);
+  assert.equal(proc.killCalled, false);
+});
+
+test("terminateChildProcess falls back to proc.kill on Windows when taskkill fails", async () => {
+  const proc = {
+    pid: 4321,
+    killCalled: false,
+    kill() {
+      this.killCalled = true;
+      return true;
+    },
+  } as unknown as ChildProcess & { killCalled: boolean };
+
+  await terminateChildProcess(proc, {
+    platform: "win32",
+    taskkill() {
+      return Promise.reject(new Error("taskkill failed"));
+    },
+  });
+
+  assert.equal(proc.killCalled, true);
+});
+
+test("terminateChildProcess uses proc.kill on non-Windows", async () => {
+  const proc = {
+    pid: 123,
+    killCalled: false,
+    kill() {
+      this.killCalled = true;
+      return true;
+    },
+  } as unknown as ChildProcess & { killCalled: boolean };
+
+  await terminateChildProcess(proc, {
+    platform: "linux",
+  });
+
+  assert.equal(proc.killCalled, true);
+});
+
+test("terminateChildProcess handles missing pid on Windows without throwing", async () => {
+  const proc = {
+    pid: undefined,
+    killCalled: false,
+    kill() {
+      this.killCalled = true;
+      return true;
+    },
+  } as unknown as ChildProcess & { killCalled: boolean };
+
+  await terminateChildProcess(proc, {
+    platform: "win32",
+    taskkill() {
+      throw new Error("should not be called");
+    },
+  });
+
+  assert.equal(proc.killCalled, true);
+});

--- a/src/lib/agents/process-utils.test.ts
+++ b/src/lib/agents/process-utils.test.ts
@@ -3,16 +3,20 @@ import assert from "node:assert/strict";
 import type { ChildProcess } from "node:child_process";
 import { terminateChildProcess } from "./process-utils";
 
-test("terminateChildProcess uses taskkill on Windows when pid exists", async () => {
+function makeMockProc(pid?: number): ChildProcess & { killCalled: boolean } {
   const proc = {
-    pid: 4321,
-    killCalled: false,
+    pid,
+    killCalled: false as boolean,
     kill() {
-      this.killCalled = true;
+      proc.killCalled = true;
       return true;
     },
-  } as unknown as ChildProcess & { killCalled: boolean };
+  };
+  return proc as unknown as ChildProcess & { killCalled: boolean };
+}
 
+test("terminateChildProcess uses taskkill on Windows when pid exists", async () => {
+  const proc = makeMockProc(4321);
   const calls: Array<{ command: string; args: string[] }> = [];
   await terminateChildProcess(proc, {
     platform: "win32",
@@ -29,15 +33,7 @@ test("terminateChildProcess uses taskkill on Windows when pid exists", async () 
 });
 
 test("terminateChildProcess falls back to proc.kill on Windows when taskkill fails", async () => {
-  const proc = {
-    pid: 4321,
-    killCalled: false,
-    kill() {
-      this.killCalled = true;
-      return true;
-    },
-  } as unknown as ChildProcess & { killCalled: boolean };
-
+  const proc = makeMockProc(4321);
   await terminateChildProcess(proc, {
     platform: "win32",
     taskkill() {
@@ -49,15 +45,7 @@ test("terminateChildProcess falls back to proc.kill on Windows when taskkill fai
 });
 
 test("terminateChildProcess uses proc.kill on non-Windows", async () => {
-  const proc = {
-    pid: 123,
-    killCalled: false,
-    kill() {
-      this.killCalled = true;
-      return true;
-    },
-  } as unknown as ChildProcess & { killCalled: boolean };
-
+  const proc = makeMockProc(123);
   await terminateChildProcess(proc, {
     platform: "linux",
   });
@@ -66,15 +54,7 @@ test("terminateChildProcess uses proc.kill on non-Windows", async () => {
 });
 
 test("terminateChildProcess handles missing pid on Windows without throwing", async () => {
-  const proc = {
-    pid: undefined,
-    killCalled: false,
-    kill() {
-      this.killCalled = true;
-      return true;
-    },
-  } as unknown as ChildProcess & { killCalled: boolean };
-
+  const proc = makeMockProc(undefined);
   await terminateChildProcess(proc, {
     platform: "win32",
     taskkill() {

--- a/src/lib/agents/process-utils.ts
+++ b/src/lib/agents/process-utils.ts
@@ -1,0 +1,49 @@
+import { execFile } from "child_process";
+import type { ChildProcess } from "child_process";
+
+type TerminateChildProcessOptions = {
+  platform?: NodeJS.Platform;
+  taskkill?: (command: string, args: string[]) => Promise<void>;
+};
+
+function killDirectly(proc: ChildProcess): void {
+  try {
+    proc.kill();
+  } catch {}
+}
+
+async function defaultTaskkill(command: string, args: string[]): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    execFile(command, args, { stdio: "ignore" }, (error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+export async function terminateChildProcess(
+  proc: ChildProcess,
+  options?: TerminateChildProcessOptions
+): Promise<void> {
+  const platform = options?.platform || process.platform;
+
+  if (platform !== "win32") {
+    killDirectly(proc);
+    return;
+  }
+
+  if (!proc.pid) {
+    killDirectly(proc);
+    return;
+  }
+
+  try {
+    const taskkill = options?.taskkill || defaultTaskkill;
+    await taskkill("taskkill.exe", ["/PID", String(proc.pid), "/T", "/F"]);
+  } catch {
+    killDirectly(proc);
+  }
+}

--- a/src/lib/agents/process-utils.ts
+++ b/src/lib/agents/process-utils.ts
@@ -14,7 +14,7 @@ function killDirectly(proc: ChildProcess): void {
 
 async function defaultTaskkill(command: string, args: string[]): Promise<void> {
   await new Promise<void>((resolve, reject) => {
-    execFile(command, args, { stdio: "ignore" }, (error) => {
+    execFile(command, args, (error: Error | null) => {
       if (error) {
         reject(error);
         return;

--- a/src/lib/agents/provider-cli.test.ts
+++ b/src/lib/agents/provider-cli.test.ts
@@ -4,13 +4,24 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { AgentProvider } from "./provider-interface";
-import { checkCliProviderAvailable, resolveCliCommand } from "./provider-cli";
+import {
+  buildRuntimePath,
+  checkCliProviderAvailable,
+  resolveCliCommand,
+} from "./provider-cli";
 
 async function createExecutableScript(source: string): Promise<string> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "cabinet-provider-cli-test-"));
-  const scriptPath = path.join(dir, "fake-provider.sh");
-  await fs.writeFile(scriptPath, source, "utf8");
-  await fs.chmod(scriptPath, 0o755);
+  const scriptPath = path.join(
+    dir,
+    process.platform === "win32" ? "fake-provider.cmd" : "fake-provider.sh"
+  );
+  const scriptSource =
+    process.platform === "win32" ? "@echo off\r\nexit /b 0\r\n" : source;
+  await fs.writeFile(scriptPath, scriptSource, "utf8");
+  if (process.platform !== "win32") {
+    await fs.chmod(scriptPath, 0o755);
+  }
   return scriptPath;
 }
 
@@ -60,4 +71,61 @@ test("checkCliProviderAvailable uses resolved command candidates", async () => {
   };
 
   assert.equal(await checkCliProviderAvailable(provider), true);
+});
+
+test("buildRuntimePath uses Windows delimiters and npm global bin paths", () => {
+  const runtimePath = buildRuntimePath({
+    platform: "win32",
+    env: {
+      USERPROFILE: "C:\\Users\\TestUser",
+      APPDATA: "C:\\Users\\TestUser\\AppData\\Roaming",
+      PATH: "C:\\Windows\\System32",
+    },
+    nvmBin: null,
+  });
+
+  assert.equal(
+    runtimePath,
+    [
+      "C:\\Users\\TestUser\\AppData\\Roaming\\npm",
+      "C:\\Users\\TestUser\\.local\\bin",
+      "C:\\Windows\\System32",
+    ].join(";")
+  );
+});
+
+test("resolveCliCommand prefers a bare Windows command when it is on PATH", () => {
+  const provider: AgentProvider = {
+    id: "windows-provider",
+    name: "Windows Provider",
+    type: "cli",
+    icon: "bot",
+    command: "codex",
+    commandCandidates: ["codex"],
+    async isAvailable() {
+      return true;
+    },
+    async healthCheck() {
+      return {
+        available: true,
+        authenticated: true,
+        version: "test",
+      };
+    },
+  };
+
+  const resolved = resolveCliCommand(provider, {
+    platform: "win32",
+    env: {
+      USERPROFILE: "C:\\Users\\TestUser",
+      APPDATA: "C:\\Users\\TestUser\\AppData\\Roaming",
+      PATH: "C:\\Windows\\System32",
+    },
+    commandLookup(command) {
+      assert.equal(command, "codex");
+      return "C:\\Users\\TestUser\\AppData\\Roaming\\npm\\codex.cmd";
+    },
+  });
+
+  assert.equal(resolved, "codex");
 });

--- a/src/lib/agents/provider-cli.test.ts
+++ b/src/lib/agents/provider-cli.test.ts
@@ -129,3 +129,40 @@ test("resolveCliCommand prefers a bare Windows command when it is on PATH", () =
 
   assert.equal(resolved, "codex");
 });
+
+test("resolveCliCommand skips unsafe non-path command candidates during lookup", () => {
+  const provider: AgentProvider = {
+    id: "unsafe-provider",
+    name: "Unsafe Provider",
+    type: "cli",
+    icon: "bot",
+    command: "safe-provider",
+    commandCandidates: ["bad;command", "safe-provider"],
+    async isAvailable() {
+      return true;
+    },
+    async healthCheck() {
+      return {
+        available: true,
+        authenticated: true,
+        version: "test",
+      };
+    },
+  };
+
+  const lookupCalls: string[] = [];
+  const resolved = resolveCliCommand(provider, {
+    platform: "linux",
+    env: {
+      HOME: "/tmp/test-user",
+      PATH: "/usr/bin",
+    },
+    commandLookup(command) {
+      lookupCalls.push(command);
+      return command === "safe-provider" ? "/usr/bin/safe-provider" : null;
+    },
+  });
+
+  assert.equal(resolved, "/usr/bin/safe-provider");
+  assert.deepEqual(lookupCalls, ["safe-provider"]);
+});

--- a/src/lib/agents/provider-cli.test.ts
+++ b/src/lib/agents/provider-cli.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import type { AgentProvider } from "./provider-interface";
 import {
+  buildCommandCandidates,
   buildRuntimePath,
   checkCliProviderAvailable,
   resolveCliCommand,
@@ -92,6 +93,69 @@ test("buildRuntimePath uses Windows delimiters and npm global bin paths", () => 
       "C:\\Windows\\System32",
     ].join(";")
   );
+});
+
+test("buildRuntimePath uses requested platform path semantics even on a different host OS", () => {
+  const runtimePath = buildRuntimePath({
+    platform: "win32",
+    env: {
+      USERPROFILE: "C:/Users/TestUser",
+      APPDATA: "C:/Users/TestUser/AppData/Roaming",
+      PATH: "C:/Windows/System32",
+    },
+    nvmBin: "C:/Users/TestUser/.nvm/bin",
+  });
+
+  assert.equal(
+    runtimePath,
+    [
+      "C:\\Users\\TestUser\\AppData\\Roaming\\npm",
+      "C:\\Users\\TestUser\\.local\\bin",
+      "C:\\Users\\TestUser\\.nvm\\bin",
+      "C:/Windows/System32",
+    ].join(";")
+  );
+});
+
+test("buildRuntimePath uses POSIX separators when a POSIX platform is requested", () => {
+  const runtimePath = buildRuntimePath({
+    platform: "linux",
+    env: {
+      HOME: "/home/test-user",
+      PATH: "/usr/bin",
+    },
+    nvmBin: "/home/test-user/.nvm/versions/node/v22/bin",
+  });
+
+  assert.equal(
+    runtimePath,
+    [
+      "/home/test-user/.local/bin",
+      "/usr/local/bin",
+      "/opt/homebrew/bin",
+      "/home/test-user/.nvm/versions/node/v22/bin",
+      "/usr/bin",
+    ].join(":")
+  );
+});
+
+test("buildCommandCandidates only returns Windows cmd paths plus bare command", () => {
+  const candidates = buildCommandCandidates("codex", {
+    platform: "win32",
+    env: {
+      USERPROFILE: "C:/Users/TestUser",
+      APPDATA: "C:/Users/TestUser/AppData/Roaming",
+      PATH: "C:/Windows/System32",
+    },
+    nvmBin: "C:/Users/TestUser/.nvm/bin",
+  });
+
+  assert.deepEqual(candidates, [
+    "C:\\Users\\TestUser\\AppData\\Roaming\\npm\\codex.cmd",
+    "C:\\Users\\TestUser\\.local\\bin\\codex.cmd",
+    "C:\\Users\\TestUser\\.nvm\\bin\\codex.cmd",
+    "codex",
+  ]);
 });
 
 test("resolveCliCommand prefers a bare Windows command when it is on PATH", () => {

--- a/src/lib/agents/provider-cli.test.ts
+++ b/src/lib/agents/provider-cli.test.ts
@@ -1,4 +1,4 @@
-import test from "node:test";
+import test, { type TestContext } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -11,8 +11,9 @@ import {
   resolveCliCommand,
 } from "./provider-cli";
 
-async function createExecutableScript(source: string): Promise<string> {
+async function createExecutableScript(t: TestContext, source: string): Promise<string> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "cabinet-provider-cli-test-"));
+  t.after(() => fs.rm(dir, { recursive: true, force: true }));
   const scriptPath = path.join(
     dir,
     process.platform === "win32" ? "fake-provider.cmd" : "fake-provider.sh"
@@ -26,8 +27,8 @@ async function createExecutableScript(source: string): Promise<string> {
   return scriptPath;
 }
 
-test("resolveCliCommand prefers an existing command candidate path", async () => {
-  const scriptPath = await createExecutableScript("#!/bin/sh\nexit 0\n");
+test("resolveCliCommand prefers an existing command candidate path", async (t) => {
+  const scriptPath = await createExecutableScript(t, "#!/bin/sh\nexit 0\n");
   const provider: AgentProvider = {
     id: "test-cli-provider",
     name: "Test CLI Provider",
@@ -50,8 +51,8 @@ test("resolveCliCommand prefers an existing command candidate path", async () =>
   assert.equal(resolveCliCommand(provider), scriptPath);
 });
 
-test("checkCliProviderAvailable uses resolved command candidates", async () => {
-  const scriptPath = await createExecutableScript("#!/bin/sh\nexit 0\n");
+test("checkCliProviderAvailable uses resolved command candidates", async (t) => {
+  const scriptPath = await createExecutableScript(t, "#!/bin/sh\nexit 0\n");
   const provider: AgentProvider = {
     id: "test-cli-provider",
     name: "Test CLI Provider",

--- a/src/lib/agents/provider-cli.test.ts
+++ b/src/lib/agents/provider-cli.test.ts
@@ -81,7 +81,7 @@ test("buildRuntimePath uses Windows delimiters and npm global bin paths", () => 
       USERPROFILE: "C:\\Users\\TestUser",
       APPDATA: "C:\\Users\\TestUser\\AppData\\Roaming",
       PATH: "C:\\Windows\\System32",
-    },
+    } as unknown as NodeJS.ProcessEnv,
     nvmBin: null,
   });
 
@@ -102,7 +102,7 @@ test("buildRuntimePath uses requested platform path semantics even on a differen
       USERPROFILE: "C:/Users/TestUser",
       APPDATA: "C:/Users/TestUser/AppData/Roaming",
       PATH: "C:/Windows/System32",
-    },
+    } as unknown as NodeJS.ProcessEnv,
     nvmBin: "C:/Users/TestUser/.nvm/bin",
   });
 
@@ -123,7 +123,7 @@ test("buildRuntimePath uses POSIX separators when a POSIX platform is requested"
     env: {
       HOME: "/home/test-user",
       PATH: "/usr/bin",
-    },
+    } as unknown as NodeJS.ProcessEnv,
     nvmBin: "/home/test-user/.nvm/versions/node/v22/bin",
   });
 
@@ -146,7 +146,7 @@ test("buildCommandCandidates only returns Windows cmd paths plus bare command", 
       USERPROFILE: "C:/Users/TestUser",
       APPDATA: "C:/Users/TestUser/AppData/Roaming",
       PATH: "C:/Windows/System32",
-    },
+    } as unknown as NodeJS.ProcessEnv,
     nvmBin: "C:/Users/TestUser/.nvm/bin",
   });
 
@@ -184,8 +184,8 @@ test("resolveCliCommand prefers a bare Windows command when it is on PATH", () =
       USERPROFILE: "C:\\Users\\TestUser",
       APPDATA: "C:\\Users\\TestUser\\AppData\\Roaming",
       PATH: "C:\\Windows\\System32",
-    },
-    commandLookup(command) {
+    } as unknown as NodeJS.ProcessEnv,
+    commandLookup(command: string) {
       assert.equal(command, "codex");
       return "C:\\Users\\TestUser\\AppData\\Roaming\\npm\\codex.cmd";
     },
@@ -220,8 +220,8 @@ test("resolveCliCommand skips unsafe non-path command candidates during lookup",
     env: {
       HOME: "/tmp/test-user",
       PATH: "/usr/bin",
-    },
-    commandLookup(command) {
+    } as unknown as NodeJS.ProcessEnv,
+    commandLookup(command: string) {
       lookupCalls.push(command);
       return command === "safe-provider" ? "/usr/bin/safe-provider" : null;
     },

--- a/src/lib/agents/provider-cli.ts
+++ b/src/lib/agents/provider-cli.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
-import { spawn } from "child_process";
+import path from "path";
+import { execFileSync, spawn } from "child_process";
 import type { AgentProvider } from "./provider-interface";
 import {
   ADAPTER_RUNTIME_PATH,
@@ -8,6 +9,105 @@ import {
 } from "./adapters/utils";
 
 export const RUNTIME_PATH = ADAPTER_RUNTIME_PATH;
+
+export type CliInvocation = {
+  command: string;
+  args: string[];
+};
+
+function resolveHomeDir(env: NodeJS.ProcessEnv): string {
+  return env.USERPROFILE || env.HOME || process.cwd();
+}
+
+function quoteWindowsCmdArg(value: string): string {
+  const escaped = value.replace(/"/g, '""').replace(/%/g, "%%");
+  return /[\s"&()^|<>]/.test(value) ? `"${escaped}"` : escaped;
+}
+
+export function buildWindowsShellCommand(command: string, args: string[]): string {
+  return [command, ...args].map(quoteWindowsCmdArg).join(" ");
+}
+
+export function buildPtyCliInvocation(
+  command: string,
+  args: string[],
+  options?: {
+    platform?: NodeJS.Platform;
+    env?: NodeJS.ProcessEnv;
+  }
+): CliInvocation {
+  const platform = options?.platform || process.platform;
+  const env = options?.env || process.env;
+
+  if (platform !== "win32") {
+    return { command, args };
+  }
+
+  return {
+    command: env.ComSpec || "cmd.exe",
+    args: ["/d", "/s", "/c", [command, ...args].map(quoteWindowsCmdArg).join(" ")],
+  };
+}
+
+export function buildCommandCandidates(
+  command: string,
+  options?: {
+    platform?: NodeJS.Platform;
+    env?: NodeJS.ProcessEnv;
+    nvmBin?: string | null;
+  }
+): string[] {
+  const platform = options?.platform || process.platform;
+  const env = options?.env || process.env;
+  const runtimeNvmBin = options?.nvmBin ?? null;
+
+  if (platform === "win32") {
+    const homeDir = resolveHomeDir(env);
+    return [
+      env.APPDATA ? path.join(env.APPDATA, "npm", `${command}.cmd`) : "",
+      env.APPDATA ? path.join(env.APPDATA, "npm", `${command}.ps1`) : "",
+      env.APPDATA ? path.join(env.APPDATA, "npm", command) : "",
+      path.join(homeDir, ".local", "bin", `${command}.cmd`),
+      path.join(homeDir, ".local", "bin", command),
+      ...(runtimeNvmBin ? [path.join(runtimeNvmBin, `${command}.cmd`), path.join(runtimeNvmBin, command)] : []),
+      command,
+    ].filter(Boolean);
+  }
+
+  return [
+    `${env.HOME || ""}/.local/bin/${command}`,
+    `/usr/local/bin/${command}`,
+    `/opt/homebrew/bin/${command}`,
+    ...(runtimeNvmBin ? [path.join(runtimeNvmBin, command)] : []),
+    command,
+  ].filter(Boolean);
+}
+
+function lookupCommandOnPath(
+  command: string,
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform
+): string | null {
+  try {
+    if (platform === "win32") {
+      const output = execFileSync("where.exe", [command], {
+        encoding: "utf8",
+        env,
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+      return output.split(/\r?\n/).find(Boolean) || null;
+    }
+
+    const output = execFileSync("/bin/sh", ["-lc", `command -v ${command}`], {
+      encoding: "utf8",
+      env,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return output || null;
+  } catch {
+    return null;
+  }
+}
 
 export function resolveCliCommand(provider: AgentProvider): string {
   const candidates = [
@@ -20,6 +120,15 @@ export function resolveCliCommand(provider: AgentProvider): string {
 
   for (const candidate of candidates) {
     if (candidate.includes("/") && fs.existsSync(candidate)) return candidate;
+  }
+
+  if (process.platform === "win32") {
+    const runtimePath = ADAPTER_RUNTIME_PATH;
+    for (const candidate of candidates) {
+      if (candidate.includes("/") || candidate.includes("\\") || /^[A-Za-z]:/.test(candidate)) continue;
+      const found = lookupCommandOnPath(candidate, { ...process.env, PATH: runtimePath }, "win32");
+      if (found) return found;
+    }
   }
 
   if (!provider.command) {
@@ -39,10 +148,17 @@ export async function checkCliProviderAvailable(provider: AgentProvider): Promis
       return;
     }
 
-    const proc = spawn(command, ["--version"], {
-      env: withAdapterRuntimeEnv(process.env),
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    const proc =
+      process.platform === "win32"
+        ? spawn(buildWindowsShellCommand(command, ["--version"]), {
+            env: withAdapterRuntimeEnv(process.env),
+            shell: true,
+            stdio: ["ignore", "pipe", "pipe"],
+          })
+        : spawn(command, ["--version"], {
+            env: withAdapterRuntimeEnv(process.env),
+            stdio: ["ignore", "pipe", "pipe"],
+          });
 
     const settle = (value: boolean) => {
       clearTimeout(timeout);

--- a/src/lib/agents/provider-cli.ts
+++ b/src/lib/agents/provider-cli.ts
@@ -9,6 +9,12 @@ import {
 } from "./adapters/utils";
 import { terminateChildProcess } from "./process-utils";
 
+type ResolveCliCommandOptions = {
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  commandLookup?: (command: string, env: NodeJS.ProcessEnv, platform: NodeJS.Platform) => string | null;
+};
+
 export const RUNTIME_PATH = ADAPTER_RUNTIME_PATH;
 
 export type CliInvocation = {
@@ -33,6 +39,35 @@ function getPlatformPathTools(platform: NodeJS.Platform) {
     api: platform === "win32" ? path.win32 : path.posix,
     delimiter: platform === "win32" ? ";" : ":",
   };
+}
+
+export function buildRuntimePath(options?: {
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  nvmBin?: string | null;
+}): string {
+  const platform = options?.platform || process.platform;
+  const env = options?.env || process.env;
+  const runtimeNvmBin = options?.nvmBin === undefined ? null : options.nvmBin;
+  const { api: pathApi, delimiter } = getPlatformPathTools(platform);
+
+  if (platform === "win32") {
+    const homeDir = resolveHomeDir(env);
+    return [
+      env.APPDATA ? pathApi.join(env.APPDATA, "npm") : "",
+      pathApi.join(homeDir, ".local", "bin"),
+      ...(runtimeNvmBin ? [pathApi.normalize(runtimeNvmBin)] : []),
+      env.PATH || "",
+    ].filter(Boolean).join(delimiter);
+  }
+
+  return [
+    `${env.HOME || ""}/.local/bin`,
+    "/usr/local/bin",
+    "/opt/homebrew/bin",
+    ...(runtimeNvmBin ? [pathApi.normalize(runtimeNvmBin)] : []),
+    env.PATH || "",
+  ].filter(Boolean).join(delimiter);
 }
 
 function quoteWindowsCmdArg(value: string): string {
@@ -82,11 +117,8 @@ export function buildCommandCandidates(
     const homeDir = resolveHomeDir(env);
     return [
       env.APPDATA ? pathApi.join(env.APPDATA, "npm", `${command}.cmd`) : "",
-      env.APPDATA ? pathApi.join(env.APPDATA, "npm", `${command}.ps1`) : "",
-      env.APPDATA ? pathApi.join(env.APPDATA, "npm", command) : "",
       pathApi.join(homeDir, ".local", "bin", `${command}.cmd`),
-      pathApi.join(homeDir, ".local", "bin", command),
-      ...(runtimeNvmBin ? [pathApi.join(runtimeNvmBin, `${command}.cmd`), pathApi.join(runtimeNvmBin, command)] : []),
+      ...(runtimeNvmBin ? [pathApi.join(runtimeNvmBin, `${command}.cmd`)] : []),
       command,
     ].filter(Boolean);
   }
@@ -127,24 +159,33 @@ function lookupCommandOnPath(
   }
 }
 
-export function resolveCliCommand(provider: AgentProvider): string {
+export function resolveCliCommand(provider: AgentProvider, options?: ResolveCliCommandOptions): string {
+  const platform = options?.platform || process.platform;
+  const env = options?.env || process.env;
+  const commandLookup = options?.commandLookup || lookupCommandOnPath;
+
   const candidates = [
     ...(provider.commandCandidates || []),
     provider.command,
   ].filter((candidate): candidate is string => !!candidate);
 
-  const resolved = resolveCommandFromCandidates(candidates, process.env);
-  if (resolved) return resolved;
+  if (!options) {
+    const resolved = resolveCommandFromCandidates(candidates, env);
+    if (resolved) return resolved;
+  }
 
   for (const candidate of candidates) {
     if (isExplicitPath(candidate) && fs.existsSync(candidate)) return candidate;
   }
 
-  if (process.platform === "win32") {
-    for (const candidate of candidates) {
-      if (isExplicitPath(candidate)) continue;
-      const found = lookupCommandOnPath(candidate, { ...process.env, PATH: ADAPTER_RUNTIME_PATH }, "win32");
-      if (found) return found;
+  for (const candidate of candidates) {
+    if (isExplicitPath(candidate)) continue;
+    if (!isSafeCommandName(candidate)) continue;
+    const found = commandLookup(candidate, { ...env, PATH: ADAPTER_RUNTIME_PATH }, platform);
+    if (found) {
+      // On Windows, return the bare candidate name so cmd.exe can resolve .cmd/.ps1 shims.
+      // On Unix, return the full resolved path.
+      return platform === "win32" ? candidate : found;
     }
   }
 

--- a/src/lib/agents/provider-cli.ts
+++ b/src/lib/agents/provider-cli.ts
@@ -20,6 +20,21 @@ function resolveHomeDir(env: NodeJS.ProcessEnv): string {
   return env.USERPROFILE || env.HOME || process.cwd();
 }
 
+function isExplicitPath(candidate: string): boolean {
+  return candidate.includes("/") || candidate.includes("\\") || /^[A-Za-z]:/.test(candidate);
+}
+
+function isSafeCommandName(candidate: string): boolean {
+  return /^[A-Za-z0-9._/-]+$/.test(candidate);
+}
+
+function getPlatformPathTools(platform: NodeJS.Platform) {
+  return {
+    api: platform === "win32" ? path.win32 : path.posix,
+    delimiter: platform === "win32" ? ";" : ":",
+  };
+}
+
 function quoteWindowsCmdArg(value: string): string {
   const escaped = value.replace(/"/g, '""').replace(/%/g, "%%");
   return /[\s"&()^|<>]/.test(value) ? `"${escaped}"` : escaped;
@@ -61,16 +76,17 @@ export function buildCommandCandidates(
   const platform = options?.platform || process.platform;
   const env = options?.env || process.env;
   const runtimeNvmBin = options?.nvmBin ?? null;
+  const { api: pathApi } = getPlatformPathTools(platform);
 
   if (platform === "win32") {
     const homeDir = resolveHomeDir(env);
     return [
-      env.APPDATA ? path.join(env.APPDATA, "npm", `${command}.cmd`) : "",
-      env.APPDATA ? path.join(env.APPDATA, "npm", `${command}.ps1`) : "",
-      env.APPDATA ? path.join(env.APPDATA, "npm", command) : "",
-      path.join(homeDir, ".local", "bin", `${command}.cmd`),
-      path.join(homeDir, ".local", "bin", command),
-      ...(runtimeNvmBin ? [path.join(runtimeNvmBin, `${command}.cmd`), path.join(runtimeNvmBin, command)] : []),
+      env.APPDATA ? pathApi.join(env.APPDATA, "npm", `${command}.cmd`) : "",
+      env.APPDATA ? pathApi.join(env.APPDATA, "npm", `${command}.ps1`) : "",
+      env.APPDATA ? pathApi.join(env.APPDATA, "npm", command) : "",
+      pathApi.join(homeDir, ".local", "bin", `${command}.cmd`),
+      pathApi.join(homeDir, ".local", "bin", command),
+      ...(runtimeNvmBin ? [pathApi.join(runtimeNvmBin, `${command}.cmd`), pathApi.join(runtimeNvmBin, command)] : []),
       command,
     ].filter(Boolean);
   }
@@ -79,7 +95,7 @@ export function buildCommandCandidates(
     `${env.HOME || ""}/.local/bin/${command}`,
     `/usr/local/bin/${command}`,
     `/opt/homebrew/bin/${command}`,
-    ...(runtimeNvmBin ? [path.join(runtimeNvmBin, command)] : []),
+    ...(runtimeNvmBin ? [pathApi.join(runtimeNvmBin, command)] : []),
     command,
   ].filter(Boolean);
 }
@@ -89,6 +105,7 @@ function lookupCommandOnPath(
   env: NodeJS.ProcessEnv,
   platform: NodeJS.Platform
 ): string | null {
+  if (!isSafeCommandName(command)) return null;
   try {
     if (platform === "win32") {
       const output = execFileSync("where.exe", [command], {
@@ -120,14 +137,13 @@ export function resolveCliCommand(provider: AgentProvider): string {
   if (resolved) return resolved;
 
   for (const candidate of candidates) {
-    if (candidate.includes("/") && fs.existsSync(candidate)) return candidate;
+    if (isExplicitPath(candidate) && fs.existsSync(candidate)) return candidate;
   }
 
   if (process.platform === "win32") {
-    const runtimePath = ADAPTER_RUNTIME_PATH;
     for (const candidate of candidates) {
-      if (candidate.includes("/") || candidate.includes("\\") || /^[A-Za-z]:/.test(candidate)) continue;
-      const found = lookupCommandOnPath(candidate, { ...process.env, PATH: runtimePath }, "win32");
+      if (isExplicitPath(candidate)) continue;
+      const found = lookupCommandOnPath(candidate, { ...process.env, PATH: ADAPTER_RUNTIME_PATH }, "win32");
       if (found) return found;
     }
   }

--- a/src/lib/agents/provider-cli.ts
+++ b/src/lib/agents/provider-cli.ts
@@ -7,6 +7,7 @@ import {
   resolveCommandFromCandidates,
   withAdapterRuntimeEnv,
 } from "./adapters/utils";
+import { terminateChildProcess } from "./process-utils";
 
 export const RUNTIME_PATH = ADAPTER_RUNTIME_PATH;
 
@@ -174,8 +175,9 @@ export async function checkCliProviderAvailable(provider: AgentProvider): Promis
     });
 
     const timeout = setTimeout(() => {
-      proc.kill();
-      settle(false);
+      void terminateChildProcess(proc).finally(() => {
+        settle(false);
+      });
     }, 5000);
   });
 }

--- a/src/lib/agents/provider-runtime.test.ts
+++ b/src/lib/agents/provider-runtime.test.ts
@@ -15,11 +15,20 @@ import {
 import { claudeCodeProvider } from "./providers/claude-code";
 import { codexCliProvider } from "./providers/codex-cli";
 
-async function createExecutableScript(source: string): Promise<string> {
+async function createExecutableScript(source: string, windowsSource?: string): Promise<string> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "cabinet-provider-test-"));
-  const scriptPath = path.join(dir, "fake-provider.sh");
-  await fs.writeFile(scriptPath, source, "utf8");
-  await fs.chmod(scriptPath, 0o755);
+  const scriptPath = path.join(
+    dir,
+    process.platform === "win32" ? "fake-provider.cmd" : "fake-provider.sh"
+  );
+  await fs.writeFile(
+    scriptPath,
+    process.platform === "win32" ? (windowsSource || "@echo off\r\nexit /b 0\r\n") : source,
+    "utf8"
+  );
+  if (process.platform !== "win32") {
+    await fs.chmod(scriptPath, 0o755);
+  }
   return scriptPath;
 }
 
@@ -77,7 +86,10 @@ test("provider runtime resolves launch specs through registered providers", asyn
     path.join(process.cwd(), "data", ".agents", ".config", "providers.json"),
     "utf8"
   ).catch(() => null);
-  const scriptPath = await createExecutableScript("#!/bin/sh\nprintf '%s' \"$1\"\n");
+  const scriptPath = await createExecutableScript(
+    "#!/bin/sh\nprintf '%s' \"$1\"\n",
+    "@echo off\r\n<nul set /p =%~1\r\nexit /b 0\r\n"
+  );
   const provider: AgentProvider = {
     id: "test-session-provider",
     name: "Test Session Provider",
@@ -169,7 +181,8 @@ test("provider runtime falls back to the enabled default when the requested prov
 test("runOneShotProviderPrompt closes stdin for CLI providers", async (t) => {
   const previousDefaultProvider = providerRegistry.defaultProvider;
   const scriptPath = await createExecutableScript(
-    "#!/bin/sh\ncat >/dev/null\nprintf '%s' \"$1\"\n"
+    "#!/bin/sh\ncat >/dev/null\nprintf '%s' \"$1\"\n",
+    "@echo off\r\n<nul set /p =%~1\r\nexit /b 0\r\n"
   );
   const provider: AgentProvider = {
     id: "test-run-provider",

--- a/src/lib/agents/provider-runtime.ts
+++ b/src/lib/agents/provider-runtime.ts
@@ -11,6 +11,7 @@ import {
   readProviderSettingsSync,
   resolveEnabledProviderId,
 } from "./provider-settings";
+import { terminateChildProcess } from "./process-utils";
 
 export interface ProviderLaunchSpec extends CliProviderInvocation {
   providerId: string;
@@ -156,8 +157,9 @@ export async function runOneShotProviderPrompt(input: {
     const timeoutHandle = setTimeout(() => {
       if (settled) return;
       settled = true;
-      proc.kill();
-      reject(new Error("Timed out after waiting for provider output"));
+      void terminateChildProcess(proc).finally(() => {
+        reject(new Error("Timed out after waiting for provider output"));
+      });
     }, input.timeoutMs || 120_000);
 
     let stdout = "";

--- a/src/lib/agents/provider-runtime.ts
+++ b/src/lib/agents/provider-runtime.ts
@@ -1,7 +1,7 @@
 import { spawn } from "child_process";
 import type { AgentProvider, CliProviderInvocation } from "./provider-interface";
 import { providerRegistry } from "./provider-registry";
-import { resolveCliCommand, RUNTIME_PATH } from "./provider-cli";
+import { buildWindowsShellCommand, resolveCliCommand, RUNTIME_PATH } from "./provider-cli";
 import {
   resolveDetachedPromptLaunchMode,
   type DetachedLaunchMode,
@@ -135,14 +135,23 @@ export async function runOneShotProviderPrompt(input: {
   });
 
   return new Promise<string>((resolve, reject) => {
-    const proc = spawn(launch.command, launch.args, {
-      cwd: input.cwd,
-      env: {
-        ...process.env,
-        PATH: RUNTIME_PATH,
-      },
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    const env = {
+      ...process.env,
+      PATH: RUNTIME_PATH,
+    };
+    const proc =
+      process.platform === "win32"
+        ? spawn(buildWindowsShellCommand(launch.command, launch.args), {
+            cwd: input.cwd,
+            env,
+            shell: true,
+            stdio: ["ignore", "pipe", "pipe"],
+          })
+        : spawn(launch.command, launch.args, {
+            cwd: input.cwd,
+            env,
+            stdio: ["ignore", "pipe", "pipe"],
+          });
     let settled = false;
     const timeoutHandle = setTimeout(() => {
       if (settled) return;

--- a/src/lib/agents/providers/claude-code.ts
+++ b/src/lib/agents/providers/claude-code.ts
@@ -1,6 +1,11 @@
 import { execSync } from "child_process";
 import type { AgentProvider, ProviderStatus } from "../provider-interface";
-import { checkCliProviderAvailable, resolveCliCommand, RUNTIME_PATH } from "../provider-cli";
+import {
+  buildCommandCandidates,
+  checkCliProviderAvailable,
+  resolveCliCommand,
+  RUNTIME_PATH,
+} from "../provider-cli";
 import { getNvmNodeBin } from "../nvm-path";
 
 const CLAUDE_THINKING_LEVELS = [
@@ -12,7 +17,7 @@ const CLAUDE_THINKING_LEVELS = [
 
 const nvmClaudePath = (() => {
   const bin = getNvmNodeBin();
-  return bin ? `${bin}/claude` : null;
+  return bin || null;
 })();
 
 export const claudeCodeProvider: AgentProvider = {
@@ -50,13 +55,7 @@ export const claudeCodeProvider: AgentProvider = {
   detachedPromptLaunchMode: "session",
   effortLevels: [...CLAUDE_THINKING_LEVELS],
   command: "claude",
-  commandCandidates: [
-    `${process.env.HOME || ""}/.local/bin/claude`,
-    "/usr/local/bin/claude",
-    "/opt/homebrew/bin/claude",
-    ...(nvmClaudePath ? [nvmClaudePath] : []),
-    "claude",
-  ],
+  commandCandidates: buildCommandCandidates("claude", { nvmBin: nvmClaudePath }),
 
   buildArgs(prompt: string, _workdir: string): string[] {
     return ["--dangerously-skip-permissions", "-p", prompt, "--output-format", "text"];

--- a/src/lib/agents/providers/codex-cli.ts
+++ b/src/lib/agents/providers/codex-cli.ts
@@ -1,6 +1,11 @@
 import { execSync } from "child_process";
 import type { AgentProvider, ProviderStatus } from "../provider-interface";
-import { checkCliProviderAvailable, resolveCliCommand, RUNTIME_PATH } from "../provider-cli";
+import {
+  buildCommandCandidates,
+  checkCliProviderAvailable,
+  resolveCliCommand,
+  RUNTIME_PATH,
+} from "../provider-cli";
 
 const CODEX_REASONING_LEVELS = [
   { id: "low", name: "Low", description: "Faster, lighter reasoning" },
@@ -96,12 +101,7 @@ export const codexCliProvider: AgentProvider = {
     },
   ],
   command: "codex",
-  commandCandidates: [
-    `${process.env.HOME || ""}/.local/bin/codex`,
-    "/usr/local/bin/codex",
-    "/opt/homebrew/bin/codex",
-    "codex",
-  ],
+  commandCandidates: buildCommandCandidates("codex"),
 
   buildArgs(prompt: string, _workdir: string): string[] {
     return [

--- a/src/lib/system/install-metadata.ts
+++ b/src/lib/system/install-metadata.ts
@@ -21,6 +21,10 @@ const APP_PATH_IGNORES = [
   ".cabinet-backups/",
 ];
 
+export function inferElectronInstallKind(platform: NodeJS.Platform = process.platform): InstallKind {
+  return platform === "win32" ? "electron-windows" : "electron-macos";
+}
+
 export async function readInstallMetadata(): Promise<InstallMetadata | null> {
   const candidates = [ROOT_INSTALL_METADATA_PATH, DATA_INSTALL_METADATA_PATH];
 
@@ -47,10 +51,11 @@ export async function writeInstallMetadata(metadata: InstallMetadata): Promise<v
 
 export function detectInstallKind(metadata: InstallMetadata | null): InstallKind {
   if (process.env.CABINET_INSTALL_KIND === "electron-macos") return "electron-macos";
+  if (process.env.CABINET_INSTALL_KIND === "electron-windows") return "electron-windows";
   if (process.env.CABINET_INSTALL_KIND === "source-managed") return "source-managed";
   if (process.env.CABINET_INSTALL_KIND === "source-custom") return "source-custom";
 
-  if (isElectronRuntime()) return "electron-macos";
+  if (isElectronRuntime()) return inferElectronInstallKind();
   if (metadata?.installKind === "source-managed" && metadata.managed) {
     return "source-managed";
   }
@@ -94,6 +99,9 @@ export async function detectInstallState(): Promise<{
     installKind,
     metadata,
     dirtyAppFiles,
-    managed: metadata?.managed === true || installKind === "electron-macos",
+    managed:
+      metadata?.managed === true ||
+      installKind === "electron-macos" ||
+      installKind === "electron-windows",
   };
 }

--- a/src/lib/system/update-service.ts
+++ b/src/lib/system/update-service.ts
@@ -18,6 +18,13 @@ function buildInstructions(installKind: InstallKind, updateAvailable: boolean, d
     ];
   }
 
+  if (installKind === "electron-windows") {
+    return [
+      "Windows portable Electron builds do not auto-update yet.",
+      "Download the latest portable zip and replace the desktop app files manually after backing up your data.",
+    ];
+  }
+
   if (installKind === "source-custom") {
     return [
       "This install is not recognized as a managed Cabinet source install.",

--- a/src/types/update.ts
+++ b/src/types/update.ts
@@ -1,7 +1,8 @@
 export type InstallKind =
   | "source-managed"
   | "source-custom"
-  | "electron-macos";
+  | "electron-macos"
+  | "electron-windows";
 
 export type UpdateState =
   | "idle"
@@ -30,6 +31,9 @@ export interface ReleaseManifest {
     macos?: {
       zipAssetName?: string;
       dmgAssetName?: string;
+    };
+    windows?: {
+      zipAssetName?: string;
     };
   };
 }

--- a/test/update-system.test.ts
+++ b/test/update-system.test.ts
@@ -4,7 +4,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { compareVersions, isStableVersion } from "@/lib/system/version-utils";
 import { readBundledReleaseManifest } from "@/lib/system/release-manifest";
-import { detectInstallKind } from "@/lib/system/install-metadata";
+import { detectInstallKind, inferElectronInstallKind } from "@/lib/system/install-metadata";
 import type { InstallMetadata } from "@/types";
 
 const pkgVersion = JSON.parse(
@@ -54,4 +54,9 @@ test("detectInstallKind respects explicit environment hints first", () => {
       process.env.CABINET_INSTALL_KIND = original;
     }
   }
+});
+
+test("inferElectronInstallKind maps Windows and macOS runtimes distinctly", () => {
+  assert.equal(inferElectronInstallKind("win32"), "electron-windows");
+  assert.equal(inferElectronInstallKind("darwin"), "electron-macos");
 });


### PR DESCRIPTION
Adds Windows support for Cabinet's Electron desktop flow.

What changed:
- add a Windows-safe Electron dev launcher via `npm run electron:start`
- add Windows packaging support via `npm run electron:package:win` and `npm run electron:make:win`
- make the Electron runtime platform-aware for bundled Node and install kind metadata
- stage Windows `node-pty` prebuilds for packaged Electron builds
- make CLI/provider command resolution and PTY spawning work on Windows
- allow the local Electron renderer origin in Next dev so the app no longer opens to a blank window
- replace the Unix-only postinstall with a cross-platform Node script
- add tests covering the Windows command/path behavior

Windows validation performed on Windows 11:
- `npm test`
- `npm run test:unit`
- `npm run electron:start`
- `npm run electron:make:win`
- verified daemon health at `http://127.0.0.1:3001/health`

Notes:
- this PR does not attempt to fix unrelated existing lint failures on `main`
- agent tests are run serially in `package.json` because they mutate shared files under `data/.agents/.config` and were flaky under parallel execution


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Electron desktop support for macOS and Windows; new dev launcher for running Electron against local servers.
  * New npm scripts: electron:start (dev), electron:start:forge, electron:package:win, electron:make:win.

* **Documentation**
  * README updated to document Source mode platform support and Electron desktop packaging for macOS and Windows.

* **Chores**
  * Packaging config updated to produce ZIP artifacts for Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->