### PR TITLE
Add Gemini CLI as an agent provider

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,5 +1,7 @@
 # Progress
 
+[2026-04-12] Added Gemini CLI as an agent provider. Gemini CLI can now be used alongside Claude Code and Codex CLI for AI editing and agent sessions. Uses `--yolo` flag for auto-approval and supports both one-shot (`-p` prompt) and interactive session modes.
+
 [2026-04-11] Added Storage tab to Settings with data directory picker. Users can view the current data dir path, browse for a new one, or type a path manually. The setting is persisted to `.cabinet-install.json` and read by `getManagedDataDir()` at startup (env var still takes priority). A restart banner shows when the path changes. Also updated the About tab to show the actual data dir path.
 
 [2026-04-11] Added Mermaid diagram viewer for .mermaid and .mmd files. Renders diagrams with the mermaid library, supports source toggle, copy source, and SVG export. Follows the current Cabinet theme (dark/light). Shows error state with fallback to source view if rendering fails.

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -1221,7 +1221,6 @@ export function OnboardingWizard({ onComplete }: { onComplete: () => void }) {
                 </p>
                 <div className="grid gap-2 sm:grid-cols-2">
                   {[
-                    { name: "Gemini CLI", type: "CLI", icon: "terminal" },
                     { name: "Anthropic API", type: "API", icon: "api" },
                     { name: "OpenAI API", type: "API", icon: "api" },
                     { name: "Google AI API", type: "API", icon: "api" },

--- a/src/lib/agents/provider-registry.ts
+++ b/src/lib/agents/provider-registry.ts
@@ -1,6 +1,7 @@
 import type { AgentProvider, ProviderRegistry } from "./provider-interface";
 import { claudeCodeProvider } from "./providers/claude-code";
 import { codexCliProvider } from "./providers/codex-cli";
+import { geminiCliProvider } from "./providers/gemini-cli";
 
 class ProviderRegistryImpl implements ProviderRegistry {
   providers = new Map<string, AgentProvider>();
@@ -39,7 +40,7 @@ export const providerRegistry = new ProviderRegistryImpl();
 // Register built-in providers
 providerRegistry.register(claudeCodeProvider);
 providerRegistry.register(codexCliProvider);
+providerRegistry.register(geminiCliProvider);
 
 // Future providers will be registered here:
-// providerRegistry.register(geminiCliProvider);
 // providerRegistry.register(anthropicApiProvider);

--- a/src/lib/agents/provider-runtime.test.ts
+++ b/src/lib/agents/provider-runtime.test.ts
@@ -14,6 +14,7 @@ import {
 } from "./provider-runtime";
 import { claudeCodeProvider } from "./providers/claude-code";
 import { codexCliProvider } from "./providers/codex-cli";
+import { geminiCliProvider } from "./providers/gemini-cli";
 
 async function createExecutableScript(source: string): Promise<string> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "cabinet-provider-test-"));
@@ -61,6 +62,26 @@ test("Codex provider builds the expected launch arguments", () => {
   assert.ok(interactiveSession);
   assert.deepEqual(interactiveSession.args, ["--ephemeral"]);
   assert.equal(interactiveSession.initialPrompt, undefined);
+});
+
+test("Gemini provider builds expected one-shot args", () => {
+  const oneShot = geminiCliProvider.buildOneShotInvocation?.("Say OK", process.cwd());
+  assert.ok(oneShot);
+  assert.deepEqual(oneShot.args, ["--approval-mode=yolo", "Say OK"]);
+});
+
+test("Gemini provider uses -i for session mode with prompt", () => {
+  const session = geminiCliProvider.buildSessionInvocation?.("Edit this file", process.cwd());
+  assert.ok(session);
+  assert.deepEqual(session.args, ["--approval-mode=yolo", "-i", "Edit this file"]);
+  assert.equal(session.initialPrompt, undefined);
+});
+
+test("Gemini provider omits -i for session mode without prompt", () => {
+  const session = geminiCliProvider.buildSessionInvocation?.(undefined, process.cwd());
+  assert.ok(session);
+  assert.deepEqual(session.args, ["--approval-mode=yolo"]);
+  assert.equal(session.initialPrompt, undefined);
 });
 
 test("Claude provider keeps the prompt injection session contract", () => {

--- a/src/lib/agents/provider-settings.test.ts
+++ b/src/lib/agents/provider-settings.test.ts
@@ -58,11 +58,11 @@ test("normalizeProviderSettings falls back to the first enabled provider when ne
     () => {
       const settings = normalizeProviderSettings({
         defaultProvider: "missing-provider",
-        disabledProviderIds: ["claude-code", "codex-cli"],
+        disabledProviderIds: ["claude-code", "codex-cli", "gemini-cli"],
       });
 
       assert.equal(settings.defaultProvider, "test-only-provider");
-      assert.deepEqual(settings.disabledProviderIds, ["claude-code", "codex-cli"]);
+      assert.deepEqual(settings.disabledProviderIds, ["claude-code", "codex-cli", "gemini-cli"]);
     }
   );
 

--- a/src/lib/agents/providers/gemini-cli.ts
+++ b/src/lib/agents/providers/gemini-cli.ts
@@ -1,0 +1,95 @@
+import { execSync } from "child_process";
+import type { AgentProvider, ProviderStatus } from "../provider-interface";
+import { checkCliProviderAvailable, resolveCliCommand, RUNTIME_PATH } from "../provider-cli";
+
+export const geminiCliProvider: AgentProvider = {
+  id: "gemini-cli",
+  name: "Gemini CLI",
+  type: "cli",
+  icon: "gem",
+  installMessage: "Gemini CLI not found. Install with: npm install -g @google/gemini-cli or see geminicli.com",
+  installSteps: [
+    { title: "Install Gemini CLI", detail: "npm install -g @google/gemini-cli" },
+    { title: "Log in", detail: "Run gemini in your terminal and follow the login prompts." },
+  ],
+  command: "gemini",
+  commandCandidates: [
+    `${process.env.HOME || ""}/.local/bin/gemini`,
+    "/usr/local/bin/gemini",
+    "/opt/homebrew/bin/gemini",
+    "gemini",
+  ],
+
+  buildArgs(prompt: string, _workdir: string): string[] {
+    return ["--approval-mode=yolo", prompt];
+  },
+
+  buildOneShotInvocation(prompt: string, workdir: string) {
+    return {
+      command: this.command || "gemini",
+      args: this.buildArgs ? this.buildArgs(prompt, workdir) : [],
+    };
+  },
+
+  buildSessionInvocation(prompt: string | undefined, _workdir: string) {
+    // Gemini uses a rich TUI — raw PTY writes don't reach its input widget.
+    // Use -i (prompt-interactive) to execute the prompt on startup while
+    // keeping the interactive session alive for follow-up messages.
+    const args = ["--approval-mode=yolo"];
+    if (prompt?.trim()) {
+      args.push("-i", prompt.trim());
+    }
+    return {
+      command: this.command || "gemini",
+      args,
+    };
+  },
+
+  async isAvailable(): Promise<boolean> {
+    return checkCliProviderAvailable(this);
+  },
+
+  async healthCheck(): Promise<ProviderStatus> {
+    try {
+      const available = await this.isAvailable();
+      if (!available) {
+        return {
+          available: false,
+          authenticated: false,
+          error: this.installMessage,
+        };
+      }
+
+      // Gemini CLI has no fast local auth-status command (unlike Claude/Codex).
+      // We only check --version here to avoid blocking the event loop with an
+      // API round-trip. Auth failures surface at first actual use.
+      try {
+        const cmd = resolveCliCommand(this);
+        const version = execSync(`${cmd} --version`, {
+          encoding: "utf8",
+          env: { ...process.env, PATH: RUNTIME_PATH },
+          stdio: ["ignore", "pipe", "ignore"],
+          timeout: 5000,
+        }).trim();
+
+        return {
+          available: true,
+          authenticated: true,
+          version,
+        };
+      } catch {
+        return {
+          available: true,
+          authenticated: false,
+          error: "Could not verify Gemini CLI status. Try running: gemini",
+        };
+      }
+    } catch (error) {
+      return {
+        available: false,
+        authenticated: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      };
+    }
+  },
+};


### PR DESCRIPTION
Registers Gemini CLI alongside Claude Code and Codex CLI. Uses --yolo for auto-approval, -p for headless one-shot mode, and -i for interactive sessions (Gemini's rich TUI ignores raw PTY writes). Removes Gemini from the onboarding "Coming soon" list. Includes tests for all three invocation modes.

(claude did most of the work, I verified it works)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gemini CLI is now available as an agent provider alongside Claude Code and Codex CLI.
  * Supports AI editing and both one-shot and interactive agent sessions (auto-approval via --yolo).

* **UI**
  * “Coming soon” providers grid no longer lists Gemini CLI.

* **Documentation**
  * Release notes updated to announce Gemini CLI availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->