### PR TITLE
Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ cabinet/
 - At least one supported CLI provider:
   - **Claude Code CLI** (`npm install -g @anthropic-ai/claude-code`)
   - **Codex CLI** (`npm install -g @openai/codex` or `brew install --cask codex`)
-- macOS or Linux (Windows via WSL)
+- macOS, Linux, or Windows
 
 ## Configuration
 
@@ -191,7 +191,22 @@ npm run dev:daemon   # Terminal + job scheduler (port 3001)
 npm run dev:all      # Both servers
 npm run build        # Production build
 npm run start        # Production mode (both servers)
+npm run electron:make  # Build desktop packages for the current platform
 ```
+
+## Desktop builds
+
+On Windows, run:
+
+```bash
+npm install
+npm run electron:make
+```
+
+Electron Forge writes generated artifacts to `out/`. The unpacked Windows
+executable is created at `out/Cabinet-win32-x64/Cabinet.exe`, and installer or
+archive artifacts are written under `out/make/`. These files are generated build
+outputs and should not be committed.
 
 ---
 

--- a/cabinet-release.json
+++ b/cabinet-release.json
@@ -1,20 +1,26 @@
 {
   "manifestVersion": 1,
-  "version": "0.3.3",
+  "version": "0.3.4",
   "channel": "stable",
-  "releaseDate": "2026-04-14T18:24:48.319Z",
-  "gitTag": "v0.3.3",
+  "releaseDate": "2026-04-15T04:39:32.025Z",
+  "gitTag": "v0.3.4",
   "repositoryUrl": "https://github.com/hilash/cabinet",
-  "releaseNotesUrl": "https://github.com/hilash/cabinet/releases/tag/v0.3.3",
-  "sourceTarballUrl": "https://github.com/hilash/cabinet/archive/refs/tags/v0.3.3.tar.gz",
+  "releaseNotesUrl": "https://github.com/hilash/cabinet/releases/tag/v0.3.4",
+  "sourceTarballUrl": "https://github.com/hilash/cabinet/archive/refs/tags/v0.3.4.tar.gz",
   "npmPackage": "create-cabinet",
-  "createCabinetVersion": "0.3.3",
+  "createCabinetVersion": "0.3.4",
   "cabinetaiPackage": "cabinetai",
-  "cabinetaiVersion": "0.3.3",
+  "cabinetaiVersion": "0.3.4",
   "electron": {
     "macos": {
       "zipAssetName": "Cabinet-darwin-arm64.zip",
       "dmgAssetName": "Cabinet.dmg"
+    },
+    "windows": {
+      "zipAssetName": "Cabinet-win32-x64-0.3.4.zip",
+      "setupExeAssetName": "Cabinet-0.3.4 Setup.exe",
+      "nupkgAssetName": "cabinet-0.3.4-full.nupkg",
+      "releasesAssetName": "RELEASES"
     }
   }
 }

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,9 +1,8 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
-const { execFileSync } = require("child_process");
+const { execFileSync, spawn } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const net = require("net");
-const { spawn } = require("child_process");
 const { app, BrowserWindow, dialog, autoUpdater } = require("electron");
 const { updateElectronApp } = require("update-electron-app");
 
@@ -19,6 +18,9 @@ if (!gotSingleInstanceLock) {
 const isDev = !app.isPackaged;
 const managedDataDir = path.join(app.getPath("userData"), "cabinet-data");
 const updateStatusPath = path.join(managedDataDir, ".cabinet-state", "update-status.json");
+const bundledNodeBinaryName = process.platform === "win32" ? "node.exe" : "node";
+const electronInstallKind = process.platform === "win32" ? "electron-windows" : "electron-macos";
+const allowWindowsAutoUpdates = process.env.CABINET_ENABLE_WINDOWS_AUTO_UPDATES === "1";
 let mainWindow = null;
 let backendChildren = [];
 const DEV_APP_DISCOVERY_TIMEOUT_MS = 45_000;
@@ -95,7 +97,7 @@ function spawnNodeBackend(args, env) {
     ".next",
     "standalone",
     "bin",
-    "node"
+    bundledNodeBinaryName
   );
 
   if (fs.existsSync(bundledNodePath)) {
@@ -114,10 +116,75 @@ function packagedStandalonePath(...parts) {
   return path.join(process.resourcesPath, "app.asar.unpacked", ".next", "standalone", ...parts);
 }
 
+function normalizeExtractedNativeModules(externalNodePty) {
+  if (process.platform !== "darwin") {
+    return;
+  }
+
+  const prebuildsDir = path.join(externalNodePty, "prebuilds");
+  if (!fs.existsSync(prebuildsDir)) {
+    return;
+  }
+
+  for (const entry of fs.readdirSync(prebuildsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || !entry.name.startsWith("darwin-")) {
+      continue;
+    }
+
+    const candidateDir = path.join(prebuildsDir, entry.name);
+    const spawnHelperPath = path.join(candidateDir, "spawn-helper");
+    const nativeModulePath = path.join(candidateDir, "pty.node");
+
+    if (fs.existsSync(spawnHelperPath)) {
+      try {
+        fs.chmodSync(spawnHelperPath, 0o755);
+      } catch {}
+    }
+
+    for (const target of [spawnHelperPath, nativeModulePath]) {
+      if (!fs.existsSync(target)) {
+        continue;
+      }
+
+      try {
+        execFileSync("xattr", ["-dr", "com.apple.quarantine", target]);
+      } catch {}
+      try {
+        execFileSync("codesign", ["--force", "--sign", "-", target]);
+      } catch {}
+    }
+  }
+}
+
+function buildWindowOptions() {
+  const options = {
+    width: 1480,
+    height: 940,
+    minWidth: 1180,
+    minHeight: 760,
+    backgroundColor: "#111111",
+    autoHideMenuBar: process.platform === "win32",
+    webPreferences: {
+      preload: path.join(__dirname, "preload.cjs"),
+      contextIsolation: true,
+      sandbox: false,
+    },
+  };
+
+  if (process.platform === "darwin") {
+    options.titleBarStyle = "hiddenInset";
+    options.trafficLightPosition = { x: 16, y: 18 };
+  } else {
+    options.title = "Cabinet";
+  }
+
+  return options;
+}
+
 /**
- * macOS Sequoia+ blocks execution of native binaries inside .app bundles.
- * Copy node-pty to a writable location outside the bundle so spawn-helper
- * can execute, and return the external node_modules path for NODE_PATH.
+ * Copy bundled native modules to a writable location outside the app bundle.
+ * macOS requires this for node-pty spawn-helper execution and Windows can
+ * reuse the same extracted location for packaged native resolution.
  */
 function extractNativeModules() {
   const externalModulesDir = path.join(app.getPath("userData"), "native-modules");
@@ -139,20 +206,7 @@ function extractNativeModules() {
     fs.rmSync(externalNodePty, { recursive: true, force: true });
     fs.mkdirSync(externalModulesDir, { recursive: true });
     fs.cpSync(bundledNodePty, externalNodePty, { recursive: true });
-
-    // Remove quarantine flags and ad-hoc codesign native binaries so macOS allows execution
-    const prebuildsDir = path.join(externalNodePty, "prebuilds", "darwin-arm64");
-    for (const name of ["spawn-helper", "pty.node"]) {
-      const target = path.join(prebuildsDir, name);
-      if (fs.existsSync(target)) {
-        try {
-          execFileSync("xattr", ["-dr", "com.apple.quarantine", target]);
-        } catch {}
-        try {
-          execFileSync("codesign", ["--force", "--sign", "-", target]);
-        } catch {}
-      }
-    }
+    normalizeExtractedNativeModules(externalNodePty);
   }
 
   return externalModulesDir;
@@ -266,7 +320,7 @@ async function startEmbeddedCabinet() {
     NODE_ENV: "production",
     PORT: String(appPort),
     CABINET_RUNTIME: "electron",
-    CABINET_INSTALL_KIND: "electron-macos",
+    CABINET_INSTALL_KIND: electronInstallKind,
     CABINET_DATA_DIR: managedDataDir,
     CABINET_APP_PORT: String(appPort),
     CABINET_DAEMON_PORT: String(daemonPort),
@@ -292,7 +346,18 @@ async function startEmbeddedCabinet() {
 }
 
 function configureAutoUpdates() {
-  if (process.platform !== "darwin") {
+  if (isDev || !["darwin", "win32"].includes(process.platform)) {
+    return;
+  }
+
+  if (process.platform === "win32" && !allowWindowsAutoUpdates) {
+    writeUpdateStatus({
+      state: "idle",
+      completedAt: new Date().toISOString(),
+      installKind: electronInstallKind,
+      message:
+        "Windows desktop auto-updates are disabled for this build. Install a newer Cabinet Setup.exe manually.",
+    });
     return;
   }
 
@@ -306,7 +371,7 @@ function configureAutoUpdates() {
     writeUpdateStatus({
       state: "failed",
       completedAt: new Date().toISOString(),
-      installKind: "electron-macos",
+      installKind: electronInstallKind,
       message: "Electron update setup failed.",
       error: error instanceof Error ? error.message : String(error),
     });
@@ -316,7 +381,7 @@ function configureAutoUpdates() {
     writeUpdateStatus({
       state: "checking",
       startedAt: new Date().toISOString(),
-      installKind: "electron-macos",
+      installKind: electronInstallKind,
       message: "Checking for a newer Cabinet desktop release...",
     });
   });
@@ -325,7 +390,7 @@ function configureAutoUpdates() {
     writeUpdateStatus({
       state: "available",
       startedAt: new Date().toISOString(),
-      installKind: "electron-macos",
+      installKind: electronInstallKind,
       message: "A new Cabinet desktop release is downloading in the background.",
     });
   });
@@ -334,7 +399,7 @@ function configureAutoUpdates() {
     writeUpdateStatus({
       state: "idle",
       completedAt: new Date().toISOString(),
-      installKind: "electron-macos",
+      installKind: electronInstallKind,
       message: "Cabinet desktop is up to date.",
     });
   });
@@ -343,7 +408,7 @@ function configureAutoUpdates() {
     writeUpdateStatus({
       state: "failed",
       completedAt: new Date().toISOString(),
-      installKind: "electron-macos",
+      installKind: electronInstallKind,
       message: "Cabinet desktop update failed.",
       error: error instanceof Error ? error.message : String(error),
     });
@@ -353,7 +418,7 @@ function configureAutoUpdates() {
     writeUpdateStatus({
       state: "restart-required",
       completedAt: new Date().toISOString(),
-      installKind: "electron-macos",
+      installKind: electronInstallKind,
       message: "Restart Cabinet to finish applying the desktop update.",
     });
 
@@ -376,7 +441,13 @@ function configureAutoUpdates() {
 
 function cleanupBackends() {
   for (const child of backendChildren) {
-    child.kill("SIGTERM");
+    try {
+      if (process.platform === "win32") {
+        child.kill();
+      } else {
+        child.kill("SIGTERM");
+      }
+    } catch {}
   }
   backendChildren = [];
 }
@@ -384,20 +455,7 @@ function cleanupBackends() {
 async function createWindow() {
   const runtime = await startEmbeddedCabinet();
 
-  mainWindow = new BrowserWindow({
-    width: 1480,
-    height: 940,
-    minWidth: 1180,
-    minHeight: 760,
-    backgroundColor: "#111111",
-    titleBarStyle: "hiddenInset",
-    trafficLightPosition: { x: 16, y: 18 },
-    webPreferences: {
-      preload: path.join(__dirname, "preload.cjs"),
-      contextIsolation: true,
-      sandbox: false,
-    },
-  });
+  mainWindow = new BrowserWindow(buildWindowOptions());
 
   if (isDev) {
     mainWindow.webContents.on("did-fail-load", async (_event, errorCode, errorDescription) => {

--- a/forge.config.cjs
+++ b/forge.config.cjs
@@ -1,9 +1,11 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { execFileSync } = require("child_process");
+const fsSync = require("fs");
 const fs = require("fs/promises");
 const path = require("path");
 const { MakerZIP } = require("@electron-forge/maker-zip");
 const { MakerDMG } = require("@electron-forge/maker-dmg");
+const { MakerSquirrel } = require("@electron-forge/maker-squirrel");
 const { AutoUnpackNativesPlugin } = require("@electron-forge/plugin-auto-unpack-natives");
 const { PublisherGithub } = require("@electron-forge/publisher-github");
 
@@ -29,6 +31,11 @@ const PACKAGER_IGNORE = [
 ];
 
 const MACOS_LOCALES_TO_KEEP = new Set(["en.lproj", "en_GB.lproj", "he.lproj"]);
+const WINDOWS_ICON_PATH = path.join(__dirname, "electron", "assets", "cabinet-icon.ico");
+const packagerIcon =
+  process.platform === "win32" && !fsSync.existsSync(WINDOWS_ICON_PATH)
+    ? undefined
+    : "./electron/assets/cabinet-icon";
 
 async function pathExists(targetPath) {
   try {
@@ -143,7 +150,7 @@ function pruneMacLocales(buildPath, electronVersion, platform, arch, done) {
 module.exports = {
   packagerConfig: {
     name: "Cabinet",
-    icon: "./electron/assets/cabinet-icon",
+    icon: packagerIcon,
     appBundleId: "com.runcabinet.cabinet",
     appCopyright: "© 2026 Hila Shmuel",
     appCategoryType: "public.app-category.productivity",
@@ -168,10 +175,18 @@ module.exports = {
   },
   makers: [
     new MakerZIP({}, ["darwin"]),
+    new MakerZIP({}, ["win32"]),
     new MakerDMG({
       format: "ULFO",
       icon: "./electron/assets/cabinet-icon.icns",
     }),
+    new MakerSquirrel(
+      {
+        name: "cabinet",
+        authors: "Hila Shmuel",
+      },
+      ["win32"]
+    ),
   ],
   plugins: [new AutoUnpackNativesPlugin({})],
   publishers: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
       "devDependencies": {
         "@electron-forge/cli": "^7.8.1",
         "@electron-forge/maker-dmg": "^7.8.1",
+        "@electron-forge/maker-squirrel": "^7.8.1",
         "@electron-forge/maker-zip": "^7.8.1",
         "@electron-forge/plugin-auto-unpack-natives": "^7.8.1",
         "@electron-forge/publisher-github": "^7.8.1",
@@ -81,6 +82,7 @@
         "@types/react-dom": "^19",
         "@types/turndown": "^5.0.6",
         "@types/ws": "^8.18.1",
+        "concurrently": "^9.2.1",
         "electron": "^36.2.0",
         "eslint": "^9",
         "eslint-config-next": "16.2.1",
@@ -142,6 +144,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -770,6 +773,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1193,6 +1197,39 @@
       }
     },
     "node_modules/@electron-forge/maker-dmg/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@electron-forge/maker-squirrel": {
+      "version": "7.11.1",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-squirrel/-/maker-squirrel-7.11.1.tgz",
+      "integrity": "sha512-oSg7fgad6l+X0DjtRkSpMzB0AjzyDO4mb2gzM4kTodkP1ADeiMi08bxy0ZeCESqLm5+fG72cAPmEr3BAPvI1yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-forge/maker-base": "7.11.1",
+        "@electron-forge/shared-types": "7.11.1",
+        "fs-extra": "^10.0.0"
+      },
+      "engines": {
+        "node": ">= 16.4.0"
+      },
+      "optionalDependencies": {
+        "electron-winstaller": "^5.3.0"
+      }
+    },
+    "node_modules/@electron-forge/maker-squirrel/node_modules/fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
@@ -2736,6 +2773,7 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
       "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
@@ -4760,6 +4798,7 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -4897,6 +4936,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -5655,6 +5695,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.2.tgz",
       "integrity": "sha512-atq35NkpeEphH6vNYJ0pTLLBA73FAbvTV9Ovd3AaTC5s99/KF5Q86zVJXvml8xPRcMGM6dLp+eSSd06oTscMSA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -5738,6 +5779,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.20.4.tgz",
       "integrity": "sha512-Zlw3FrXTy01+o1yISeX/LC+iJeHA+ym602bMXGmtA6lyl7QSOSO7WExweJ6xeJGhbCjldwT5al6fkRAs8iGJZg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -5907,6 +5949,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.20.4.tgz",
       "integrity": "sha512-X+5plTKhOioNcQ4KsAFJJSb/3+zR8Xhdpow4HzXtoV1KcbdDey1fhZdpsfkbrzCL0s6/wAgwZuAchCK7HujurQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -5999,6 +6042,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.20.4.tgz",
       "integrity": "sha512-vEHXRL9k9G02pp3P+DyUnN4YRaRAHGfTBC6gck0s9TpsCM9NIchL0qI1fb/u46Bu6UaoMMk58DGr7xaJ29g7KQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -6104,6 +6148,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.20.4.tgz",
       "integrity": "sha512-8p6hVT65DjuQjtEdlH6ewX9SOJHlVQAOee3sWIJQmeJNRnZNvqPIBLleebUqDiljNTpxBv6s6QWkSTKgf3btwg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -6118,6 +6163,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.2.tgz",
       "integrity": "sha512-G2ENwIazoSKkAnN5MN5yN91TIZNFm6TxB74kPf3Empr2k9W51Hkcier70jHGpArhgcEaL4BVreuU1PRDRwCeGw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -6733,6 +6779,7 @@
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -6762,6 +6809,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6771,6 +6819,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -6896,6 +6945,7 @@
       "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.1",
         "@typescript-eslint/types": "8.57.1",
@@ -7675,6 +7725,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8509,6 +8560,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8893,6 +8945,7 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
       "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "12.0.0",
         "@chevrotain/gast": "12.0.0",
@@ -9227,6 +9280,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/confbox": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
@@ -9427,6 +9521,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
       "integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -9848,6 +9943,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10447,6 +10543,66 @@
       "integrity": "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==",
       "license": "ISC"
     },
+    "node_modules/electron-winstaller": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
+      "integrity": "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@electron/asar": "^3.2.1",
+        "debug": "^4.1.1",
+        "fs-extra": "^7.0.1",
+        "lodash": "^4.17.21",
+        "temp": "^0.9.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@electron/windows-sign": "^1.1.2"
+      }
+    },
+    "node_modules/electron-winstaller/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/electron-winstaller/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-winstaller/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/electron/node_modules/@electron/get": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
@@ -10536,31 +10692,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/end-of-stream": {
@@ -10887,6 +11018,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11072,6 +11204,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -11418,6 +11551,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -12682,6 +12816,7 @@
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
       "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -12691,6 +12826,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
       "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -14679,6 +14815,7 @@
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
       "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "devlop": "^1.0.0",
@@ -17463,6 +17600,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
       "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -17492,6 +17630,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -17540,6 +17679,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.7.tgz",
       "integrity": "sha512-jUwKNCEIGiqdvhlS91/2QAg21e4dfU5bH2iwmSDQeosXJgKF7smG0YSplOWK0cjSNgIqXe7VXqo7EIfUFJdt3w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -17711,6 +17851,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17720,6 +17861,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -18333,6 +18475,16 @@
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -18446,6 +18598,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -18829,6 +18982,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {
@@ -19618,7 +19784,8 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -19707,6 +19874,50 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/temp": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+      "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mkdirp": "^0.5.1",
+        "rimraf": "~2.6.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/temp/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/temp/node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
     },
     "node_modules/terser": {
       "version": "5.46.1",
@@ -19834,6 +20045,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -19933,6 +20145,16 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
@@ -20222,6 +20444,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21372,6 +21595,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,19 +1,22 @@
 {
   "name": "cabinet",
+  "productName": "Cabinet",
   "version": "0.3.4",
+  "description": "AI-first startup operating system with files on disk, AI workspaces, and agents with memory.",
+  "author": "Hila Shmuel",
   "private": true,
   "main": "electron/main.cjs",
   "scripts": {
     "dev": "node scripts/dev-next.mjs",
     "dev:terminal": "tsx server/terminal-server.ts",
     "dev:daemon": "node scripts/dev-daemon.mjs",
-    "dev:all": "npm run dev & npm run dev:daemon",
-    "debug:chrome": "bash scripts/launch-chrome-debug.sh",
+    "dev:all": "concurrently -k -n app,daemon \"npm:dev\" \"npm:dev:daemon\"",
+    "debug:chrome": "node scripts/launch-chrome-debug.mjs",
     "build": "next build",
     "electron:prep": "node scripts/prepare-electron-package.mjs",
     "release:manifest": "node scripts/generate-release-manifest.mjs",
-    "start": "npm run start:next & npm run start:daemon",
-    "start:next": "next start",
+    "start": "concurrently -k -n app,daemon \"npm:start:next\" \"npm:start:daemon\"",
+    "start:next": "node scripts/start-next.mjs",
     "start:daemon": "tsx server/cabinet-daemon.ts",
     "electron:start": "electron-forge start",
     "electron:package": "npm run build && npm run electron:prep && electron-forge package",
@@ -21,7 +24,7 @@
     "lint": "eslint",
     "test:unit": "tsx --test test/update-system.test.ts",
     "test": "tsx --test test/*.test.ts",
-    "postinstall": "chmod +x node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper 2>/dev/null; xattr -d com.apple.provenance node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper 2>/dev/null; xattr -d com.apple.provenance node_modules/node-pty/prebuilds/darwin-arm64/pty.node 2>/dev/null; true"
+    "postinstall": "node scripts/postinstall.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
@@ -80,8 +83,10 @@
     "zustand": "^5.0.12"
   },
   "devDependencies": {
+    "concurrently": "^9.2.1",
     "@electron-forge/cli": "^7.8.1",
     "@electron-forge/maker-dmg": "^7.8.1",
+    "@electron-forge/maker-squirrel": "^7.8.1",
     "@electron-forge/maker-zip": "^7.8.1",
     "@electron-forge/plugin-auto-unpack-natives": "^7.8.1",
     "@electron-forge/publisher-github": "^7.8.1",

--- a/scripts/generate-release-manifest.mjs
+++ b/scripts/generate-release-manifest.mjs
@@ -40,6 +40,12 @@ const manifest = {
       zipAssetName: "Cabinet-darwin-arm64.zip",
       dmgAssetName: "Cabinet.dmg",
     },
+    windows: {
+      zipAssetName: `Cabinet-win32-x64-${version}.zip`,
+      setupExeAssetName: `Cabinet-${version} Setup.exe`,
+      nupkgAssetName: `cabinet-${version}-full.nupkg`,
+      releasesAssetName: "RELEASES",
+    },
   },
 };
 

--- a/scripts/launch-chrome-debug.mjs
+++ b/scripts/launch-chrome-debug.mjs
@@ -1,0 +1,150 @@
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { spawn } from "child_process";
+
+const appUrl = process.argv[2] || "http://localhost:3000";
+const debugPort = process.env.DEBUG_PORT || "9222";
+const versionEndpoint = `http://127.0.0.1:${debugPort}/json/version`;
+const listEndpoint = `http://127.0.0.1:${debugPort}/json/list`;
+
+function browserCandidates() {
+  if (process.platform === "win32") {
+    const localAppData = process.env.LOCALAPPDATA || "";
+    const programFiles = process.env.ProgramFiles || "C:\\Program Files";
+    const programFilesX86 = process.env["ProgramFiles(x86)"] || "C:\\Program Files (x86)";
+
+    return [
+      path.join(programFiles, "Google", "Chrome", "Application", "chrome.exe"),
+      path.join(programFilesX86, "Google", "Chrome", "Application", "chrome.exe"),
+      path.join(localAppData, "Google", "Chrome", "Application", "chrome.exe"),
+      path.join(programFiles, "Chromium", "Application", "chrome.exe"),
+      path.join(programFilesX86, "Chromium", "Application", "chrome.exe"),
+      "chrome",
+      "chrome.exe",
+      "msedge",
+      "msedge.exe",
+    ];
+  }
+
+  if (process.platform === "darwin") {
+    return [
+      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+      "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+      "/Applications/Chromium.app/Contents/MacOS/Chromium",
+      "google-chrome",
+      "google-chrome-stable",
+      "chromium",
+      "chromium-browser",
+    ];
+  }
+
+  return [
+    "google-chrome",
+    "google-chrome-stable",
+    "chrome",
+    "chromium",
+    "chromium-browser",
+    "microsoft-edge",
+  ];
+}
+
+async function pathExists(targetPath) {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findBrowser() {
+  for (const candidate of browserCandidates()) {
+    if (candidate.includes(path.sep) || candidate.includes("/")) {
+      if (await pathExists(candidate)) {
+        return candidate;
+      }
+      continue;
+    }
+
+    try {
+      const child = spawn(candidate, ["--version"], {
+        stdio: "ignore",
+      });
+      const result = await new Promise((resolve) => {
+        child.on("error", () => resolve(false));
+        child.on("exit", (code) => resolve(code === 0));
+      });
+      if (result) {
+        return candidate;
+      }
+    } catch {
+      // Keep trying.
+    }
+  }
+
+  return null;
+}
+
+async function waitForDevTools(timeoutMs = 10_000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const response = await fetch(versionEndpoint);
+      if (response.ok) {
+        return true;
+      }
+    } catch {
+      // Retry until timeout.
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+
+  return false;
+}
+
+const browser = await findBrowser();
+if (!browser) {
+  console.error("No supported Chrome/Chromium browser was found.");
+  process.exit(1);
+}
+
+const profileDir = await fs.mkdtemp(path.join(os.tmpdir(), "cabinet-chrome-debug-"));
+
+console.log(`Launching ${browser}`);
+console.log(`App URL: ${appUrl}`);
+console.log(`Temporary profile: ${profileDir}`);
+
+const args = [
+  `--remote-debugging-port=${debugPort}`,
+  `--user-data-dir=${profileDir}`,
+  "--no-first-run",
+  "--no-default-browser-check",
+  appUrl,
+];
+
+const child = spawn(browser, args, {
+  detached: true,
+  stdio: "ignore",
+});
+child.unref();
+
+if (!(await waitForDevTools())) {
+  console.error(
+    `Chrome was launched, but the DevTools endpoint did not come up on port ${debugPort} in time.`
+  );
+  process.exit(1);
+}
+
+console.log("DevTools ready.");
+console.log(versionEndpoint);
+console.log(listEndpoint);
+
+try {
+  const response = await fetch(listEndpoint);
+  const body = await response.text();
+  console.log(body);
+} catch {
+  // Ignore list fetch failures after the main endpoint is up.
+}

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,0 +1,64 @@
+import fs from "fs/promises";
+import path from "path";
+import { execFileSync } from "child_process";
+
+const projectRoot = process.cwd();
+const nodePtyDir = path.join(projectRoot, "node_modules", "node-pty");
+
+async function pathExists(targetPath) {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function chmodIfPresent(targetPath, mode) {
+  if (!(await pathExists(targetPath))) return;
+  try {
+    await fs.chmod(targetPath, mode);
+  } catch {
+    // Ignore permission normalization failures during install.
+  }
+}
+
+async function main() {
+  if (!(await pathExists(nodePtyDir))) {
+    return;
+  }
+
+  if (process.platform !== "darwin") {
+    return;
+  }
+
+  const prebuildsRoot = path.join(nodePtyDir, "prebuilds");
+  if (!(await pathExists(prebuildsRoot))) {
+    return;
+  }
+
+  const entries = await fs.readdir(prebuildsRoot, { withFileTypes: true });
+  const darwinPrebuilds = entries
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith("darwin-"))
+    .map((entry) => path.join(prebuildsRoot, entry.name));
+
+  for (const prebuildDir of darwinPrebuilds) {
+    const spawnHelperPath = path.join(prebuildDir, "spawn-helper");
+    const ptyBinaryPath = path.join(prebuildDir, "pty.node");
+
+    await chmodIfPresent(spawnHelperPath, 0o755);
+
+    for (const targetPath of [spawnHelperPath, ptyBinaryPath]) {
+      if (!(await pathExists(targetPath))) continue;
+      try {
+        execFileSync("xattr", ["-d", "com.apple.provenance", targetPath], {
+          stdio: "ignore",
+        });
+      } catch {
+        // Ignore missing xattr entries and environments without xattr.
+      }
+    }
+  }
+}
+
+await main();

--- a/scripts/prepare-electron-package.mjs
+++ b/scripts/prepare-electron-package.mjs
@@ -1,5 +1,4 @@
 import { build as bundle } from "esbuild";
-import { execFileSync } from "child_process";
 import fs from "fs/promises";
 import path from "path";
 
@@ -15,7 +14,8 @@ const daemonMigrationsDir = path.join(standaloneServerDir, "migrations");
 const stagedNativeDir = path.join(standaloneDir, ".native");
 const stagedNodePtyDir = path.join(stagedNativeDir, "node-pty");
 const stagedSeedDir = path.join(standaloneDir, ".seed");
-const bundledNodeBinaryPath = path.join(standaloneBinDir, "node");
+const bundledNodeBinaryName = process.platform === "win32" ? "node.exe" : "node";
+const bundledNodeBinaryPath = path.join(standaloneBinDir, bundledNodeBinaryName);
 const rootNodePtyDir = path.join(projectRoot, "node_modules", "node-pty");
 const dataDir = path.join(projectRoot, "data");
 const agentLibraryDir = path.join(projectRoot, "src", "lib", "agents", "library");
@@ -126,19 +126,30 @@ async function stageDaemonRuntime() {
   // copies it to userData where macOS allows execution.
   await Promise.all([
     copyDirectory(path.join(rootNodePtyDir, "lib"), path.join(stagedNodePtyDir, "lib")),
-    copyDirectory(
-      path.join(rootNodePtyDir, "prebuilds", "darwin-arm64"),
-      path.join(stagedNodePtyDir, "prebuilds", "darwin-arm64")
-    ),
+    copyDirectory(path.join(rootNodePtyDir, "prebuilds"), path.join(stagedNodePtyDir, "prebuilds")),
     copyFile(path.join(rootNodePtyDir, "package.json"), path.join(stagedNodePtyDir, "package.json")),
   ]);
 
-  await fs.chmod(path.join(stagedNodePtyDir, "prebuilds", "darwin-arm64", "spawn-helper"), 0o755);
+  if (process.platform === "darwin") {
+    const prebuildsDir = path.join(stagedNodePtyDir, "prebuilds");
+    const entries = await fs.readdir(prebuildsDir, { withFileTypes: true }).catch(() => []);
+    await Promise.all(
+      entries
+        .filter((entry) => entry.isDirectory() && entry.name.startsWith("darwin-"))
+        .map((entry) =>
+          fs
+            .chmod(path.join(prebuildsDir, entry.name, "spawn-helper"), 0o755)
+            .catch(() => undefined)
+        )
+    );
+  }
 }
 
 async function stageBundledNodeRuntime() {
   await copyFile(process.execPath, bundledNodeBinaryPath);
-  await fs.chmod(bundledNodeBinaryPath, 0o755);
+  if (process.platform !== "win32") {
+    await fs.chmod(bundledNodeBinaryPath, 0o755);
+  }
 }
 
 async function stageSeedContent() {

--- a/scripts/start-next.mjs
+++ b/scripts/start-next.mjs
@@ -1,0 +1,28 @@
+import path from "path";
+import { spawn } from "child_process";
+
+const PROJECT_ROOT = process.cwd();
+const standaloneServer = path.join(PROJECT_ROOT, ".next", "standalone", "server.js");
+
+const child = spawn(process.execPath, [standaloneServer, ...process.argv.slice(2)], {
+  cwd: PROJECT_ROOT,
+  stdio: "inherit",
+  env: {
+    ...process.env,
+    CABINET_PROJECT_ROOT: PROJECT_ROOT,
+    CABINET_DATA_DIR:
+      process.env.CABINET_DATA_DIR || path.join(PROJECT_ROOT, "data"),
+  },
+});
+
+process.on("SIGINT", () => child.kill("SIGINT"));
+process.on("SIGTERM", () => child.kill("SIGTERM"));
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exit(code ?? 0);
+});

--- a/server/cabinet-daemon.ts
+++ b/server/cabinet-daemon.ts
@@ -161,6 +161,7 @@ const CLAUDE_READY_CHECK_INTERVAL_MS = 500;
 const CLAUDE_READY_FALLBACK_MS = 15000;
 const INITIAL_PROMPT_CHUNK_SIZE = process.platform === "win32" ? 1024 : 4096;
 const INITIAL_PROMPT_CHUNK_DELAY_MS = process.platform === "win32" ? 12 : 1;
+const INITIAL_PROMPT_SUBMIT_DELAY_MS = process.platform === "win32" ? 350 : 150;
 const BRACKETED_PASTE_START = "\x1b[200~";
 const BRACKETED_PASTE_END = "\x1b[201~";
 
@@ -403,10 +404,14 @@ function submitInitialPrompt(session: PtySession): void {
       return;
     }
 
-    // Small delay so the terminal processes the pasted text before Enter.
-    if (!session.exited) {
-      session.pty.write("\r");
-    }
+    // Give Claude's TUI time to finish processing the bracketed paste before
+    // sending Enter. Without this, Windows PTYs can show the text but miss the
+    // submit keystroke.
+    setTimeout(() => {
+      if (!session.exited) {
+        session.pty.write("\r");
+      }
+    }, INITIAL_PROMPT_SUBMIT_DELAY_MS);
   };
 
   writeNextChunk();

--- a/server/cabinet-daemon.ts
+++ b/server/cabinet-daemon.ts
@@ -33,6 +33,7 @@ import {
   getSessionLaunchSpec,
   resolveProviderId,
 } from "../src/lib/agents/provider-runtime";
+import { RUNTIME_PATH } from "../src/lib/agents/provider-cli";
 import { getNvmNodeBin } from "../src/lib/agents/nvm-path";
 import {
   appendConversationTranscript,
@@ -104,13 +105,27 @@ getDb();
 console.log("Database ready.");
 
 const nvmBin = getNvmNodeBin();
-const enrichedPath = [
-  `${process.env.HOME}/.local/bin`,
-  "/usr/local/bin",
-  "/opt/homebrew/bin",
-  ...(nvmBin ? [nvmBin] : []),
-  process.env.PATH,
-].join(":");
+const ptyTermName = process.platform === "win32" ? "xterm-color" : "xterm-256color";
+
+function buildPtyEnv(): Record<string, string> {
+  const env: Record<string, string> = {
+    ...(process.env as Record<string, string>),
+    PATH: RUNTIME_PATH,
+    FORCE_COLOR: "3",
+  };
+
+  if (process.platform !== "win32") {
+    env.TERM = ptyTermName;
+    env.COLORTERM = "truecolor";
+    env.LANG = process.env.LANG || "en_US.UTF-8";
+  }
+
+  if (nvmBin && !env.PATH.includes(nvmBin)) {
+    env.PATH = `${nvmBin}${path.delimiter}${env.PATH}`;
+  }
+
+  return env;
+}
 
 // ===== PTY Terminal Server =====
 
@@ -142,6 +157,8 @@ interface PtySession {
 const sessions = new Map<string, PtySession>();
 const completedOutput = new Map<string, { output: string; completedAt: number }>();
 const CLAUDE_AUTO_EXIT_GRACE_MS = 1200;
+const CLAUDE_READY_CHECK_INTERVAL_MS = 500;
+const CLAUDE_READY_FALLBACK_MS = 15000;
 
 function resolveSessionCwd(input?: string): string {
   if (!input) return DATA_DIR;
@@ -373,6 +390,31 @@ function submitInitialPrompt(session: PtySession): void {
       session.pty.write("\r");
     }
   }, 150);
+}
+
+function scheduleInitialPromptSubmission(session: PtySession): void {
+  if (!session.initialPrompt || session.initialPromptSent || session.exited) {
+    return;
+  }
+
+  if (session.initialPromptTimer) {
+    clearTimeout(session.initialPromptTimer);
+    delete session.initialPromptTimer;
+  }
+
+  const waitForClaudePrompt = session.readyStrategy === "claude";
+  const waitElapsed = Date.now() - session.createdAt.getTime();
+  const claudeReady = waitForClaudePrompt && claudePromptReady(session.output.join(""));
+  const shouldFallback = waitForClaudePrompt && waitElapsed >= CLAUDE_READY_FALLBACK_MS;
+
+  if (!waitForClaudePrompt || claudeReady || shouldFallback) {
+    submitInitialPrompt(session);
+    return;
+  }
+
+  session.initialPromptTimer = setTimeout(() => {
+    scheduleInitialPromptSubmission(session);
+  }, CLAUDE_READY_CHECK_INTERVAL_MS);
 }
 
 async function syncConversationChunk(sessionId: string, chunk: string): Promise<void> {
@@ -626,18 +668,11 @@ function createDetachedSession(input: {
   }
 
   const term = pty.spawn(launch.command, launch.args, {
-    name: "xterm-256color",
+    name: ptyTermName,
     cols: 120,
     rows: 30,
     cwd,
-    env: {
-      ...(process.env as Record<string, string>),
-      PATH: enrichedPath,
-      TERM: "xterm-256color",
-      COLORTERM: "truecolor",
-      FORCE_COLOR: "3",
-      LANG: "en_US.UTF-8",
-    },
+    env: buildPtyEnv(),
   });
 
   const session: PtySession = {
@@ -732,9 +767,7 @@ function createDetachedSession(input: {
   }
 
   if (session.initialPrompt) {
-    session.initialPromptTimer = setTimeout(() => {
-      submitInitialPrompt(session);
-    }, 1500);
+    scheduleInitialPromptSubmission(session);
   }
 
   return session;
@@ -1176,11 +1209,17 @@ const server = http.createServer(async (req, res) => {
       return;
     }
     try {
-      // SIGTERM first, then SIGKILL after 2s if still alive
+      // Windows PTYs do not reliably support POSIX signal names.
       session.pty.kill();
       const fallback = setTimeout(() => {
         if (!session.exited) {
-          try { session.pty.kill("SIGKILL"); } catch {}
+          try {
+            if (process.platform === "win32") {
+              session.pty.kill();
+            } else {
+              session.pty.kill("SIGKILL");
+            }
+          } catch {}
         }
       }, 2000);
       session.pty.onExit(() => clearTimeout(fallback));

--- a/server/cabinet-daemon.ts
+++ b/server/cabinet-daemon.ts
@@ -159,6 +159,10 @@ const completedOutput = new Map<string, { output: string; completedAt: number }>
 const CLAUDE_AUTO_EXIT_GRACE_MS = 1200;
 const CLAUDE_READY_CHECK_INTERVAL_MS = 500;
 const CLAUDE_READY_FALLBACK_MS = 15000;
+const INITIAL_PROMPT_CHUNK_SIZE = process.platform === "win32" ? 1024 : 4096;
+const INITIAL_PROMPT_CHUNK_DELAY_MS = process.platform === "win32" ? 12 : 1;
+const BRACKETED_PASTE_START = "\x1b[200~";
+const BRACKETED_PASTE_END = "\x1b[201~";
 
 function resolveSessionCwd(input?: string): string {
   if (!input) return DATA_DIR;
@@ -383,13 +387,29 @@ function submitInitialPrompt(session: PtySession): void {
     delete session.initialPromptTimer;
   }
 
-  session.pty.write(session.initialPrompt);
-  // Small delay so the terminal processes the pasted text before Enter
-  setTimeout(() => {
+  const promptPayload = `${BRACKETED_PASTE_START}${session.initialPrompt}${BRACKETED_PASTE_END}`;
+  let offset = 0;
+
+  const writeNextChunk = () => {
+    if (session.exited) {
+      return;
+    }
+
+    const chunk = promptPayload.slice(offset, offset + INITIAL_PROMPT_CHUNK_SIZE);
+    if (chunk) {
+      session.pty.write(chunk);
+      offset += chunk.length;
+      setTimeout(writeNextChunk, INITIAL_PROMPT_CHUNK_DELAY_MS);
+      return;
+    }
+
+    // Small delay so the terminal processes the pasted text before Enter.
     if (!session.exited) {
       session.pty.write("\r");
     }
-  }, 150);
+  };
+
+  writeNextChunk();
 }
 
 function scheduleInitialPromptSubmission(session: PtySession): void {

--- a/server/terminal-server.ts
+++ b/server/terminal-server.ts
@@ -26,6 +26,10 @@ const sessions = new Map<string, Session>();
 
 // Completed session output (kept for 30 minutes for retrieval)
 const completedOutput = new Map<string, { output: string; completedAt: number }>();
+const INITIAL_PROMPT_CHUNK_SIZE = process.platform === "win32" ? 1024 : 4096;
+const INITIAL_PROMPT_CHUNK_DELAY_MS = process.platform === "win32" ? 12 : 1;
+const BRACKETED_PASTE_START = "\x1b[200~";
+const BRACKETED_PASTE_END = "\x1b[201~";
 
 // Cleanup old completed output every 5 minutes
 setInterval(() => {
@@ -78,8 +82,28 @@ function submitInitialPrompt(session: Session): void {
     delete session.initialPromptTimer;
   }
 
-  session.pty.write(session.initialPrompt);
-  session.pty.write("\r");
+  const promptPayload = `${BRACKETED_PASTE_START}${session.initialPrompt}${BRACKETED_PASTE_END}`;
+  let offset = 0;
+
+  const writeNextChunk = () => {
+    if (session.exited) {
+      return;
+    }
+
+    const chunk = promptPayload.slice(offset, offset + INITIAL_PROMPT_CHUNK_SIZE);
+    if (chunk) {
+      session.pty.write(chunk);
+      offset += chunk.length;
+      setTimeout(writeNextChunk, INITIAL_PROMPT_CHUNK_DELAY_MS);
+      return;
+    }
+
+    if (!session.exited) {
+      session.pty.write("\r");
+    }
+  };
+
+  writeNextChunk();
 }
 
 const CLAUDE_PATH = (() => {

--- a/server/terminal-server.ts
+++ b/server/terminal-server.ts
@@ -1,10 +1,10 @@
 import { WebSocketServer, WebSocket } from "ws";
 import * as pty from "node-pty";
-import path from "path";
 import http from "http";
-import { execSync } from "child_process";
 import { DATA_DIR } from "../src/lib/storage/path-utils";
 import { getDaemonPort } from "../src/lib/runtime/runtime-config";
+import { RUNTIME_PATH, resolveCliCommand } from "../src/lib/agents/provider-cli";
+import { claudeCodeProvider } from "../src/lib/agents/providers/claude-code";
 
 const PORT = getDaemonPort();
 
@@ -82,48 +82,30 @@ function submitInitialPrompt(session: Session): void {
   session.pty.write("\r");
 }
 
-// Resolve the claude binary path at startup
-function resolveClaudePath(): string {
-  const candidates = [
-    path.join(process.env.HOME || "", ".local", "bin", "claude"),
-    "/usr/local/bin/claude",
-    "/opt/homebrew/bin/claude",
-  ];
+const CLAUDE_PATH = (() => {
+  try {
+    return resolveCliCommand(claudeCodeProvider);
+  } catch {
+    return "claude";
+  }
+})();
+const ptyTermName = process.platform === "win32" ? "xterm-color" : "xterm-256color";
 
-  for (const candidate of candidates) {
-    try {
-      const fs = require("fs");
-      if (fs.existsSync(candidate)) {
-        console.log(`Found claude at: ${candidate}`);
-        return candidate;
-      }
-    } catch {}
+function buildPtyEnv(): Record<string, string> {
+  const env: Record<string, string> = {
+    ...(process.env as Record<string, string>),
+    PATH: RUNTIME_PATH,
+    FORCE_COLOR: "3",
+  };
+
+  if (process.platform !== "win32") {
+    env.TERM = ptyTermName;
+    env.COLORTERM = "truecolor";
+    env.LANG = process.env.LANG || "en_US.UTF-8";
   }
 
-  try {
-    const resolved = execSync("which claude", {
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        PATH: `${process.env.HOME}/.local/bin:${process.env.PATH}`,
-      },
-    }).trim();
-    if (resolved) {
-      console.log(`Resolved claude via which: ${resolved}`);
-      return resolved;
-    }
-  } catch {}
-
-  console.warn("Could not resolve claude path, using 'claude' directly");
-  return "claude";
+  return env;
 }
-
-const CLAUDE_PATH = resolveClaudePath();
-
-const enrichedPath = [
-  `${process.env.HOME}/.local/bin`,
-  process.env.PATH,
-].join(":");
 
 // Create HTTP server to handle both WebSocket upgrades and REST endpoints
 const server = http.createServer((req, res) => {
@@ -247,29 +229,19 @@ wss.on("connection", (ws, req) => {
   }
 
   // New session — spawn PTY
-  let shell: string;
-  let args: string[];
-
-  shell = CLAUDE_PATH;
-  args = prompt
+  const shell = CLAUDE_PATH;
+  const args = prompt
     ? ["--dangerously-skip-permissions", prompt]
     : ["--dangerously-skip-permissions"];
 
   let term: pty.IPty;
   try {
     term = pty.spawn(shell, args, {
-      name: "xterm-256color",
+      name: ptyTermName,
       cols: 120,
       rows: 30,
       cwd: DATA_DIR,
-      env: {
-        ...(process.env as Record<string, string>),
-        PATH: enrichedPath,
-        TERM: "xterm-256color",
-        COLORTERM: "truecolor",
-        FORCE_COLOR: "3",
-        LANG: "en_US.UTF-8",
-      },
+      env: buildPtyEnv(),
     });
   } catch (err: unknown) {
     const errMsg = err instanceof Error ? err.message : String(err);

--- a/server/terminal-server.ts
+++ b/server/terminal-server.ts
@@ -28,6 +28,7 @@ const sessions = new Map<string, Session>();
 const completedOutput = new Map<string, { output: string; completedAt: number }>();
 const INITIAL_PROMPT_CHUNK_SIZE = process.platform === "win32" ? 1024 : 4096;
 const INITIAL_PROMPT_CHUNK_DELAY_MS = process.platform === "win32" ? 12 : 1;
+const INITIAL_PROMPT_SUBMIT_DELAY_MS = process.platform === "win32" ? 350 : 150;
 const BRACKETED_PASTE_START = "\x1b[200~";
 const BRACKETED_PASTE_END = "\x1b[201~";
 
@@ -98,9 +99,11 @@ function submitInitialPrompt(session: Session): void {
       return;
     }
 
-    if (!session.exited) {
-      session.pty.write("\r");
-    }
+    setTimeout(() => {
+      if (!session.exited) {
+        session.pty.write("\r");
+      }
+    }, INITIAL_PROMPT_SUBMIT_DELAY_MS);
   };
 
   writeNextChunk();

--- a/src/app/api/terminal/open/route.ts
+++ b/src/app/api/terminal/open/route.ts
@@ -1,14 +1,17 @@
 import { NextResponse } from "next/server";
 import { exec } from "child_process";
+import os from "os";
 
 export async function POST() {
-  const home = process.env.HOME || "~";
+  const home = os.homedir();
 
   try {
     if (process.platform === "darwin") {
       exec(`open -a Terminal "${home}"`);
     } else if (process.platform === "win32") {
-      exec(`start cmd /K "cd /d ${home}"`);
+      exec(
+        `powershell -NoProfile -Command "Start-Process powershell -ArgumentList '-NoExit','-Command','Set-Location -LiteralPath ''${home.replace(/'/g, "''")}'''"`
+      );
     } else {
       // Linux: try common terminal emulators
       exec(

--- a/src/components/layout/status-bar.tsx
+++ b/src/components/layout/status-bar.tsx
@@ -133,7 +133,7 @@ export function StatusBar() {
   const didAutoPullRef = useRef(false);
   const [appAlive, setAppAlive] = useState(true);
   const [daemonAlive, setDaemonAlive] = useState(true);
-  const [installKind, setInstallKind] = useState<"source-managed" | "source-custom" | "electron-macos">("source-custom");
+  const [installKind, setInstallKind] = useState<"source-managed" | "source-custom" | "electron-macos" | "electron-windows">("source-custom");
   const [showServerPopup, setShowServerPopup] = useState(false);
   const [providerStatuses, setProviderStatuses] = useState<
     { id: string; name: string; available: boolean; authenticated: boolean }[]
@@ -145,6 +145,7 @@ export function StatusBar() {
     () => !providersLoaded || providerStatuses.some((p) => p.available && p.authenticated),
     [providersLoaded, providerStatuses],
   );
+  const isElectronInstall = installKind === "electron-macos" || installKind === "electron-windows";
 
   const fetchProviderStatus = useCallback(async () => {
     try {
@@ -470,7 +471,7 @@ export function StatusBar() {
                     <div className="pt-1.5 border-t border-border space-y-1">
                       <p className="text-[10px] font-medium text-foreground/70">How to fix</p>
                       {(!appAlive || !daemonAlive) && (
-                        installKind === "electron-macos" ? (
+                        isElectronInstall ? (
                           <p className="text-[10px] text-muted-foreground">
                             {!appAlive && !daemonAlive
                               ? "Both servers are down. Try quitting and reopening the Cabinet app."

--- a/src/lib/agents/agent-manager.ts
+++ b/src/lib/agents/agent-manager.ts
@@ -2,6 +2,7 @@ import { spawn, type ChildProcess } from "child_process";
 import path from "path";
 import { DATA_DIR } from "@/lib/storage/path-utils";
 import { getOneShotLaunchSpec } from "./provider-runtime";
+import { RUNTIME_PATH } from "./provider-cli";
 
 export interface AgentSession {
   id: string;
@@ -89,7 +90,7 @@ export async function runAgent(
     cwd,
     env: {
       ...process.env,
-      PATH: `${process.env.HOME || ""}/.local/bin:${process.env.PATH || ""}`,
+      PATH: RUNTIME_PATH,
     },
     stdio: ["ignore", "pipe", "pipe"],
   });

--- a/src/lib/agents/provider-cli.ts
+++ b/src/lib/agents/provider-cli.ts
@@ -1,17 +1,92 @@
 import fs from "fs";
-import { execSync, spawn } from "child_process";
+import os from "os";
+import path from "path";
+import { execFileSync, spawn } from "child_process";
 import type { AgentProvider } from "./provider-interface";
 import { getNvmNodeBin } from "./nvm-path";
 
 const nvmBin = getNvmNodeBin();
 
-export const RUNTIME_PATH = [
-  `${process.env.HOME || ""}/.local/bin`,
-  "/usr/local/bin",
-  "/opt/homebrew/bin",
-  ...(nvmBin ? [nvmBin] : []),
-  process.env.PATH || "",
-].filter(Boolean).join(":");
+function preferredRuntimePathEntries(): string[] {
+  const entries = new Set<string>();
+  const homeDir = os.homedir();
+
+  if (process.platform === "win32") {
+    const appData = process.env.APPDATA || path.join(homeDir, "AppData", "Roaming");
+    entries.add(path.join(appData, "npm"));
+    const localAppData = process.env.LOCALAPPDATA || path.join(homeDir, "AppData", "Local");
+    entries.add(path.join(localAppData, "Programs", "Microsoft VS Code", "bin"));
+  } else {
+    entries.add(path.join(homeDir, ".local", "bin"));
+    entries.add("/usr/local/bin");
+    entries.add("/opt/homebrew/bin");
+  }
+
+  if (nvmBin) {
+    entries.add(nvmBin);
+  }
+
+  if (process.env.PATH) {
+    entries.add(process.env.PATH);
+  }
+
+  return [...entries].filter(Boolean);
+}
+
+export const RUNTIME_PATH = preferredRuntimePathEntries().join(path.delimiter);
+
+export interface CliExecutionSpec {
+  command: string;
+  args: string[];
+}
+
+function isPathLikeCommand(candidate: string): boolean {
+  return path.isAbsolute(candidate) || /[\\/]/.test(candidate);
+}
+
+function resolveCommandFromPath(command: string): string | null {
+  const lookupCommand = process.platform === "win32" ? "where.exe" : "which";
+
+  try {
+    const output = execFileSync(lookupCommand, [command], {
+      encoding: "utf8",
+      env: { ...process.env, PATH: RUNTIME_PATH },
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+
+    return output
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) || null;
+  } catch {
+    return null;
+  }
+}
+
+function quoteWindowsCmdArgument(arg: string): string {
+  if (!arg) {
+    return '""';
+  }
+
+  const escaped = arg.replace(/"/g, '""');
+  return /[\s"&<>^|()]/.test(arg) ? `"${escaped}"` : escaped;
+}
+
+export function normalizeCliExecution(
+  command: string,
+  args: string[] = []
+): CliExecutionSpec {
+  if (process.platform !== "win32" || !/\.(cmd|bat)$/i.test(command)) {
+    return { command, args };
+  }
+
+  const comspec = process.env.ComSpec || "cmd.exe";
+  const commandLine = [command, ...args].map(quoteWindowsCmdArgument).join(" ");
+  return {
+    command: comspec,
+    args: ["/d", "/s", "/c", commandLine],
+  };
+}
 
 export function resolveCliCommand(provider: AgentProvider): string {
   const candidates = [
@@ -20,25 +95,16 @@ export function resolveCliCommand(provider: AgentProvider): string {
   ].filter((candidate): candidate is string => !!candidate);
 
   for (const candidate of candidates) {
-    if (candidate.includes("/") && fs.existsSync(candidate)) {
+    if (isPathLikeCommand(candidate) && fs.existsSync(candidate)) {
       return candidate;
     }
   }
 
   for (const candidate of candidates) {
-    if (candidate.includes("/")) continue;
-    try {
-      const resolved = execSync(`command -v ${candidate}`, {
-        encoding: "utf8",
-        env: { ...process.env, PATH: RUNTIME_PATH },
-        stdio: ["ignore", "pipe", "ignore"],
-      }).trim();
-
-      if (resolved) {
-        return resolved;
-      }
-    } catch {
-      // Ignore and keep trying.
+    if (isPathLikeCommand(candidate)) continue;
+    const resolved = resolveCommandFromPath(candidate);
+    if (resolved) {
+      return resolved;
     }
   }
 
@@ -59,7 +125,8 @@ export async function checkCliProviderAvailable(provider: AgentProvider): Promis
       return;
     }
 
-    const proc = spawn(command, ["--version"], {
+    const invocation = normalizeCliExecution(command, ["--version"]);
+    const proc = spawn(invocation.command, invocation.args, {
       env: {
         ...process.env,
         PATH: RUNTIME_PATH,

--- a/src/lib/agents/provider-runtime.ts
+++ b/src/lib/agents/provider-runtime.ts
@@ -1,7 +1,7 @@
 import { spawn } from "child_process";
 import type { AgentProvider, CliProviderInvocation } from "./provider-interface";
 import { providerRegistry } from "./provider-registry";
-import { resolveCliCommand, RUNTIME_PATH } from "./provider-cli";
+import { normalizeCliExecution, resolveCliCommand, RUNTIME_PATH } from "./provider-cli";
 import {
   resolveDetachedPromptLaunchMode,
   type DetachedLaunchMode,
@@ -77,8 +77,7 @@ function buildLaunchSpec(
     providerId: provider.id,
     providerName: provider.name,
     installMessage: provider.installMessage,
-    command: resolveCliCommand(provider),
-    args: invocation.args,
+    ...normalizeCliExecution(resolveCliCommand(provider), invocation.args),
     initialPrompt: invocation.initialPrompt,
     readyStrategy: invocation.readyStrategy,
   };

--- a/src/lib/agents/providers/claude-code.ts
+++ b/src/lib/agents/providers/claude-code.ts
@@ -1,12 +1,25 @@
-import { execSync } from "child_process";
+import os from "os";
+import path from "path";
+import { execFileSync } from "child_process";
 import type { AgentProvider, ProviderStatus } from "../provider-interface";
-import { checkCliProviderAvailable, resolveCliCommand, RUNTIME_PATH } from "../provider-cli";
+import {
+  checkCliProviderAvailable,
+  normalizeCliExecution,
+  resolveCliCommand,
+  RUNTIME_PATH,
+} from "../provider-cli";
 import { getNvmNodeBin } from "../nvm-path";
 
 const nvmClaudePath = (() => {
   const bin = getNvmNodeBin();
-  return bin ? `${bin}/claude` : null;
+  return bin ? path.join(bin, process.platform === "win32" ? "claude.cmd" : "claude") : null;
 })();
+
+const homeDir = os.homedir();
+const windowsNpmBin =
+  process.platform === "win32"
+    ? path.join(process.env.APPDATA || path.join(homeDir, "AppData", "Roaming"), "npm")
+    : null;
 
 export const claudeCodeProvider: AgentProvider = {
   id: "claude-code",
@@ -33,9 +46,15 @@ export const claudeCodeProvider: AgentProvider = {
   ],
   command: "claude",
   commandCandidates: [
-    `${process.env.HOME || ""}/.local/bin/claude`,
+    path.join(homeDir, ".local", "bin", "claude"),
     "/usr/local/bin/claude",
     "/opt/homebrew/bin/claude",
+    ...(windowsNpmBin
+      ? [
+          path.join(windowsNpmBin, "claude.cmd"),
+          path.join(windowsNpmBin, "claude.exe"),
+        ]
+      : []),
     ...(nvmClaudePath ? [nvmClaudePath] : []),
     "claude",
   ],
@@ -78,7 +97,8 @@ export const claudeCodeProvider: AgentProvider = {
       // Check actual auth status via `claude auth status`
       try {
         const cmd = resolveCliCommand(this);
-        const output = execSync(`${cmd} auth status`, {
+        const invocation = normalizeCliExecution(cmd, ["auth", "status"]);
+        const output = execFileSync(invocation.command, invocation.args, {
           encoding: "utf8",
           env: { ...process.env, PATH: RUNTIME_PATH },
           stdio: ["ignore", "pipe", "ignore"],

--- a/src/lib/agents/providers/codex-cli.ts
+++ b/src/lib/agents/providers/codex-cli.ts
@@ -1,6 +1,19 @@
-import { execSync } from "child_process";
+import os from "os";
+import path from "path";
+import { execFileSync } from "child_process";
 import type { AgentProvider, ProviderStatus } from "../provider-interface";
-import { checkCliProviderAvailable, resolveCliCommand, RUNTIME_PATH } from "../provider-cli";
+import {
+  checkCliProviderAvailable,
+  normalizeCliExecution,
+  resolveCliCommand,
+  RUNTIME_PATH,
+} from "../provider-cli";
+
+const homeDir = os.homedir();
+const windowsNpmBin =
+  process.platform === "win32"
+    ? path.join(process.env.APPDATA || path.join(homeDir, "AppData", "Roaming"), "npm")
+    : null;
 
 export const codexCliProvider: AgentProvider = {
   id: "codex-cli",
@@ -22,9 +35,15 @@ export const codexCliProvider: AgentProvider = {
   ],
   command: "codex",
   commandCandidates: [
-    `${process.env.HOME || ""}/.local/bin/codex`,
+    path.join(homeDir, ".local", "bin", "codex"),
     "/usr/local/bin/codex",
     "/opt/homebrew/bin/codex",
+    ...(windowsNpmBin
+      ? [
+          path.join(windowsNpmBin, "codex.cmd"),
+          path.join(windowsNpmBin, "codex.exe"),
+        ]
+      : []),
     "codex",
   ],
 
@@ -77,7 +96,8 @@ export const codexCliProvider: AgentProvider = {
       // Check auth status via `codex login status`
       try {
         const cmd = resolveCliCommand(this);
-        const output = execSync(`${cmd} login status 2>&1`, {
+        const invocation = normalizeCliExecution(cmd, ["login", "status"]);
+        const output = execFileSync(invocation.command, invocation.args, {
           encoding: "utf8",
           env: { ...process.env, PATH: RUNTIME_PATH },
           stdio: ["ignore", "pipe", "ignore"],

--- a/src/lib/runtime/runtime-config.ts
+++ b/src/lib/runtime/runtime-config.ts
@@ -2,7 +2,9 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 
-export const PROJECT_ROOT = process.cwd();
+export const PROJECT_ROOT = path.resolve(
+  process.env.CABINET_PROJECT_ROOT?.trim() || process.cwd()
+);
 const DEFAULT_RELEASE_MANIFEST_URL =
   "https://github.com/hilash/cabinet/releases/latest/download/cabinet-release.json";
 

--- a/src/lib/system/install-metadata.ts
+++ b/src/lib/system/install-metadata.ts
@@ -47,10 +47,13 @@ export async function writeInstallMetadata(metadata: InstallMetadata): Promise<v
 
 export function detectInstallKind(metadata: InstallMetadata | null): InstallKind {
   if (process.env.CABINET_INSTALL_KIND === "electron-macos") return "electron-macos";
+  if (process.env.CABINET_INSTALL_KIND === "electron-windows") return "electron-windows";
   if (process.env.CABINET_INSTALL_KIND === "source-managed") return "source-managed";
   if (process.env.CABINET_INSTALL_KIND === "source-custom") return "source-custom";
 
-  if (isElectronRuntime()) return "electron-macos";
+  if (isElectronRuntime()) {
+    return process.platform === "win32" ? "electron-windows" : "electron-macos";
+  }
   if (metadata?.installKind === "source-managed" && metadata.managed) {
     return "source-managed";
   }
@@ -94,6 +97,9 @@ export async function detectInstallState(): Promise<{
     installKind,
     metadata,
     dirtyAppFiles,
-    managed: metadata?.managed === true || installKind === "electron-macos",
+    managed:
+      metadata?.managed === true ||
+      installKind === "electron-macos" ||
+      installKind === "electron-windows",
   };
 }

--- a/src/lib/system/update-service.ts
+++ b/src/lib/system/update-service.ts
@@ -6,14 +6,18 @@ import { readUpdateStatus } from "@/lib/system/update-status";
 import { PROJECT_ROOT } from "@/lib/runtime/runtime-config";
 import type { InstallKind, UpdateCheckResult } from "@/types";
 
+function isElectronDesktopInstall(installKind: InstallKind): boolean {
+  return installKind === "electron-macos" || installKind === "electron-windows";
+}
+
 function buildInstructions(installKind: InstallKind, updateAvailable: boolean, dirtyAppFiles: string[]): string[] {
   if (!updateAvailable) {
     return ["You already have the latest Cabinet release this install can see."];
   }
 
-  if (installKind === "electron-macos") {
+  if (isElectronDesktopInstall(installKind)) {
     return [
-      "Electron downloads supported updates in the background.",
+      "Cabinet desktop downloads supported updates in the background.",
       "When the update is ready, Cabinet will ask the user to restart the desktop app.",
     ];
   }

--- a/src/types/update.ts
+++ b/src/types/update.ts
@@ -1,7 +1,8 @@
 export type InstallKind =
   | "source-managed"
   | "source-custom"
-  | "electron-macos";
+  | "electron-macos"
+  | "electron-windows";
 
 export type UpdateState =
   | "idle"
@@ -30,6 +31,12 @@ export interface ReleaseManifest {
     macos?: {
       zipAssetName?: string;
       dmgAssetName?: string;
+    };
+    windows?: {
+      zipAssetName?: string;
+      setupExeAssetName?: string;
+      nupkgAssetName?: string;
+      releasesAssetName?: string;
     };
   };
 }

--- a/test/conversation-output-cleaning.test.ts
+++ b/test/conversation-output-cleaning.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { buildManualConversationPrompt } from "../src/lib/agents/conversation-runner";
+import { resolveCabinetDir } from "../src/lib/cabinets/server-paths";
 import {
   parseCabinetBlock,
   transcriptShowsCompletedRun,
@@ -37,7 +38,7 @@ test("manual cabinet-scoped prompts explicitly pin work to the cabinet root", as
 
   assert.equal(
     prompt.cwd,
-    "/Users/mybiblepath/Development/cabinet/data/hilas-cabinet"
+    resolveCabinetDir("hilas-cabinet")
   );
   assert.match(
     prompt.prompt,

--- a/test/update-system.test.ts
+++ b/test/update-system.test.ts
@@ -55,3 +55,18 @@ test("detectInstallKind respects explicit environment hints first", () => {
     }
   }
 });
+
+test("detectInstallKind supports explicit Windows desktop installs", () => {
+  const original = process.env.CABINET_INSTALL_KIND;
+  process.env.CABINET_INSTALL_KIND = "electron-windows";
+
+  try {
+    assert.equal(detectInstallKind(null), "electron-windows");
+  } finally {
+    if (original === undefined) {
+      delete process.env.CABINET_INSTALL_KIND;
+    } else {
+      process.env.CABINET_INSTALL_KIND = original;
+    }
+  }
+});


### PR DESCRIPTION
  ## Summary

  This adds Windows desktop packaging/runtime support for Cabinet.

  Changes include:
  - Windows-compatible Electron Forge packaging via ZIP and Squirrel makers
  - Windows-safe npm scripts for dev/start/postinstall flows
  - Windows CLI provider path resolution for Claude Code and Codex
  - Windows Electron runtime handling for bundled Node, native modules, app metadata, update state, and process cleanup
  - More reliable Claude prompt injection in Windows PTYs by chunking bracketed-paste input and delaying submit
  - README notes for building Windows desktop artifacts

  ## Validation

  Tested locally on Windows:

  - `npm install`
  - `npm test`
  - `npm run build`
  - `npm run electron:make`

  The Windows build produced:

  - `out/Cabinet-win32-x64/Cabinet.exe`
  - `out/make/squirrel.windows/x64/Cabinet-0.3.4 Setup.exe`
  - `out/make/zip/win32/x64/Cabinet-win32-x64-0.3.4.zip`

  Generated `out/` artifacts are intentionally not committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.3.4

* **New Features**
  * Added official Windows desktop application support with native installer
  * Enabled Windows auto-update capability for managed installations
  * Added Windows-specific terminal and shell integration

* **Improvements**
  * Enhanced cross-platform packaging and build system
  * Improved installation process with platform-specific handling
  * Better environment and PATH configuration across platforms

* **Documentation**
  * Updated platform requirements to include Windows
  * Added desktop build instructions for Windows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->