### PR TITLE
fix(electron): hardened-runtime entitlements for daemon native modules

### DIFF
--- a/electron/entitlements.mac.plist
+++ b/electron/entitlements.mac.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+  <true/>
+</dict>
+</plist>

--- a/forge.config.cjs
+++ b/forge.config.cjs
@@ -156,6 +156,9 @@ module.exports = {
     osxSign: process.env.APPLE_ID
       ? {
           identity: process.env.APPLE_SIGN_IDENTITY,
+          optionsForFile: () => ({
+            entitlements: path.join(__dirname, "electron", "entitlements.mac.plist"),
+          }),
         }
       : undefined,
     osxNotarize: process.env.APPLE_ID


### PR DESCRIPTION
## Summary
- Add `electron/entitlements.mac.plist` declaring the four hardened-runtime entitlements the daemon needs: `allow-jit`, `allow-unsigned-executable-memory`, `disable-library-validation`, and `allow-dyld-environment-variables`.
- Wire it into `osxSign.optionsForFile` in `forge.config.cjs` so every signed binary in the bundle (including `bin/node` deep inside `app.asar.unpacked`) inherits them.

## Why
The DMG installs were properly signed and notarized, but hardened runtime was blocking the spawned `bin/node` from loading `better_sqlite3.node` and `node-pty`'s native binaries. The daemon would crash on first DB access, the app would surface "fetch failed" / "Service Disruption — Daemon down", and the agent would fail.

`disable-library-validation` is the load-bearing entitlement here — without it, the OS refuses to let a signed binary load `.node` modules signed under a different identity, which is exactly what `bin/node` does for `better-sqlite3` and `node-pty`.

## Test plan
- [ ] Bump to v0.4.3 and trigger `electron-release.yml` for that tag
- [ ] Download the new DMG from the GitHub release
- [ ] Install fresh into `/Applications`, launch
- [ ] Confirm Service Disruption panel does NOT appear (daemon healthy)
- [ ] Run an agent task end-to-end; confirm no "fetch failed"
- [ ] Verify on the built artifact: `codesign -dv --entitlements - <Cabinet.app>/Contents/Resources/app.asar.unpacked/.next/standalone/bin/node` shows the four entitlement keys

## Follow-up (not in this PR)
A separate change to `.github/workflows/electron-release.yml` splits the single `electron-forge publish` step into make → verify → upload, gating the upload on `codesign --verify`, `spctl`, `xcrun stapler validate`, and an explicit entitlements check. Held back from this PR because the current OAuth token lacks the `workflow` scope. Will land once auth is refreshed (`gh auth refresh -h github.com -s workflow`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced macOS build configuration and application signing settings to include proper runtime entitlements and security permissions. These updates ensure the application executes correctly on macOS systems while maintaining necessary security settings and compatibility across different macOS environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->