### PR TITLE
fix(chat): render markdown in AI agent messages

### DIFF
--- a/src/components/agents/conversation-content-viewer.tsx
+++ b/src/components/agents/conversation-content-viewer.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from "react";
 import type { ReactNode } from "react";
 import { parseTranscript, type Block } from "@/lib/agents/transcript-parser";
+import { Markdown } from "@/components/tasks/conversation/markdown";
 
 const LABEL_COLORS: Record<string, string> = {
   SUMMARY: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
@@ -200,11 +201,10 @@ function ActionsBlock({ block }: { block: Extract<Block, { type: "actions" }> })
 
 function MarkdownBlock({ content }: { content: string }) {
   return (
-    <div className="my-1 whitespace-pre-wrap break-words font-mono text-[12px] leading-relaxed text-foreground">
-      {content.split("\n").map((line, index) => (
-        <div key={index}>{renderInlineFormatting(line)}</div>
-      ))}
-    </div>
+    <Markdown
+      content={content}
+      className="text-[14.5px] leading-[1.65] tracking-[-0.005em] text-foreground/95"
+    />
   );
 }
 


### PR DESCRIPTION
## Summary

AI agent messages were rendering markdown literally — `**bold**` showed as raw asterisks, lists/headings unformatted, all in mono font. User messages already rendered correctly.

**Root cause:** in `ConversationContentViewer`, the `text` block fell through to `MarkdownBlock`, whose body only handled inline links + backticks via `renderInlineFormatting`, in `font-mono`. The component's name implied full markdown but the implementation never got there.

**Fix:** route `MarkdownBlock` through the existing `<Markdown>` component (`src/components/tasks/conversation/markdown.tsx`) — the same one user messages already use, which goes through `markdownToHtml()` and renders with prose styling. Structured blocks (diff / code / cabinet / actions / structured / tokens) are untouched.

Net diff: +5 / -5 in one file.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on the modified file
- [x] Verified locally with `npm run dev:all` against an existing cabinet workspace — CEO agent messages with `**bold**`, numbered lists, bullets, and inline code now render correctly; structured transcript blocks (DECISION, ARTIFACT, diffs, code) still render with their existing styling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated markdown content rendering approach.

* **Style**
  * Changed typography sizing, line-height, letter-spacing, and opacity for markdown content blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->