### PR TITLE
fix(electron): use resolveAgentTemplateDir for add agent template lookup

### DIFF
--- a/src/app/api/agents/library/[slug]/add/route.ts
+++ b/src/app/api/agents/library/[slug]/add/route.ts
@@ -2,12 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 import path from "path";
 import fs from "fs/promises";
 import matter from "gray-matter";
-import { PROJECT_ROOT } from "@/lib/runtime/runtime-config";
 import { ensureAgentScaffold } from "@/lib/agents/scaffold";
+import { resolveAgentTemplateDir } from "@/lib/agents/library-manager";
 import { normalizeCabinetPath } from "@/lib/cabinets/paths";
 import { resolveCabinetDir } from "@/lib/cabinets/server-paths";
-
-const LIBRARY_DIR = path.join(PROJECT_ROOT, "src", "lib", "agents", "library");
 
 export async function POST(
   req: NextRequest,
@@ -21,14 +19,15 @@ export async function POST(
       typeof body.cabinetPath === "string" ? body.cabinetPath : undefined,
       true
     );
-    const templateDir = path.join(LIBRARY_DIR, slug);
     const targetDir = path.join(resolveCabinetDir(cabinetPath), ".agents", slug);
 
-    // Verify template exists
-    const personaPath = path.join(templateDir, "persona.md");
-    try {
-      await fs.access(personaPath);
-    } catch {
+    // Resolve the template via the shared library resolver so we hit the
+    // seeded copy under DATA_DIR in Electron builds (where `src/` is pruned
+    // by scripts/prepare-electron-package.mjs) and fall back to the source
+    // tree in dev. Without this, `Add Agent` returns 404 in every Electron
+    // release.
+    const templateDir = await resolveAgentTemplateDir(slug);
+    if (!templateDir) {
       return NextResponse.json(
         { error: `Template "${slug}" not found` },
         { status: 404 }


### PR DESCRIPTION
## Summary

`POST /api/agents/library/[slug]/add` returns `404 Template "<slug>" not found` on every call in the Electron release. The handler resolves templates from `PROJECT_ROOT/src/lib/agents/library`, but `scripts/prepare-electron-package.mjs` prunes `src/` via `STANDALONE_PRUNE_PATHS`. The same script copies the templates to `.next/standalone/.seed/.agents/.library` before the prune, but this handler never adopted the seeded path.

`GET /api/agents/library` doesn't hit this because `library-manager.ts` already exposes `resolveAgentLibraryDir` / `resolveAgentTemplateDir` with a fallback chain (`DATA_DIR/.agents/.library` → `SOURCE_AGENT_LIBRARY_DIR`). The fix is to adopt the same helper here.

Behavior is unchanged in dev (the source tree still resolves); Electron builds now find the seeded copy under the data dir.

## Reproduction (before the patch)

In any Electron release, after onboarding completes, click any persona in **Settings → Agents → Library → Add**, or:

\`\`\`bash
curl -X POST 'http://127.0.0.1:<port>/api/agents/library/data-analyst/add' \\
     -H 'Content-Type: application/json' \\
     --data '{"cabinetPath":"."}'
# -> 404 {"error":"Template \"data-analyst\" not found"}
\`\`\`

After this PR: \`201 Created\`, agent scaffolded under \`<cabinet>/.agents/<slug>/\`.

## Why dev mode hides this

\`PROJECT_ROOT = process.cwd()\`, which in \`npm run dev\` and \`npx cabinetai run\` (which clones the full repo to \`~/.cabinet/app/v<version>/\`) keeps \`src/\` intact. Only the Electron DMG (which goes through \`prepare-electron-package.mjs\` + \`electron-forge\`) drops \`src/\` from the standalone bundle, so the broken path only surfaces there.

## Test plan

- [ ] \`npm run lint\` passes
- [ ] In dev (\`npm run dev:all\`): \`POST /api/agents/library/data-analyst/add\` still returns \`201\` and scaffolds the agent — no behavior change
- [ ] In an Electron build (\`npm run electron:make\`): same call returns \`201\` instead of \`404\`, and the resulting \`.agents/<slug>/\` is identical to the dev-mode result
- [ ] Calling twice in a row still returns \`409 Agent already exists\` on the second call

## Notes

- Diff is 8 insertions / 9 deletions in a single file. Removed the now-unused \`PROJECT_ROOT\` import and the module-level \`LIBRARY_DIR\` constant.
- Added a comment at the resolver call site explaining the packaging foot-gun, so the next reader sees why we go through the helper instead of \`path.join(PROJECT_ROOT, …)\` like the old code did.
- Did **not** touch \`prepare-electron-package.mjs\`. A follow-up could either keep \`src/lib/agents/library/\` in the standalone bundle (preserving the historical path) or add a comment in \`STANDALONE_PRUNE_PATHS\` flagging that \`src/\` consumers must use seeded paths. Open to whichever you prefer — happy to send a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved agent template resolution mechanism to use a shared resolver, providing more consistent error handling when templates are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->