### PR TITLE
fix(providers): refresh model lists across all CLI providers (May 2026)

### DIFF
--- a/src/lib/agents/action-dispatcher.test.ts
+++ b/src/lib/agents/action-dispatcher.test.ts
@@ -104,13 +104,13 @@ test("resolveDispatchRuntime — action model + effort override both parent + pe
 });
 
 test("resolveDispatchRuntime — effort is dropped when resolved provider doesn't advertise it", () => {
-  // Parent uses codex-cli with effort=xhigh. Dispatch to a claude-code
-  // target (via action override). Claude advertises low/medium/high/max —
-  // NOT xhigh — so effort should be dropped rather than passed through
-  // and rejected by the CLI.
+  // Parent uses codex-cli/gpt-5.1-codex-max with effort=none (a Codex-only
+  // level). Dispatch to a claude-code target (via action override). Claude
+  // advertises low/medium/high/xhigh/max — no `none` — so effort should be
+  // dropped rather than passed through and rejected by the CLI.
   const parent = makeParent({
     providerId: "codex-cli",
-    adapterConfig: { model: "gpt-5.4", effort: "xhigh" },
+    adapterConfig: { model: "gpt-5.1-codex-max", effort: "none" },
   });
   const target = makePersona({ provider: "codex-cli" });
 

--- a/src/lib/agents/providers/claude-code.ts
+++ b/src/lib/agents/providers/claude-code.ts
@@ -6,11 +6,23 @@ import {
 } from "../provider-cli";
 import { getNvmNodeBin } from "../nvm-path";
 
-const CLAUDE_THINKING_LEVELS = [
+// Effort levels per Claude Code docs: Opus 4.7 supports an extra `xhigh`
+// rung (recommended default); Opus 4.6 / Sonnet 4.6 stop at `max`. Setting
+// an unsupported level falls back to the highest the model accepts, but we
+// surface the right list so the picker doesn't show levels that won't apply.
+const OPUS_THINKING_LEVELS = [
   { id: "low", name: "Low", description: "Quick, minimal reasoning" },
   { id: "medium", name: "Medium", description: "Balanced depth" },
   { id: "high", name: "High", description: "Thorough reasoning" },
-  { id: "max", name: "Max", description: "Maximum depth" },
+  { id: "xhigh", name: "Extra High", description: "Recommended for hardest tasks" },
+  { id: "max", name: "Max", description: "Deepest reasoning, no token cap" },
+] as const;
+
+const SONNET_THINKING_LEVELS = [
+  { id: "low", name: "Low", description: "Quick, minimal reasoning" },
+  { id: "medium", name: "Medium", description: "Balanced depth" },
+  { id: "high", name: "High", description: "Thorough reasoning" },
+  { id: "max", name: "Max", description: "Deepest reasoning, no token cap" },
 ] as const;
 
 const nvmClaudePath = (() => {
@@ -36,13 +48,31 @@ export const claudeCodeProvider: AgentProvider = {
       id: "opus",
       name: "Claude Opus 4.7",
       description: "Most intelligent with configurable effort",
-      effortLevels: [...CLAUDE_THINKING_LEVELS],
+      effortLevels: [...OPUS_THINKING_LEVELS],
+    },
+    {
+      id: "opus[1m]",
+      name: "Claude Opus 4.7 (1M context)",
+      description: "Opus 4.7 with 1M-token context for very long sessions",
+      effortLevels: [...OPUS_THINKING_LEVELS],
     },
     {
       id: "sonnet",
       name: "Claude Sonnet 4.6",
       description: "Fast and capable with configurable effort",
-      effortLevels: [...CLAUDE_THINKING_LEVELS],
+      effortLevels: [...SONNET_THINKING_LEVELS],
+    },
+    {
+      id: "sonnet[1m]",
+      name: "Claude Sonnet 4.6 (1M context)",
+      description: "Sonnet 4.6 with 1M-token context for very long sessions",
+      effortLevels: [...SONNET_THINKING_LEVELS],
+    },
+    {
+      id: "opusplan",
+      name: "Opus + Sonnet (opusplan)",
+      description: "Opus during plan mode, Sonnet for execution",
+      effortLevels: [...OPUS_THINKING_LEVELS],
     },
     {
       id: "haiku",
@@ -53,7 +83,7 @@ export const claudeCodeProvider: AgentProvider = {
   ],
   detachedPromptLaunchMode: "session",
   supportsTerminalResume: true,
-  effortLevels: [...CLAUDE_THINKING_LEVELS],
+  effortLevels: [...OPUS_THINKING_LEVELS],
   command: "claude",
   commandCandidates: [
     `${process.env.HOME || ""}/.local/bin/claude`,

--- a/src/lib/agents/providers/codex-cli.ts
+++ b/src/lib/agents/providers/codex-cli.ts
@@ -45,23 +45,58 @@ export const codexCliProvider: AgentProvider = {
   ],
   detachedPromptLaunchMode: "one-shot",
   // Models are annotated with `requires` so UI pickers can badge entries the
-  // user's current auth mode can't hit. Codex backend behavior (verified
-  // live 2026-04-21): ChatGPT-plan accounts currently only accept
-  // `gpt-5.4`; every "gpt-5.x-codex" / `o*` / `gpt-4.1*` id documented here
-  // 400s with `model not supported when using Codex with a ChatGPT
-  // account`. API-key auth (`OPENAI_API_KEY`) accepts the rest.
+  // user's current auth mode can't hit. Per OpenAI's Codex models docs
+  // (verified 2026-05-03): `gpt-5.5` and `gpt-5.3-codex-spark` are
+  // ChatGPT-only; the older `*-codex` / `o*` / `gpt-4.1*` ids are API-key
+  // only; the `gpt-5.4`/`gpt-5.4-mini`/`gpt-5.3-codex`/`gpt-5.2` line works
+  // with both auth modes.
   models: [
+    {
+      id: "gpt-5.5",
+      name: "GPT-5.5",
+      description: "Recommended default — strongest coding model (ChatGPT sign-in only)",
+      requires: "chatgpt_plan",
+      effortLevels: [...CODEX_EXTENDED_REASONING_LEVELS],
+    },
     {
       id: "gpt-5.4",
       name: "GPT-5.4",
-      description: "Default model on ChatGPT-plan Codex accounts",
+      description: "Previous flagship — works with both ChatGPT and API key",
+      requires: "any",
+      effortLevels: [...CODEX_EXTENDED_REASONING_LEVELS],
+    },
+    {
+      id: "gpt-5.4-mini",
+      name: "GPT-5.4 Mini",
+      description: "Faster, lower-cost variant for lighter coding tasks",
+      requires: "any",
+      effortLevels: [...CODEX_EXTENDED_REASONING_LEVELS],
+    },
+    {
+      id: "gpt-5.3-codex",
+      name: "GPT-5.3 Codex",
+      description: "Codex-tuned model for agentic coding",
+      requires: "any",
+      effortLevels: [...CODEX_EXTENDED_REASONING_LEVELS],
+    },
+    {
+      id: "gpt-5.3-codex-spark",
+      name: "GPT-5.3 Codex Spark",
+      description: "Real-time coding iteration (ChatGPT Pro research preview)",
+      requires: "chatgpt_plan",
+      effortLevels: [...CODEX_REASONING_LEVELS],
+    },
+    {
+      id: "gpt-5.2",
+      name: "GPT-5.2",
+      description: "General-purpose GPT-5.2",
       requires: "any",
       effortLevels: [...CODEX_EXTENDED_REASONING_LEVELS],
     },
     {
       id: "gpt-5.2-codex",
       name: "GPT-5.2 Codex",
-      description: "Flagship Codex model for agentic coding (API-key only)",
+      description: "Earlier Codex flagship (API-key only)",
       requires: "api_key",
       effortLevels: [...CODEX_EXTENDED_REASONING_LEVELS],
     },

--- a/src/lib/agents/providers/copilot-cli.ts
+++ b/src/lib/agents/providers/copilot-cli.ts
@@ -5,26 +5,55 @@ import {
   resolveCliCommand,
 } from "../provider-cli";
 
+// Copilot CLI's `--model` accepts whatever the user's plan exposes via
+// `/model` in the TUI. Verified 2026-05-03 against GitHub's supported-models
+// docs; "auto" was added 2026-04-17 and routes across GPT-5.x, Sonnet 4.6,
+// Haiku 4.5 based on plan + policy.
 const COPILOT_MODELS = [
   {
-    id: "claude-sonnet-4.5",
-    name: "Claude Sonnet 4.5 (via Copilot)",
-    description: "Anthropic Sonnet routed through GitHub Copilot",
+    id: "auto",
+    name: "Auto (recommended)",
+    description: "Copilot picks the best model for each turn based on your plan",
   },
   {
-    id: "gpt-5",
-    name: "GPT-5 (via Copilot)",
-    description: "OpenAI flagship routed through GitHub Copilot",
+    id: "gpt-5.5",
+    name: "GPT-5.5 (via Copilot)",
+    description: "OpenAI's strongest coding model routed through Copilot",
   },
   {
-    id: "gpt-5-mini",
-    name: "GPT-5 Mini (via Copilot)",
-    description: "Fast, cheap option routed through GitHub Copilot",
+    id: "gpt-5.4",
+    name: "GPT-5.4 (via Copilot)",
+    description: "Previous OpenAI flagship routed through Copilot",
   },
   {
-    id: "gemini-2.5-pro",
-    name: "Gemini 2.5 Pro (via Copilot)",
-    description: "Google model routed through GitHub Copilot",
+    id: "gpt-5.3-codex",
+    name: "GPT-5.3 Codex (via Copilot)",
+    description: "Codex-tuned OpenAI model routed through Copilot",
+  },
+  {
+    id: "claude-opus-4.7",
+    name: "Claude Opus 4.7 (via Copilot)",
+    description: "Anthropic's most intelligent model routed through Copilot",
+  },
+  {
+    id: "claude-sonnet-4.6",
+    name: "Claude Sonnet 4.6 (via Copilot)",
+    description: "Anthropic Sonnet routed through Copilot",
+  },
+  {
+    id: "claude-haiku-4.5",
+    name: "Claude Haiku 4.5 (via Copilot)",
+    description: "Fast Anthropic model routed through Copilot",
+  },
+  {
+    id: "gemini-3.1-pro",
+    name: "Gemini 3.1 Pro (via Copilot)",
+    description: "Google's flagship Gemini routed through Copilot",
+  },
+  {
+    id: "gemini-3-flash",
+    name: "Gemini 3 Flash (via Copilot)",
+    description: "Fast Google model routed through Copilot",
   },
 ] as const;
 

--- a/src/lib/agents/providers/cursor-cli.ts
+++ b/src/lib/agents/providers/cursor-cli.ts
@@ -5,17 +5,23 @@ import {
   resolveCliCommand,
 } from "../provider-cli";
 
+// Cursor exposes a curated multi-vendor list. Verified 2026-05-03 against
+// Cursor's changelog/docs; Composer 2 is the new flagship in-house model
+// (launched April 2026). The CLI's `--model` accepts these IDs; `auto` lets
+// Cursor route per request.
 const CURSOR_MODEL_IDS = [
   { id: "auto", name: "Auto", description: "Let Cursor pick the best model" },
-  { id: "composer-1.5", name: "Composer 1.5", description: "Cursor's agentic coding model" },
+  { id: "composer-2", name: "Composer 2", description: "Cursor's flagship in-house coding model" },
+  { id: "composer-1.5", name: "Composer 1.5", description: "Previous Cursor in-house coding model" },
+  { id: "gpt-5.5", name: "GPT-5.5", description: "OpenAI's strongest coding model" },
+  { id: "gpt-5.4", name: "GPT-5.4" },
   { id: "gpt-5.3-codex", name: "GPT-5.3 Codex" },
   { id: "gpt-5.3-codex-high", name: "GPT-5.3 Codex (High)" },
-  { id: "gpt-5.2-codex", name: "GPT-5.2 Codex" },
   { id: "sonnet-4.6", name: "Claude Sonnet 4.6" },
-  { id: "opus-4.6", name: "Claude Opus 4.6" },
-  { id: "gemini-3-pro", name: "Gemini 3 Pro" },
+  { id: "opus-4.7", name: "Claude Opus 4.7" },
   { id: "gemini-3.1-pro", name: "Gemini 3.1 Pro" },
-  { id: "grok", name: "Grok" },
+  { id: "gemini-3-flash", name: "Gemini 3 Flash" },
+  { id: "grok-4", name: "Grok 4" },
 ] as const;
 
 export const cursorCliProvider: AgentProvider = {

--- a/src/lib/agents/providers/gemini-cli.ts
+++ b/src/lib/agents/providers/gemini-cli.ts
@@ -89,17 +89,26 @@ export const geminiCliProvider: AgentProvider = {
     },
   ],
   detachedPromptLaunchMode: "one-shot",
+  // Gemini 3 Pro Preview was deprecated 2026-03-09 — `gemini-3.1-pro-preview`
+  // is the active flagship preview. Verified against Gemini CLI docs and
+  // Google's model docs on 2026-05-03.
   models: [
-    {
-      id: "gemini-3-flash-preview",
-      name: "Gemini 3 Flash Preview",
-      description: "Latest fast Gemini preview model",
-      effortLevels: [],
-    },
     {
       id: "gemini-3.1-pro-preview",
       name: "Gemini 3.1 Pro Preview",
       description: "Most capable Gemini preview model when access is enabled",
+      effortLevels: [],
+    },
+    {
+      id: "gemini-3-flash-preview",
+      name: "Gemini 3 Flash Preview",
+      description: "Fast Gemini 3 preview for high-frequency terminal workflows",
+      effortLevels: [],
+    },
+    {
+      id: "gemini-3.1-flash-lite",
+      name: "Gemini 3.1 Flash Lite",
+      description: "Lightweight Gemini 3.1 for lower-cost runs",
       effortLevels: [],
     },
     {
@@ -117,7 +126,7 @@ export const geminiCliProvider: AgentProvider = {
     {
       id: "gemini-2.5-flash-lite",
       name: "Gemini 2.5 Flash Lite",
-      description: "Lightweight model for lower-cost runs",
+      description: "Lightweight stable Gemini for lower-cost runs",
       effortLevels: [],
     },
   ],

--- a/src/lib/agents/providers/grok-cli.ts
+++ b/src/lib/agents/providers/grok-cli.ts
@@ -5,18 +5,31 @@ import {
   resolveCliCommand,
 } from "../provider-cli";
 
+// Verified 2026-05-03 against xAI's models docs. Grok 4.3 finished
+// rollout 2026-04-30 and is xAI's recommended default; the 4.x-fast line
+// covers cost-sensitive high-volume use; Grok 3 has been retired from the
+// recommended catalog so it's no longer listed here.
 const GROK_MODELS = [
-  { id: "grok-4", name: "Grok 4", description: "xAI's flagship reasoning model" },
+  {
+    id: "grok-4.3",
+    name: "Grok 4.3",
+    description: "xAI's recommended default — fastest, most intelligent (1M context)",
+  },
+  { id: "grok-4", name: "Grok 4", description: "Frontier reasoning workloads" },
+  {
+    id: "grok-4-fast",
+    name: "Grok 4 Fast",
+    description: "Fast, cost-efficient Grok 4 for high-volume use",
+  },
+  {
+    id: "grok-4.1-fast",
+    name: "Grok 4.1 Fast",
+    description: "Cheapest Grok 4.x — high-throughput, low-latency",
+  },
   {
     id: "grok-code-fast-1",
     name: "Grok Code Fast 1",
-    description: "Fast code-focused Grok model",
-  },
-  { id: "grok-3", name: "Grok 3", description: "Previous generation flagship" },
-  {
-    id: "grok-3-fast",
-    name: "Grok 3 Fast",
-    description: "Faster, lower-latency Grok 3",
+    description: "Fast code-focused Grok model for agentic coding",
   },
 ] as const;
 

--- a/src/lib/agents/providers/opencode.ts
+++ b/src/lib/agents/providers/opencode.ts
@@ -14,13 +14,17 @@ const OPENCODE_VARIANT_LEVELS = [
   { id: "max", name: "Max", description: "Provider max effort" },
 ] as const;
 
+// Used only when `opencode models` discovery fails (CLI not installed or
+// not authed). OpenCode reaches the API directly so we can't include
+// ChatGPT-only ids like `gpt-5.5` here. Refreshed 2026-05-03.
 const OPENCODE_FALLBACK_MODELS = [
-  { id: "openai/gpt-5.2-codex", name: "openai/gpt-5.2-codex" },
   { id: "openai/gpt-5.4", name: "openai/gpt-5.4" },
-  { id: "openai/gpt-5.1-codex-max", name: "openai/gpt-5.1-codex-max" },
-  { id: "anthropic/claude-sonnet-4-6", name: "anthropic/claude-sonnet-4-6" },
+  { id: "openai/gpt-5.4-mini", name: "openai/gpt-5.4-mini" },
+  { id: "openai/gpt-5.3-codex", name: "openai/gpt-5.3-codex" },
   { id: "anthropic/claude-opus-4-7", name: "anthropic/claude-opus-4-7" },
-  { id: "google/gemini-2.5-pro", name: "google/gemini-2.5-pro" },
+  { id: "anthropic/claude-sonnet-4-6", name: "anthropic/claude-sonnet-4-6" },
+  { id: "google/gemini-3.1-pro", name: "google/gemini-3.1-pro" },
+  { id: "xai/grok-4.3", name: "xai/grok-4.3" },
 ] as const;
 
 export const openCodeProvider: AgentProvider = {

--- a/src/lib/agents/providers/pi.ts
+++ b/src/lib/agents/providers/pi.ts
@@ -14,12 +14,14 @@ const PI_THINKING_LEVELS = [
   { id: "xhigh", name: "Extra High", description: "Maximum depth" },
 ] as const;
 
+// Used only when `pi --list-models` discovery fails. Refreshed 2026-05-03.
 const PI_FALLBACK_MODELS = [
-  { id: "xai/grok-4", name: "xai/grok-4" },
-  { id: "anthropic/claude-sonnet-4-6", name: "anthropic/claude-sonnet-4-6" },
+  { id: "xai/grok-4.3", name: "xai/grok-4.3" },
   { id: "anthropic/claude-opus-4-7", name: "anthropic/claude-opus-4-7" },
-  { id: "openai/gpt-5.2-codex", name: "openai/gpt-5.2-codex" },
-  { id: "google/gemini-2.5-pro", name: "google/gemini-2.5-pro" },
+  { id: "anthropic/claude-sonnet-4-6", name: "anthropic/claude-sonnet-4-6" },
+  { id: "openai/gpt-5.4", name: "openai/gpt-5.4" },
+  { id: "openai/gpt-5.3-codex", name: "openai/gpt-5.3-codex" },
+  { id: "google/gemini-3.1-pro", name: "google/gemini-3.1-pro" },
 ] as const;
 
 export const piProvider: AgentProvider = {


### PR DESCRIPTION
## Summary
- Customer reported **GPT-5.5 missing from Codex picker**. Audit found 6 of 8 provider lists were stale.
- Refresh every hardcoded model catalog across Codex, Claude Code, Gemini, Copilot, Cursor, and Grok to match each vendor's current offerings as of 2026-05-03.
- OpenCode and Pi already discover dynamically via their CLIs; their hardcoded fallbacks were also refreshed.

## Per-provider changes
| Provider | What changed |
|---|---|
| Codex | +`gpt-5.5` (chatgpt-only), `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark` (chatgpt-only), `gpt-5.2`. Rewrote auth-mode comment. |
| Claude Code | +`opus[1m]`, `sonnet[1m]`, `opusplan`. Split effort levels: Opus 4.7 gets `xhigh`, Sonnet doesn't. |
| Gemini | +`gemini-3.1-flash-lite`. Reordered (3.1 Pro Preview first). Noted `gemini-3-pro-preview` deprecation (2026-03-09). |
| Copilot | Replaced 4-entry list with 9 modern entries incl. `auto`, `gpt-5.5`, `gpt-5.4`, Sonnet 4.6, Haiku 4.5, Opus 4.7. |
| Cursor | +`composer-2` (the missing flagship — referenced in active forum thread), `gpt-5.5`, `gpt-5.4`, `gemini-3-flash`. Bumped `opus-4.6` → `opus-4.7`. |
| Grok | +`grok-4.3` (xAI's new recommended default), `grok-4-fast`, `grok-4.1-fast`. Dropped legacy `grok-3`/`grok-3-fast`. |
| OpenCode | Refreshed `listModels()` fallback list. |
| Pi | Refreshed `listModels()` fallback list. |

## Test changes
One test in `action-dispatcher.test.ts` asserted that `xhigh` effort was non-portable to claude-code. That assumption changed because Opus 4.7 actually supports `xhigh` per Anthropic's docs. Test now uses `none` (which is genuinely Codex-only) to validate the same drop-when-unsupported behavior.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean (only pre-existing `_workdir` unused-arg warnings)
- [x] All 16 agent provider/adapter tests pass per file
- [ ] Manual: open the model picker in dev and verify each provider shows the new entries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Updated model catalogs across multiple AI provider integrations (Codex CLI, Copilot CLI, Cursor CLI, Gemini CLI, Grok CLI, OpenCode, Pi CLI)
  * Added support for newer AI models (GPT-5.x variants, Claude Opus 4.7, Gemini 3.1, Grok 4.x)
  * Removed outdated models from provider offerings
  * Enhanced Claude Code provider with improved per-model thinking effort configurations

* **Tests**
  * Updated provider mismatch test scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->