### PR TITLE
fix(terminal): make /api/daemon/pty reachable from non-local browsers

### DIFF
--- a/cabinetai/src/commands/run.ts
+++ b/cabinetai/src/commands/run.ts
@@ -109,7 +109,10 @@ async function runCabinet(opts: { appVersion?: string; open?: boolean }): Promis
     CABINET_APP_ORIGIN: appOrigin,
     CABINET_DAEMON_PORT: String(daemonPort),
     CABINET_DAEMON_URL: daemonOrigin,
-    CABINET_PUBLIC_DAEMON_ORIGIN: daemonWsOrigin,
+    // Note: do not pin CABINET_PUBLIC_DAEMON_ORIGIN here. The /api/daemon/auth
+    // route derives the browser-visible WS origin from the request Host so a
+    // remote browser connects to the same hostname it reached the app on. Set
+    // CABINET_PUBLIC_DAEMON_ORIGIN explicitly only when serving behind a proxy.
   };
 
   log("Starting Next.js server...");

--- a/src/app/api/daemon/auth/route.ts
+++ b/src/app/api/daemon/auth/route.ts
@@ -1,8 +1,11 @@
-import { NextResponse } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 import { getOrCreateDaemonToken } from "@/lib/agents/daemon-auth";
-import { getPublicDaemonWsOrigin } from "@/lib/runtime/runtime-config";
+import { getPublicDaemonWsOriginForRequest } from "@/lib/runtime/runtime-config";
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   const token = await getOrCreateDaemonToken();
-  return NextResponse.json({ token, wsOrigin: getPublicDaemonWsOrigin() });
+  return NextResponse.json({
+    token,
+    wsOrigin: getPublicDaemonWsOriginForRequest(request),
+  });
 }

--- a/src/lib/runtime/runtime-config.ts
+++ b/src/lib/runtime/runtime-config.ts
@@ -155,6 +155,42 @@ export function getPublicDaemonWsOrigin(): string {
   return origin.replace(/^http:/, "ws:");
 }
 
+/**
+ * Browser-visible daemon WS origin: explicit public override wins; otherwise
+ * use the request host with the daemon port so LAN/remote browsers connect to
+ * the same hostname they reached the app on.
+ */
+export function getPublicDaemonWsOriginForRequest(
+  request: { headers: Headers } | null | undefined
+): string {
+  const explicit = normalizeOrigin(process.env.CABINET_PUBLIC_DAEMON_ORIGIN);
+  if (explicit) {
+    if (explicit.startsWith("ws://") || explicit.startsWith("wss://")) return explicit;
+    if (explicit.startsWith("https://")) return explicit.replace(/^https:/, "wss:");
+    if (explicit.startsWith("http://")) return explicit.replace(/^http:/, "ws:");
+    // Scheme-less value (e.g. "cabinet.example.com") would be rejected by the
+    // browser's WebSocket constructor. Treat as malformed and fall through
+    // to Host-derived defaulting below.
+  }
+
+  const rawHost = request?.headers.get("host")?.trim();
+  if (rawHost) {
+    try {
+      const proto = request?.headers.get("x-forwarded-proto")?.split(",")[0]?.trim();
+      // Use new URL() so IPv6 hosts like "[::1]:4000" parse correctly.
+      const url = new URL(`${proto === "https" ? "https" : "http"}://${rawHost}`);
+      url.protocol = proto === "https" ? "wss:" : "ws:";
+      url.port = String(getDaemonPort());
+      url.pathname = "";
+      return url.origin;
+    } catch {
+      // Malformed Host — fall through to loopback fallback.
+    }
+  }
+
+  return getPublicDaemonWsOrigin();
+}
+
 export function getDaemonUrl(): string {
   return (
     normalizeOrigin(process.env.CABINET_DAEMON_URL) ||

--- a/test/daemon-ws-origin-for-request.test.ts
+++ b/test/daemon-ws-origin-for-request.test.ts
@@ -1,0 +1,140 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getPublicDaemonWsOriginForRequest } from "@/lib/runtime/runtime-config";
+
+const ORIGINAL_PUBLIC = process.env.CABINET_PUBLIC_DAEMON_ORIGIN;
+const ORIGINAL_PORT = process.env.CABINET_DAEMON_PORT;
+
+function withEnv(env: Record<string, string | undefined>, fn: () => void) {
+  const prev: Record<string, string | undefined> = {};
+  for (const [k, v] of Object.entries(env)) {
+    prev[k] = process.env[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  try {
+    fn();
+  } finally {
+    for (const [k, v] of Object.entries(prev)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+function fakeReq(headers: Record<string, string>) {
+  return { headers: new Headers(headers) };
+}
+
+// Pin the daemon port for deterministic assertions across machines.
+test.before(() => {
+  process.env.CABINET_DAEMON_PORT = "4100";
+});
+
+test.after(() => {
+  if (ORIGINAL_PORT === undefined) delete process.env.CABINET_DAEMON_PORT;
+  else process.env.CABINET_DAEMON_PORT = ORIGINAL_PORT;
+  if (ORIGINAL_PUBLIC === undefined) delete process.env.CABINET_PUBLIC_DAEMON_ORIGIN;
+  else process.env.CABINET_PUBLIC_DAEMON_ORIGIN = ORIGINAL_PUBLIC;
+});
+
+// --- Explicit override branch ---------------------------------------------
+
+test("explicit ws:// override is returned as-is", () => {
+  withEnv({ CABINET_PUBLIC_DAEMON_ORIGIN: "ws://cabinet.example.com:4100" }, () => {
+    const out = getPublicDaemonWsOriginForRequest(fakeReq({ host: "evil.invalid:4000" }));
+    assert.equal(out, "ws://cabinet.example.com:4100");
+  });
+});
+
+test("explicit wss:// override is returned as-is", () => {
+  withEnv({ CABINET_PUBLIC_DAEMON_ORIGIN: "wss://cabinet.example.com" }, () => {
+    const out = getPublicDaemonWsOriginForRequest(fakeReq({ host: "evil.invalid:4000" }));
+    assert.equal(out, "wss://cabinet.example.com");
+  });
+});
+
+test("explicit http:// override is upgraded to ws://", () => {
+  withEnv({ CABINET_PUBLIC_DAEMON_ORIGIN: "http://cabinet.example.com:4100" }, () => {
+    const out = getPublicDaemonWsOriginForRequest(fakeReq({ host: "evil.invalid:4000" }));
+    assert.equal(out, "ws://cabinet.example.com:4100");
+  });
+});
+
+test("explicit https:// override is upgraded to wss://", () => {
+  withEnv({ CABINET_PUBLIC_DAEMON_ORIGIN: "https://cabinet.example.com" }, () => {
+    const out = getPublicDaemonWsOriginForRequest(fakeReq({ host: "evil.invalid:4000" }));
+    assert.equal(out, "wss://cabinet.example.com");
+  });
+});
+
+// --- Host-header derivation (the LAN/remote-browser fix) -------------------
+
+test("LAN browser: derives ws://<host>:<daemonPort> from Host header", () => {
+  withEnv({ CABINET_PUBLIC_DAEMON_ORIGIN: undefined }, () => {
+    const out = getPublicDaemonWsOriginForRequest(fakeReq({ host: "192.168.1.50:4000" }));
+    assert.equal(out, "ws://192.168.1.50:4100");
+  });
+});
+
+test("Bonjour .local hostname is preserved", () => {
+  withEnv({ CABINET_PUBLIC_DAEMON_ORIGIN: undefined }, () => {
+    const out = getPublicDaemonWsOriginForRequest(fakeReq({ host: "my-mac.local:4000" }));
+    assert.equal(out, "ws://my-mac.local:4100");
+  });
+});
+
+test("reverse proxy: x-forwarded-proto: https → wss://", () => {
+  withEnv({ CABINET_PUBLIC_DAEMON_ORIGIN: undefined }, () => {
+    const out = getPublicDaemonWsOriginForRequest(
+      fakeReq({ host: "cabinet.example.com", "x-forwarded-proto": "https" })
+    );
+    assert.equal(out, "wss://cabinet.example.com:4100");
+  });
+});
+
+test("x-forwarded-proto with comma-list takes the first proto", () => {
+  withEnv({ CABINET_PUBLIC_DAEMON_ORIGIN: undefined }, () => {
+    const out = getPublicDaemonWsOriginForRequest(
+      fakeReq({ host: "cabinet.example.com", "x-forwarded-proto": "https, http" })
+    );
+    assert.equal(out, "wss://cabinet.example.com:4100");
+  });
+});
+
+test("IPv6 host like [::1]:4000 parses correctly and gets daemon port", () => {
+  withEnv({ CABINET_PUBLIC_DAEMON_ORIGIN: undefined }, () => {
+    const out = getPublicDaemonWsOriginForRequest(fakeReq({ host: "[::1]:4000" }));
+    assert.equal(out, "ws://[::1]:4100");
+  });
+});
+
+test("loopback Host stays loopback (single-host case still works)", () => {
+  withEnv({ CABINET_PUBLIC_DAEMON_ORIGIN: undefined }, () => {
+    const out = getPublicDaemonWsOriginForRequest(fakeReq({ host: "127.0.0.1:4000" }));
+    assert.equal(out, "ws://127.0.0.1:4100");
+  });
+});
+
+// --- Fallback branches -----------------------------------------------------
+
+test("scheme-less explicit override falls through to Host derivation", () => {
+  withEnv({ CABINET_PUBLIC_DAEMON_ORIGIN: "cabinet.example.com" }, () => {
+    const out = getPublicDaemonWsOriginForRequest(fakeReq({ host: "192.168.1.50:4000" }));
+    assert.equal(out, "ws://192.168.1.50:4100");
+  });
+});
+
+test("missing Host header falls back to loopback (legacy helper)", () => {
+  withEnv({ CABINET_PUBLIC_DAEMON_ORIGIN: undefined }, () => {
+    const out = getPublicDaemonWsOriginForRequest(fakeReq({}));
+    assert.match(out, /^ws:\/\/127\.0\.0\.1:4100$/);
+  });
+});
+
+test("null request falls back to loopback", () => {
+  withEnv({ CABINET_PUBLIC_DAEMON_ORIGIN: undefined }, () => {
+    const out = getPublicDaemonWsOriginForRequest(null);
+    assert.match(out, /^ws:\/\/127\.0\.0\.1:4100$/);
+  });
+});


### PR DESCRIPTION
## Why

When Cabinet is started on one machine and the browser opens it from another (LAN box, home server, VPS, anywhere not the same host), the **Terminal** pane never connects. The auth handshake hands the browser a hard-coded loopback WS origin, so the browser ends up dialling its own machine on `ws://127.0.0.1:4100/api/daemon/pty` instead of the actual cabinet host. Connection refused, "Connection error. Run `npm run dev:all`" toast appears.

This was raised in Discord — running `npx cabinetai run` on a Linux box on the home network, opening it from another machine on the same LAN, terminal fails.

## Root cause

1. `src/components/terminal/web-terminal.tsx` builds the WS URL from `auth.wsOrigin` returned by `/api/daemon/auth`.
2. `/api/daemon/auth` returns `getPublicDaemonWsOrigin()`.
3. `cabinetai/src/commands/run.ts` (and the persisted `runtime-ports.json#daemon.wsOrigin`) hard-code that to `ws://127.0.0.1:<daemonPort>` at startup, **even clobbering a user-supplied `CABINET_PUBLIC_DAEMON_ORIGIN` env var**.

So even the documented `.env` override (`# CABINET_PUBLIC_DAEMON_ORIGIN=ws://...`) didn't work for `npx cabinetai run`.

The Node daemon already binds to `0.0.0.0` (default for `server.listen(PORT)` with no host arg), so the daemon port is reachable from LAN — only the URL handed to the browser was wrong.

## Fix

Two small, focused changes:

1. **`cabinetai/src/commands/run.ts`** — stop pinning loopback. `CABINET_PUBLIC_DAEMON_ORIGIN` is forwarded to the app process only if the operator set one; the persisted `runtime-ports.json#daemon.wsOrigin` is set only when explicit. No baked-in default.

2. **`/api/daemon/auth` + `runtime-config.ts`** — new `getPublicDaemonWsOriginForRequest(request)` resolves wsOrigin per request:
   1. Explicit `CABINET_PUBLIC_DAEMON_ORIGIN` (env or persisted) wins — public hostname / reverse-proxy setups.
   2. Otherwise derive from the inbound `Host` header, keeping the daemon port and honouring `x-forwarded-proto` for `wss://`.
   3. Loopback only as a last-resort fallback.

So a browser hitting `http://192.168.1.50:4000/api/daemon/auth` is told to dial `ws://192.168.1.50:4100/api/daemon/pty` — which works.

Electron and `scripts/dev-daemon.mjs` aren't touched: they always serve to a colocated browser, so loopback there is correct and stays as-is.

## Behaviour matrix

| Scenario | Before | After |
| --- | --- | --- |
| `npx cabinetai run` on local box, browser on same machine | Works (loopback) | Works (Host = `127.0.0.1` or `localhost`) |
| `npx cabinetai run` on LAN box, browser elsewhere on LAN | **Broken** (browser dials own loopback) | **Works** (Host = LAN IP/hostname) |
| Behind a reverse proxy / public domain | Broken unless ENV set, but ENV was clobbered | Works via explicit `CABINET_PUBLIC_DAEMON_ORIGIN` (now actually honoured) or via `x-forwarded-proto` + Host |
| Electron desktop app | Works (loopback) | Unchanged — still loopback |
| `npm run dev:daemon` (scripts/dev-daemon.mjs) | Works (loopback) | Unchanged — still loopback |

## Notes

- The legacy `getPublicDaemonWsOrigin()` is kept as a no-arg fallback (used internally and as the "no Host header" branch) so any other call site keeps working.
- For HTTPS deployments behind a proxy, the daemon port still has to be reachable from the browser. A future improvement could proxy the WS through Next.js so it lives on the same origin/port, but that's a bigger change and not required to unblock the LAN case.
- No new env vars. No migration. `CABINET_PUBLIC_DAEMON_ORIGIN` documented in `.env.example` now actually does what the comment says.

## Test

- Manual: `lint` clean on touched files; type-check on the runtime-config / auth-route / run.ts edits is clean (pre-existing tiptap/commander errors are unrelated).
- Suggested manual smoke (didn't have a remote box handy): start `npx cabinetai run` on host A, open `http://<A-LAN-IP>:4000` from host B, open the Terminal pane — should connect to `ws://<A-LAN-IP>:4100/api/daemon/pty`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added syntax highlighting support via highlight.js library
  * Implemented automatic daemon WebSocket origin detection from request headers

* **Improvements**
  * Simplified daemon configuration by deriving connection parameters from incoming requests instead of explicit environment variables
<!-- end of auto-generated comment: release notes by coderabbit.ai -->