### PR TITLE
fix(cli/daemon/onboarding): EMFILE recovery + CLI parity + Reset onboarding fix

### DIFF
--- a/cabinetai/src/commands/reset-config.ts
+++ b/cabinetai/src/commands/reset-config.ts
@@ -1,0 +1,67 @@
+import type { Command } from "commander";
+import fs from "fs";
+import path from "path";
+import { log, success, warning, error } from "../lib/log.js";
+import { confirm } from "../lib/prompt.js";
+import { CABINET_MANIFEST, findCabinetRoot } from "../lib/paths.js";
+
+export function registerResetConfig(program: Command): void {
+  program
+    .command("reset-config")
+    .description(
+      "Forget the current cabinet binding by removing the .cabinet manifest. " +
+        "Content stays — only the marker file is deleted, so the next `cabinetai run` " +
+        "treats this directory as a fresh location."
+    )
+    .option(
+      "-y, --yes",
+      "Don't prompt for confirmation (use in scripts; default is interactive)"
+    )
+    .action(async (opts: { yes?: boolean }) => {
+      try {
+        await resetConfig(opts);
+      } catch (err) {
+        error(err instanceof Error ? err.message : String(err));
+      }
+    });
+}
+
+async function resetConfig(opts: { yes?: boolean }): Promise<void> {
+  const cwd = process.cwd();
+  const cabinetDir = findCabinetRoot(cwd);
+  if (!cabinetDir) {
+    log(`No .cabinet manifest found from ${cwd} upward — nothing to reset.`);
+    return;
+  }
+
+  const manifestPath = path.join(cabinetDir, CABINET_MANIFEST);
+  console.log("");
+  warning("This will remove the cabinet manifest:");
+  console.log(`    ${manifestPath}`);
+  console.log("");
+  console.log(
+    `  Your content (${cabinetDir}) stays untouched — only the marker file is deleted.\n` +
+      "  After reset, the next `cabinetai run` will treat your cwd as a fresh location\n" +
+      "  (and either find a different ancestor cabinet, or bootstrap a new one)."
+  );
+  console.log("");
+
+  const ok = opts.yes ? true : await confirm("Remove the manifest?", false);
+  if (!ok) {
+    log("Cancelled — nothing changed.");
+    return;
+  }
+
+  try {
+    fs.unlinkSync(manifestPath);
+    success(`Removed ${manifestPath}`);
+    log(
+      `Cabinet at ${cabinetDir} is no longer bound. Run \`cabinetai run --data-dir <path>\` ` +
+        `to bind a different directory, or \`cabinetai run\` to bootstrap from your cwd.`
+    );
+  } catch (err) {
+    error(
+      `Failed to remove ${manifestPath}: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}

--- a/cabinetai/src/commands/run.ts
+++ b/cabinetai/src/commands/run.ts
@@ -1,10 +1,18 @@
 import type { Command } from "commander";
+import os from "os";
 import path from "path";
 import fs from "fs";
 import { log, success, error, warning } from "../lib/log.js";
 import { ensureApp } from "../lib/app-manager.js";
 import { openBrowser, npmCommand, spawnChild } from "../lib/process.js";
-import { resolveOrBootstrapCabinetRoot } from "../lib/scaffold.js";
+import {
+  bootstrapCabinetAt,
+  resolveCabinetRoot,
+  resolveOrBootstrapCabinetRoot,
+  type ResolvedCabinetRoot,
+} from "../lib/scaffold.js";
+import { CABINET_MANIFEST } from "../lib/paths.js";
+import { confirmOrContinue } from "../lib/prompt.js";
 import {
   parsePort,
   findAvailablePort,
@@ -16,26 +24,223 @@ import {
 } from "../lib/ports.js";
 import { VERSION } from "../version.js";
 
+type ResolutionSource =
+  | "data-dir-flag"
+  | "env-var"
+  | "manifest-here"
+  | "manifest-ancestor"
+  | "bootstrapped";
+
+interface ResolveOptions {
+  dataDirFlag?: string;
+}
+
+/**
+ * Reasons a directory looks like a poor choice to bootstrap as a cabinet.
+ * Returns null for directories that look fine.
+ */
+function looksRiskyForBootstrap(dir: string): string | null {
+  const resolved = path.resolve(dir);
+  if (resolved === os.homedir()) return "this is your home directory";
+  const base = path.basename(resolved).toLowerCase();
+  const devNames = new Set([
+    "developer",
+    "development",
+    "projects",
+    "code",
+    "src",
+    "source",
+    "workspace",
+    "repos",
+    "git",
+    "github",
+  ]);
+  if (devNames.has(base)) return `"${path.basename(resolved)}" looks like a dev folder`;
+  try {
+    const entries = fs.readdirSync(resolved, { withFileTypes: true });
+    const subdirs = entries.filter((e) => e.isDirectory() && !e.name.startsWith(".")).length;
+    if (subdirs > 50) return `${subdirs} subdirectories — likely too broad for a single cabinet`;
+  } catch {
+    // unreadable cwd; let the rest of the flow surface the real error
+  }
+  return null;
+}
+
+async function resolveCabinetDir(opts: ResolveOptions): Promise<{
+  resolved: ResolvedCabinetRoot;
+  source: ResolutionSource;
+}> {
+  // 1. Explicit --data-dir wins over everything else.
+  if (opts.dataDirFlag) {
+    const target = path.resolve(opts.dataDirFlag);
+    fs.mkdirSync(target, { recursive: true });
+    const found = resolveCabinetRoot(target);
+    if (found && !found.resolvedFromAncestor) {
+      // The exact dir already has a manifest — reuse it silently.
+      const existing: ResolvedCabinetRoot = {
+        cabinetDir: found.cabinetDir,
+        name: path.basename(found.cabinetDir),
+        bootstrapped: false,
+        startedFrom: target,
+        resolvedFromAncestor: false,
+      };
+      return { resolved: existing, source: "data-dir-flag" };
+    }
+    // Either nothing here yet, or a parent has one (we ignore that — explicit wins).
+    return { resolved: bootstrapCabinetAt(target), source: "data-dir-flag" };
+  }
+
+  // 2. CABINET_DATA_DIR env var. Same precedence as the daemon's runtime-config.
+  const envDir = process.env.CABINET_DATA_DIR?.trim();
+  if (envDir) {
+    const target = path.resolve(envDir);
+    fs.mkdirSync(target, { recursive: true });
+    const found = resolveCabinetRoot(target);
+    if (found && !found.resolvedFromAncestor) {
+      return {
+        resolved: {
+          cabinetDir: found.cabinetDir,
+          name: path.basename(found.cabinetDir),
+          bootstrapped: false,
+          startedFrom: target,
+          resolvedFromAncestor: false,
+        },
+        source: "env-var",
+      };
+    }
+    return { resolved: bootstrapCabinetAt(target), source: "env-var" };
+  }
+
+  // 3. Walk up from cwd to find an existing cabinet.
+  const found = resolveCabinetRoot();
+  if (found) {
+    if (found.resolvedFromAncestor) {
+      // Surprising case Gareth hit: ran in ~/Developer/cabinet but ~/Developer
+      // already has a .cabinet from a previous run. Make sure the user knows.
+      console.log("");
+      warning(
+        `Found an existing cabinet at a parent of your current directory:`
+      );
+      console.log(`    cabinet root:  ${found.cabinetDir}`);
+      console.log(`    your cwd:      ${found.startedFrom}`);
+      console.log(
+        `    manifest file: ${path.join(found.cabinetDir, CABINET_MANIFEST)}`
+      );
+      console.log("");
+      console.log(
+        "  Cabinet walks up from your cwd looking for a .cabinet file. To run\n" +
+          "  in your current directory instead, pass --data-dir explicitly:\n" +
+          `    cabinetai run --data-dir ${found.startedFrom}`
+      );
+      const proceed = await confirmOrContinue(
+        `Use the cabinet at ${found.cabinetDir}?`,
+        true,
+        true
+      );
+      if (!proceed) {
+        console.log("");
+        log(
+          `Aborted. Re-run with --data-dir to choose a directory, or remove ${path.join(
+            found.cabinetDir,
+            CABINET_MANIFEST
+          )} (cabinetai reset-config) to forget this cabinet.`
+        );
+        process.exit(0);
+      }
+    }
+    return {
+      resolved: {
+        cabinetDir: found.cabinetDir,
+        name: path.basename(found.cabinetDir),
+        bootstrapped: false,
+        startedFrom: found.startedFrom,
+        resolvedFromAncestor: found.resolvedFromAncestor,
+      },
+      source: found.resolvedFromAncestor ? "manifest-ancestor" : "manifest-here",
+    };
+  }
+
+  // 4. About to bootstrap cwd. Warn first if it looks risky.
+  const cwd = path.resolve(process.cwd());
+  const risky = looksRiskyForBootstrap(cwd);
+  if (risky) {
+    console.log("");
+    warning(`About to make this directory a cabinet — but ${risky}.`);
+    console.log(`    target:   ${cwd}`);
+    console.log("");
+    console.log(
+      "  Cabinet indexes every supported file under the cabinet directory.\n" +
+        "  A focused workspace works far better than a full dev folder.\n" +
+        "  Recommended: ~/Documents/Cabinet (or any fresh empty directory).\n" +
+        "\n" +
+        `  To pick a different folder:  cabinetai run --data-dir ~/Documents/Cabinet`
+    );
+    const proceed = await confirmOrContinue(`Continue and bootstrap ${cwd}?`, true, false);
+    if (!proceed) {
+      console.log("");
+      log("Aborted. Pick a fresh empty folder or use --data-dir.");
+      process.exit(0);
+    }
+  }
+
+  return {
+    resolved: resolveOrBootstrapCabinetRoot(cwd),
+    source: "bootstrapped",
+  };
+}
+
+function describeSource(source: ResolutionSource, resolved: ResolvedCabinetRoot): string {
+  switch (source) {
+    case "data-dir-flag":
+      return resolved.bootstrapped ? "--data-dir (bootstrapped)" : "--data-dir";
+    case "env-var":
+      return resolved.bootstrapped
+        ? "CABINET_DATA_DIR (bootstrapped)"
+        : "CABINET_DATA_DIR";
+    case "manifest-here":
+      return "found .cabinet here";
+    case "manifest-ancestor":
+      return `found .cabinet at parent (walked up from ${resolved.startedFrom})`;
+    case "bootstrapped":
+      return "bootstrapped here (no .cabinet found)";
+  }
+}
+
 export function registerRun(program: Command): void {
   program
     .command("run")
     .description("Start Cabinet serving the current cabinet directory")
     .option("--app-version <version>", "Override the app version to use")
     .option("--no-open", "Don't open the browser automatically")
-    .action(async (opts: { appVersion?: string; open?: boolean }) => {
-      try {
-        await runCabinet(opts);
-      } catch (err) {
-        error(err instanceof Error ? err.message : String(err));
+    .option(
+      "--data-dir <path>",
+      "Use this exact directory as the cabinet (skips upward traversal)"
+    )
+    .action(
+      async (opts: {
+        appVersion?: string;
+        open?: boolean;
+        dataDir?: string;
+      }) => {
+        try {
+          await runCabinet(opts);
+        } catch (err) {
+          error(err instanceof Error ? err.message : String(err));
+        }
       }
-    });
+    );
 }
 
-async function runCabinet(opts: { appVersion?: string; open?: boolean }): Promise<void> {
-  // 1. Find or bootstrap the current directory as a cabinet
-  const { cabinetDir, name, bootstrapped } = resolveOrBootstrapCabinetRoot();
+async function runCabinet(opts: {
+  appVersion?: string;
+  open?: boolean;
+  dataDir?: string;
+}): Promise<void> {
+  // 1. Resolve where this cabinet lives (with TTY warnings for surprising cases)
+  const { resolved, source } = await resolveCabinetDir({ dataDirFlag: opts.dataDir });
+  const { cabinetDir, name, bootstrapped } = resolved;
   if (bootstrapped) {
-    success(`Bootstrapped "${name}" in the current directory.`);
+    success(`Bootstrapped "${name}" at ${cabinetDir}`);
   }
 
   const version = opts.appVersion || VERSION;
@@ -50,10 +255,12 @@ async function runCabinet(opts: { appVersion?: string; open?: boolean }): Promis
   `);
 
   log(`Cabinet directory: ${cabinetDir}`);
+  log(`Manifest:          ${path.join(cabinetDir, CABINET_MANIFEST)}`);
+  log(`Source:            ${describeSource(source, resolved)}`);
 
   // 2. Ensure app is installed
   const appDir = await ensureApp(version);
-  log(`App directory: ${appDir}`);
+  log(`App directory:     ${appDir}`);
 
   // 3. Quick doctor: auto-install deps if missing
   if (!fs.existsSync(path.join(appDir, "node_modules", "next"))) {

--- a/cabinetai/src/index.ts
+++ b/cabinetai/src/index.ts
@@ -6,6 +6,7 @@ import { registerUpdate } from "./commands/update.js";
 import { registerImport } from "./commands/import.js";
 import { registerList } from "./commands/list.js";
 import { registerUninstall } from "./commands/uninstall.js";
+import { registerResetConfig } from "./commands/reset-config.js";
 
 import { VERSION } from "./version.js";
 
@@ -23,5 +24,6 @@ registerUpdate(program);
 registerImport(program);
 registerList(program);
 registerUninstall(program);
+registerResetConfig(program);
 
 program.parse();

--- a/cabinetai/src/lib/prompt.ts
+++ b/cabinetai/src/lib/prompt.ts
@@ -5,6 +5,24 @@ export function confirm(question: string, defaultYes = false): Promise<boolean> 
     console.log(`  (non-interactive shell — refusing destructive action)`);
     return Promise.resolve(false);
   }
+  return ask(question, defaultYes);
+}
+
+/**
+ * Prompt-or-default: in non-interactive shells, returns `nonInteractiveDefault`
+ * silently rather than refusing. Use for soft warnings where we want to keep
+ * existing behavior unchanged for CI/scripts.
+ */
+export function confirmOrContinue(
+  question: string,
+  nonInteractiveDefault: boolean,
+  defaultYes = true
+): Promise<boolean> {
+  if (!process.stdin.isTTY) return Promise.resolve(nonInteractiveDefault);
+  return ask(question, defaultYes);
+}
+
+function ask(question: string, defaultYes: boolean): Promise<boolean> {
   const suffix = defaultYes ? "[Y/n]" : "[y/N]";
   return new Promise((resolve) => {
     const rl = readline.createInterface({

--- a/cabinetai/src/lib/scaffold.ts
+++ b/cabinetai/src/lib/scaffold.ts
@@ -17,6 +17,15 @@ export interface ResolvedCabinetRoot {
   cabinetDir: string;
   name: string;
   bootstrapped: boolean;
+  /**
+   * The directory the user started from (typically process.cwd()).
+   * When upward traversal found a parent `.cabinet`, `cabinetDir !== startedFrom`
+   * and the caller can warn the user that an existing cabinet was reused
+   * instead of treating their current dir as a fresh cabinet.
+   */
+  startedFrom: string;
+  /** True when findCabinetRoot walked up to an ancestor, not cwd itself. */
+  resolvedFromAncestor: boolean;
 }
 
 function buildCabinetManifest(
@@ -99,30 +108,50 @@ export function scaffoldCabinetDir(
   return manifest;
 }
 
-export function resolveOrBootstrapCabinetRoot(
+export function resolveCabinetRoot(
   startDir = process.cwd()
-): ResolvedCabinetRoot {
-  const cabinetDir = findCabinetRoot(startDir);
-  if (cabinetDir) {
-    return {
-      cabinetDir,
-      name: inferCabinetName(cabinetDir),
-      bootstrapped: false,
-    };
-  }
+): { cabinetDir: string; startedFrom: string; resolvedFromAncestor: boolean } | null {
+  const startedFrom = path.resolve(startDir);
+  const cabinetDir = findCabinetRoot(startedFrom);
+  if (!cabinetDir) return null;
+  return {
+    cabinetDir,
+    startedFrom,
+    resolvedFromAncestor: path.resolve(cabinetDir) !== startedFrom,
+  };
+}
 
-  const targetDir = path.resolve(startDir);
-  const name = inferCabinetName(targetDir);
+export function bootstrapCabinetAt(targetDir: string): ResolvedCabinetRoot {
+  const resolved = path.resolve(targetDir);
+  const name = inferCabinetName(resolved);
   scaffoldCabinetDir({
-    targetDir,
+    targetDir: resolved,
     name,
     kind: "root",
     preserveIndex: true,
   });
-
   return {
-    cabinetDir: targetDir,
+    cabinetDir: resolved,
     name,
     bootstrapped: true,
+    startedFrom: resolved,
+    resolvedFromAncestor: false,
   };
+}
+
+export function resolveOrBootstrapCabinetRoot(
+  startDir = process.cwd()
+): ResolvedCabinetRoot {
+  const startedFrom = path.resolve(startDir);
+  const found = resolveCabinetRoot(startedFrom);
+  if (found) {
+    return {
+      cabinetDir: found.cabinetDir,
+      name: inferCabinetName(found.cabinetDir),
+      bootstrapped: false,
+      startedFrom,
+      resolvedFromAncestor: found.resolvedFromAncestor,
+    };
+  }
+  return bootstrapCabinetAt(startedFrom);
 }

--- a/server/cabinet-daemon.ts
+++ b/server/cabinet-daemon.ts
@@ -31,7 +31,7 @@ import yaml from "js-yaml";
 import chokidar from "chokidar";
 import matter from "gray-matter";
 import { getDb, closeDb } from "./db";
-import { DATA_DIR } from "../src/lib/storage/path-utils";
+import { DATA_DIR, isHiddenEntry } from "../src/lib/storage/path-utils";
 import { discoverCabinetPathsSync } from "../src/lib/cabinets/discovery";
 import { resolveCabinetDir } from "../src/lib/cabinets/server-paths";
 import {
@@ -91,6 +91,141 @@ import {
 
 const PORT = getDaemonPort();
 const CABINET_MANIFEST_FILE = ".cabinet";
+
+// ===== Watcher backend probe =====
+// Cabinet uses chokidar v5, which drops fsevents support and watches via
+// node:fs.watch on every platform. fs.watch is per-directory: it opens one
+// kernel handle (FSEvents stream on macOS, inotify watch on linux,
+// ReadDirectoryChangesW on windows) per directory, each using one fd. So
+// large trees exhaust `ulimit -n` regardless of platform — there is no
+// "recursive single-fd" path. We still log the platform for support reports.
+type WatcherBackend = {
+  platform: NodeJS.Platform;
+  fdPerDir: boolean;
+  description: string;
+};
+
+let cachedWatcherBackend: WatcherBackend | null = null;
+
+function probeWatcherBackend(): WatcherBackend {
+  if (cachedWatcherBackend) return cachedWatcherBackend;
+  // Note: chokidar 5.x is in package.json. If a downgrade adds an FSEvents
+  // path back in, update this probe and the big-tree guard below.
+  let chokidarVersion = "unknown";
+  try {
+    const chokidarPkgPath = path.join(
+      process.cwd(),
+      "node_modules",
+      "chokidar",
+      "package.json"
+    );
+    chokidarVersion = JSON.parse(fs.readFileSync(chokidarPkgPath, "utf-8")).version;
+  } catch {
+    /* leave as unknown */
+  }
+  const perPlatform: Record<string, string> = {
+    darwin: "node fs.watch via FSEvents stream (one fd per directory)",
+    linux: "node fs.watch via inotify (one watch per directory; see /proc/sys/fs/inotify/max_user_watches)",
+    win32: "node fs.watch via ReadDirectoryChangesW (one handle per directory)",
+  };
+  cachedWatcherBackend = {
+    platform: process.platform,
+    fdPerDir: true, // chokidar v5 is always per-dir
+    description: `chokidar ${chokidarVersion} → ${
+      perPlatform[process.platform] ?? `node fs.watch (platform=${process.platform})`
+    }`,
+  };
+  return cachedWatcherBackend;
+}
+
+// ===== Big-tree guard =====
+// When the watcher backend opens one fd per directory, even ulimit -n 65536
+// can be exhausted by a real dev tree (node_modules adds tens of thousands).
+// Pre-flight: count dirs respecting the same ignore rules as the indexer,
+// early-exit at MAX_DIRS, and abort startup with a friendly message if we'd
+// definitely blow the limit. Cheap (~tens of ms even on huge trees) because
+// we stop counting as soon as we cross the threshold.
+const BIG_TREE_DIR_THRESHOLD = 1500;
+
+async function countWatchableDirs(maxBeforeAbort: number): Promise<number> {
+  let count = 0;
+  const stack: string[] = [DATA_DIR];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    count += 1;
+    if (count > maxBeforeAbort) return count;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (isHiddenEntry(entry.name)) continue;
+      stack.push(path.join(dir, entry.name));
+    }
+  }
+  return count;
+}
+
+function getOpenFileLimit(): number | null {
+  // posix_getrlimit isn't in Node's stdlib. We could shell out to `ulimit`,
+  // but the simplest check is: try to read it from `process.getrlimit?.()`
+  // (added in Node 22) or fall back to null and skip the check.
+  const proc = process as unknown as {
+    getrlimit?: (resource: string) => { soft: number; hard: number };
+  };
+  if (typeof proc.getrlimit !== "function") return null;
+  try {
+    return proc.getrlimit("nofile").soft;
+  } catch {
+    return null;
+  }
+}
+
+async function guardAgainstBigTree(): Promise<void> {
+  const backend = probeWatcherBackend();
+  if (!backend.fdPerDir) return; // FSEvents/ReadDirectoryChangesW are O(1) in fds
+  const dirCount = await countWatchableDirs(BIG_TREE_DIR_THRESHOLD);
+  const ulimit = getOpenFileLimit();
+  const ulimitTooLow = ulimit !== null && ulimit < 4096;
+  if (dirCount <= BIG_TREE_DIR_THRESHOLD && !ulimitTooLow) return;
+
+  const lines = [
+    "",
+    "  ╭─ Cabinet refused to start ─────────────────────────────────────────",
+    "  │",
+    `  │  Cabinet directory: ${DATA_DIR}`,
+    `  │  Watchable directories: ${dirCount > BIG_TREE_DIR_THRESHOLD ? `>${BIG_TREE_DIR_THRESHOLD}` : dirCount}` +
+      (ulimit !== null ? `   |   ulimit -n: ${ulimit}` : ""),
+    `  │  Watcher backend: ${backend.description}`,
+    "  │",
+    "  │  This combination will exhaust file-descriptor limits and crash with",
+    "  │  EMFILE. Pick a focused workspace instead of your full dev folder:",
+    "  │",
+    "  │    cabinetai run --data-dir ~/Documents/Cabinet",
+    "  │    # or:  CABINET_DATA_DIR=~/Documents/Cabinet cabinetai run",
+    "  │    # or:  cabinetai reset-config && cabinetai run",
+    "  │",
+    "  │  If you really meant this directory, raise the descriptor limit and",
+    "  │  set CABINET_ALLOW_BIG_TREE=1 to bypass this check:",
+    "  │",
+    "  │    ulimit -n 65536 && CABINET_ALLOW_BIG_TREE=1 cabinetai run",
+    "  │",
+    "  ╰────────────────────────────────────────────────────────────────────",
+    "",
+  ];
+  if (process.env.CABINET_ALLOW_BIG_TREE === "1") {
+    console.warn(
+      `[cabinet-daemon] big-tree guard bypassed by CABINET_ALLOW_BIG_TREE=1 ` +
+        `(${dirCount > BIG_TREE_DIR_THRESHOLD ? ">" : ""}${dirCount} dirs, platform=${backend.platform})`
+    );
+    return;
+  }
+  for (const line of lines) console.error(line);
+  process.exit(1);
+}
 
 // ===== Search index =====
 
@@ -1717,6 +1852,24 @@ scheduleWatcher.on("all", () => {
   queueScheduleReload();
 });
 
+// Same EMFILE/ENOSPC failure mode as the search watcher — log once, close,
+// keep the daemon up. Schedule reloads pause; the rest of the daemon (jobs,
+// API, sessions) keeps serving.
+let scheduleWatcherFailed = false;
+scheduleWatcher.on("error", (err: unknown) => {
+  if (scheduleWatcherFailed) return;
+  scheduleWatcherFailed = true;
+  const code = (err as NodeJS.ErrnoException)?.code;
+  const msg = err instanceof Error ? err.message : String(err);
+  console.warn(
+    `[schedule-watcher] disabled: ${code ?? "error"} — ${msg}.\n` +
+      `  Schedule changes won't auto-reload. POST /reload-schedules to refresh manually.`
+  );
+  void scheduleWatcher.close().catch(() => {
+    /* already closing */
+  });
+});
+
 server.listen(PORT, () => {
   console.log(`Cabinet Daemon running on port ${PORT}`);
   console.log(`  Terminal WebSocket: ws://localhost:${PORT}/api/daemon/pty`);
@@ -1728,6 +1881,8 @@ server.listen(PORT, () => {
   console.log(`  Search endpoint: GET http://localhost:${PORT}/search`);
   console.log(`  Default provider: ${resolveProviderId()}`);
   console.log(`  Working directory: ${DATA_DIR}`);
+  const watcherBackend = probeWatcherBackend();
+  console.log(`  Watcher backend: ${watcherBackend.description}`);
 
   getOrCreateSessionId();
   printStartupBannerIfNeeded();
@@ -1754,7 +1909,9 @@ server.listen(PORT, () => {
       }
     });
   });
-  void bootstrapSearchIndex().then(() => startSearchWatcher());
+  void guardAgainstBigTree().then(() =>
+    bootstrapSearchIndex().then(() => startSearchWatcher())
+  );
   void (async () => {
     try {
       const { loadExternalAdapters } = await import(

--- a/server/search/watcher.ts
+++ b/server/search/watcher.ts
@@ -72,5 +72,36 @@ export function startWatcher(
   watcher.on("change", (p) => schedule(p, "change"));
   watcher.on("unlink", (p) => schedule(p, "remove"));
 
+  // EMFILE / ENOSPC fire when the kernel runs out of file descriptors / inotify
+  // watches. Without this handler, every error becomes an unhandled rejection
+  // and chokidar keeps retrying — flooding the log with thousands of identical
+  // traces. We log once, close the watcher, and leave the daemon up. Live
+  // updates stop, but search/UI still work; the user sees a clear next step.
+  let watcherFailed = false;
+  watcher.on("error", (err: unknown) => {
+    if (watcherFailed) return;
+    watcherFailed = true;
+    const code = (err as NodeJS.ErrnoException)?.code;
+    const msg = err instanceof Error ? err.message : String(err);
+    if (code === "EMFILE" || code === "ENOSPC") {
+      console.warn(
+        `[search-watcher] disabled: ${code} (file watch limit exhausted on ${DATA_DIR}).\n` +
+          `  Live updates are off. Search results still work but won't auto-refresh.\n` +
+          `  Cabinet uses chokidar v5, which opens one OS handle per directory, so\n` +
+          `  large trees can exhaust the limit even with ulimit -n raised.\n` +
+          `  Fix options:\n` +
+          `    1. Pick a smaller cabinet directory:  cabinetai run --data-dir ~/Documents/Cabinet\n` +
+          `    2. Forget the current binding:        cabinetai reset-config\n` +
+          `    3. Raise the descriptor limit:        ulimit -n 65536  (macOS/Linux)\n` +
+          `    4. Linux only: bump inotify watches: sudo sysctl fs.inotify.max_user_watches=524288`
+      );
+    } else {
+      console.warn(`[search-watcher] disabled: ${code ?? "error"} — ${msg}`);
+    }
+    void watcher.close().catch(() => {
+      /* already closing */
+    });
+  });
+
   return watcher;
 }

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -113,6 +113,21 @@ import { useEditorStore } from "@/stores/editor-store";
 
 const DISMISSED_UPDATE_STORAGE_KEY = "cabinet.dismissed-update-version";
 const WIZARD_DONE_STORAGE_KEY = "cabinet.wizard-done";
+// sessionStorage key set by Settings → Storage → Reset onboarding. While
+// present we (a) skip the silent-accept of dataDirConfirmed and (b) skip the
+// agents-config self-correction that would otherwise rewrite wizard-done="1"
+// from server state — both of which silently undid Reset before this guard.
+// Cleared when the wizard completes; auto-clears on tab close (sessionStorage).
+export const ONBOARDING_RESET_MARKER_KEY = "cabinet.onboarding-reset-in-progress";
+
+function isOnboardingResetInProgress(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.sessionStorage.getItem(ONBOARDING_RESET_MARKER_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
 
 // useLayoutEffect logs a no-op warning during SSR; alias to useEffect on the
 // server so we get pre-paint sync on the client without console noise.
@@ -158,9 +173,20 @@ export function AppShell() {
   const [showDataDirPrompt, setShowDataDirPrompt] = useState<boolean>(false);
   useIsoLayoutEffect(() => {
     try {
+      const resetting = isOnboardingResetInProgress();
       const wizardDone =
         window.localStorage.getItem(WIZARD_DONE_STORAGE_KEY) === "1";
-      if (wizardDone) {
+      if (resetting) {
+        // Explicit reset in progress: re-show the data-dir picker (with the
+        // current folder pre-filled) so the user can confirm or change it
+        // before the wizard re-runs. Do NOT silent-accept dataDirConfirmed —
+        // that would skip the picker the user just asked to see again.
+        if (!isDataDirConfirmed()) {
+          setShowDataDirPrompt(true);
+        }
+        // Leave showWizard=null so the agents-config effect (below) can flip
+        // it to true regardless of whether workspace.json exists on disk.
+      } else if (wizardDone) {
         setShowWizard(false);
         // Existing user — silent-accept their current data dir choice so the
         // first-launch picker never ambushes them post-update.
@@ -389,6 +415,14 @@ export function AppShell() {
       dedupFetch("/api/agents/config")
         .then((r) => r.json())
         .then((data) => {
+          // While Reset onboarding is in progress, force the wizard to show
+          // even though workspace.json still exists on disk. Without this the
+          // self-correction below silently rewrites wizard-done="1" within a
+          // second of reload and undoes the reset the user just requested.
+          if (isOnboardingResetInProgress()) {
+            setShowWizard(true);
+            return;
+          }
           const done = !!data.exists;
           setShowWizard(!done);
           if (done) {
@@ -479,6 +513,9 @@ export function AppShell() {
       window.localStorage.setItem("cabinet.tasks.v2.view", "kanban");
       window.localStorage.setItem("cabinet.tasks.v2.trigger", "all");
       window.localStorage.removeItem("cabinet.tasks.v2.agent");
+      // Onboarding flow finished — drop the reset marker so the next page
+      // load goes through the normal silent-accept path.
+      window.sessionStorage.removeItem(ONBOARDING_RESET_MARKER_KEY);
     } catch {
       // ignore
     }

--- a/src/components/settings/data-locations-section.tsx
+++ b/src/components/settings/data-locations-section.tsx
@@ -20,6 +20,7 @@ import {
   listMatchingLocalStorageKeys,
 } from "@/lib/data-locations/client-registry";
 import type { DataLocation, DataLocationSnapshot } from "@/lib/data-locations/types";
+import { ONBOARDING_RESET_MARKER_KEY } from "@/components/layout/app-shell";
 
 function formatBytes(bytes: number | undefined): string {
   if (bytes === undefined) return "";
@@ -107,6 +108,16 @@ export function DataLocationsSection() {
       destructive: true,
     });
     if (!ok) return;
+
+    // Set the reset marker BEFORE clearing localStorage. app-shell reads this
+    // on the next reload to (a) re-show the data-dir picker and (b) suppress
+    // the agents-config self-correction that would otherwise re-write
+    // wizard-done="1" within a second and silently undo the reset.
+    try {
+      window.sessionStorage.setItem(ONBOARDING_RESET_MARKER_KEY, "1");
+    } catch {
+      // ignore — fall back to best-effort clear-only behavior
+    }
 
     let cleared = 0;
     for (const loc of onboardingRows) {


### PR DESCRIPTION
## Summary

Closes the gap left by the transparency commit (`33fa93c`) and the v0.4.2 EMFILE bug report from `garethprice` ([gist](https://gist.github.com/iamgp/9473f48e05b47432449fa94556c02830)). Two areas:

1. **Daemon EMFILE crash + CLI-path onboarding** (commit `054b886`) — the user pointed `npx cabinetai run` at `~/Developer` and got 5,690 lines of `EMFILE` from chokidar. The transparency commit shipped the web/Electron data-locations panel, but `npx` users skipped every guard. This patch hardens the daemon and brings the CLI to parity.
2. **Reset onboarding actually works** (commit `5b9b0e3`) — the new "Reset onboarding" button promised to clear three flags and treat the next launch as a first run, but two auto-restore paths in `app-shell.tsx` silently undid the reset within ~1s of reload. Fixed with a sessionStorage marker that suppresses both paths.

## What changed

### Daemon (P0–P2)
- `server/search/watcher.ts` — `.on('error')` catches `EMFILE`/`ENOSPC`, logs once with fix instructions, closes cleanly. No more unhandled-rejection cascade.
- `server/cabinet-daemon.ts:1716` — same handler on the schedule watcher.
- `server/cabinet-daemon.ts` — `probeWatcherBackend()` logs the actual chokidar backend on startup (e.g. `chokidar 5.0.0 → node fs.watch via FSEvents stream (one fd per directory)`). One log line that would have made the original report a 30-second triage.
- `server/cabinet-daemon.ts` — `guardAgainstBigTree()` pre-flight: refuses startup over 1,500 watchable dirs (respecting `IGNORED_DIRS` via `isHiddenEntry`) or under `ulimit -n 4096` with a friendly box pointing at `--data-dir`/`reset-config`. `CABINET_ALLOW_BIG_TREE=1` bypasses with a warning.

> **Discovery during implementation:** chokidar v4+ dropped fsevents support entirely. Every platform now uses `fs.watch` per directory, so the per-dir-fd issue is universal on macOS, not a "fallback only" case. Probe message + guard are platform-agnostic.

### CLI (P4-CLI / P6-CLI)
- `cabinetai/src/commands/run.ts` — banner now shows Cabinet directory + Manifest path + Source (`--data-dir | env-var | manifest-here | manifest-ancestor | bootstrapped`).
- `cabinetai/src/commands/run.ts` — new `--data-dir <path>` flag (skips upward traversal, bootstraps if needed).
- `cabinetai/src/commands/run.ts` — warns on **upward-traversal hit** (Gareth's bug: ran from `~/Developer/cabinet` but `~/Developer` had a stale `.cabinet` from a previous run, so the parent was reused silently).
- `cabinetai/src/commands/run.ts` — warns before bootstrapping a **risky cwd** (home dir, dev-folder names like `developer|projects|code|src|workspace|repos|github`, or >50 immediate subdirs).
- `cabinetai/src/commands/reset-config.ts` — new command that removes the local `.cabinet` manifest (content untouched) so the next run treats cwd fresh.
- `cabinetai/src/lib/scaffold.ts` — split into `resolveCabinetRoot()` (pure) + `bootstrapCabinetAt(targetDir)` (explicit), keeping `resolveOrBootstrapCabinetRoot` with new metadata for callers.
- `cabinetai/src/lib/prompt.ts` — `confirmOrContinue()` (soft prompt that preserves current behavior in non-TTY for CI/scripts).

### Reset onboarding fix
- `src/components/layout/app-shell.tsx` — exports `ONBOARDING_RESET_MARKER_KEY` + `isOnboardingResetInProgress()`. Two auto-restore paths now bail out when the marker is set:
  - Layout effect: skip silent-accept of `dataDirConfirmed`; force-show the data-dir-prompt.
  - `/api/agents/config` self-correction: `setShowWizard(true)` regardless of `workspace.json` on disk; skip the `wizard-done` re-write.
  - `handleWizardComplete` clears the marker — normal sessions are unaffected.
- `src/components/settings/data-locations-section.tsx` — the reset handler writes the marker before clearing localStorage keys.

## Test plan

- [x] Typecheck root + `cabinetai/` (`tsc --noEmit`)
- [x] Lint touched files (`npx eslint server/... src/...`)
- [x] Full repo test suite (`npm test`) — 47/49 pass; the 2 fails are pre-existing on `main`
- [x] cabinetai builds clean (`cabinetai/ npm run build`)
- [x] Daemon end-to-end: `mkdir /tmp/big && for i in {1..2000}; do mkdir /tmp/big/d$i; done && CABINET_DATA_DIR=/tmp/big tsx server/cabinet-daemon.ts` → friendly refusal box, exit 1; `CABINET_ALLOW_BIG_TREE=1` → bypass warning + boot
- [x] CLI end-to-end: `--data-dir` flag bootstraps explicitly; risky-cwd warning fires from a 52-subdir cwd; upward-traversal warning fires from a nested subdir; `reset-config -y` removes the manifest with informative output
- [x] Smoke: `npm run dev` + `npm run dev:daemon` boot clean against a fresh dir; `/api/health`, `/api/data-locations`, `/api/system/data-dir` all 200; daemon banner shows the new `Watcher backend` line
- [x] Reset onboarding chrome-devtools end-to-end: pre-reset → click Reset → reload → data-dir-prompt fires → confirm folder → welcome dictionary → click Get started → wizard re-fires. localStorage stays clean throughout; marker persists until wizard completes; no console errors
- [ ] Manual smoke on a Mac DMG build (next release)
- [ ] Linux smoke (different watcher backend message; same guard logic)

## Background

**EMFILE** = "too many open files" — per-process file-descriptor limit hit (macOS soft default ~256/2,560). Each `fs.watch()` consumes one fd. **ENOSPC** = "no space (in the watcher table)" on Linux — exhausted inotify per-user limit. Same failure mode, different limit, both handled.

**Why the CLI path matters:** the user fell back to `npx` because the Mac DMG download page showed a waitlist (out-of-scope marketing concern, flagged separately). On `npx`, the web onboarding wizard only runs after the daemon successfully boots, so it never fires when the daemon crashes during bootstrap. The CLI-side guards in this PR catch the problem before the daemon even starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to reset onboarding configuration through new CLI command
  * Added `--data-dir` flag to explicitly specify cabinet directory on startup

* **Improvements**
  * Enhanced cabinet directory resolution with better precedence handling
  * Added detection and graceful handling for large directory trees to prevent file watch failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->