### PR TITLE
fix: resume onboarding marquee from paused position on hover-out

### DIFF
--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -301,7 +301,8 @@ function TeamCarousel({
   onSelect: (t: RegistryTemplate) => void;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
-  const [isPaused, setIsPaused] = useState(false);
+  const isPausedRef = useRef(false);
+  const positionRef = useRef(0);
 
   // Use real templates if loaded, otherwise fall back to room-filtered starter teams.
   const fallbackTeams = STARTER_TEAMS.filter((t) => t.rooms.includes(roomType));
@@ -314,29 +315,28 @@ function TeamCarousel({
     if (!el) return;
 
     let animationId: number;
-    let position = 0;
 
     const animate = () => {
-      if (!isPaused) {
-        position += 1.2;
+      if (!isPausedRef.current) {
+        positionRef.current += 1.2;
         const halfWidth = el.scrollWidth / 2;
-        if (position >= halfWidth) position = 0;
-        el.style.transform = `translateX(-${position}px)`;
+        if (positionRef.current >= halfWidth) positionRef.current = 0;
+        el.style.transform = `translateX(-${positionRef.current}px)`;
       }
       animationId = requestAnimationFrame(animate);
     };
 
     animationId = requestAnimationFrame(animate);
     return () => cancelAnimationFrame(animationId);
-  }, [isPaused]);
+  }, []);
 
   const doubled = [...items, ...items];
 
   return (
     <div
       className="tilt-carousel relative w-full py-4"
-      onMouseEnter={() => setIsPaused(true)}
-      onMouseLeave={() => setIsPaused(false)}
+      onMouseEnter={() => { isPausedRef.current = true; }}
+      onMouseLeave={() => { isPausedRef.current = false; }}
     >
       <div ref={scrollRef} className="flex gap-2 will-change-transform">
         {doubled.map((item, i) => {


### PR DESCRIPTION
## Problem

On the **Build Your Team** onboarding step, hovering the rolling card carousel pauses it correctly, but moving the mouse away causes it to jump back to the beginning instead of resuming from where it stopped.

Closes #61

## Root Cause

`TeamCarousel` had `isPaused` in the `useEffect` dependency array. Every hover state change triggered a re-run of the effect, reinitialising `position = 0` and restarting the animation from the start.

## Fix

Replace `useState(isPaused)` and the local `position` variable with refs:

```diff
- const [isPaused, setIsPaused] = useState(false);
+ const isPausedRef = useRef(false);
+ const positionRef = useRef(0);

  useEffect(() => {
    ...
-   let position = 0;
    const animate = () => {
-     if (!isPaused) {
-       position += 1.2;
+     if (!isPausedRef.current) {
+       positionRef.current += 1.2;
        ...
      }
    };
- }, [isPaused]);
+ }, []);
```

The RAF loop now runs once and reads the latest ref values without reinitialising — position persists across pause/resume cycles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TeamCarousel animation performance to prevent stuttering during hover interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->