### PR TITLE
fix(sidebar): drag reorder math

### DIFF
--- a/src/components/sidebar/tree-node.tsx
+++ b/src/components/sidebar/tree-node.tsx
@@ -317,8 +317,10 @@ export function TreeNode({
       const fromPath = e.dataTransfer.getData("text/plain");
       if (!fromPath || fromPath === node.path) return;
 
-      // Don't drop onto own children
-      if (fromPath.startsWith(node.path + "/")) return;
+      // Don't drop a page into one of its own descendants (would be circular).
+      // The previous direction blocked dropping a child onto its parent's
+      // before/after zone — a legitimate way to reach the top level.
+      if (node.path.startsWith(fromPath + "/")) return;
 
       const fromName = fromPath.split("/").pop() || "";
       const nodeParent = node.path.split("/").slice(0, -1).join("/");

--- a/src/lib/storage/order-store.ts
+++ b/src/lib/storage/order-store.ts
@@ -245,7 +245,10 @@ export async function computeInsertOrder(
       .filter((x) => x.name !== selfName)
       .find((x) => x.name === nextName)?.order;
     if (typeof refreshed === "number") return Math.max(refreshed - ORDER_GAP, 1);
-    return ORDER_GAP;
+    // nextName disappeared between renumber and re-read (e.g. concurrent
+    // delete). Land at 1 so the new item still sorts above whatever the
+    // post-renumber first sibling is — ORDER_GAP would tie with it.
+    return 1;
   }
 
   return ORDER_GAP;

--- a/src/lib/storage/order-store.ts
+++ b/src/lib/storage/order-store.ts
@@ -237,7 +237,16 @@ export async function computeInsertOrder(
   }
 
   if (prevO !== null) return prevO + ORDER_GAP;
-  if (nextO !== null) return Math.max(nextO - ORDER_GAP, 1);
+  if (nextO !== null) {
+    if (nextO - ORDER_GAP >= 1) return nextO - ORDER_GAP;
+    await renumberSiblings(parentVirtualPath);
+    const after = await listOrderedSiblings(parentVirtualPath);
+    const refreshed = after
+      .filter((x) => x.name !== selfName)
+      .find((x) => x.name === nextName)?.order;
+    if (typeof refreshed === "number") return Math.max(refreshed - ORDER_GAP, 1);
+    return ORDER_GAP;
+  }
 
   return ORDER_GAP;
 }


### PR DESCRIPTION
## Summary

Three bugs in the sidebar's drag-reorder logic.

### 1. Items can't be dropped above the first sibling

`computeInsertOrder` (`src/lib/storage/order-store.ts:240`) clamped the new order to `Math.max(nextO - ORDER_GAP, 1)` when inserting before the first sibling. If that sibling has `order: 0` (or any value `≤ ORDER_GAP`), the expression `nextO - ORDER_GAP` evaluates to `≤ 0`; the clamp pins the new item to `order: 1`. But `1 > 0`, so the moved item still sorts *after* the original first sibling — the drop appears to snap back to its previous position.

Mirror the renumber-on-collision pattern from the both-neighbors branch (lines 224-237): when there's no positive integer gap below `nextO`, run `renumberSiblings` to spread orders out, then place the moved item below the refreshed `nextO`.

### 2. Sub-items can't be dragged out to top level

`handleDrop` in `src/components/sidebar/tree-node.tsx:321` had this guard:

\`\`\`ts
// Don't drop onto own children
if (fromPath.startsWith(node.path + \"/\")) return;
\`\`\`

The comment describes the circular-move case: don't drop a parent onto one of its own descendants. But the code as written checks the *opposite* relation — it returns when the source is a descendant of the target, which fires exactly when the user drags a child row onto its parent's before/after zone. That's the only way to drag a sub-item to be a sibling of its parent and walk it back up the tree, so the guard silently rejected the most common reparent gesture.

Flip the check to \`node.path.startsWith(fromPath + \"/\")\` so it catches the actual circular case (target is a descendant of source). The storage-layer check at \`page-io.ts:169-171\` already covers the circular case at write time, so the UI guard's role is purely UX-level early-return.

### 3. Silent collision when \`nextName\` disappears post-renumber

If the anchor sibling (\`nextName\`) is renamed or deleted between \`computeInsertOrder\`'s renumber pass and its re-read of the sibling list, the code fell back to \`return ORDER_GAP\`. But \`ORDER_GAP\` is the order \`renumberSiblings\` just assigned to whoever's now at top — the moved item ties with that sibling instead of sorting above it, and the locale-compare tiebreaker decides the visible order. The user dragged \"to the top\" and silently got \"tied with the top.\"

Return \`1\` instead. Strictly less than any post-renumber order, so the moved item lands at top regardless of which sibling now holds first place.

## Test plan

- [ ] Drop a sibling onto the very top of its list (parent has a sibling with \`order: 0\` or \`order: 100\`). The new ordering persists across reload.
- [ ] Drag a sub-item (e.g. \`Skills\` under \`Getting Started\`) onto the top edge of \`Getting Started\` itself. The sub-item moves to top level above its former parent.
- [ ] Drag a parent item onto one of its own descendants. The move is blocked (storage layer throws \"Cannot move a page into itself\").
- [ ] Repeated top-of-list drops on the same parent don't accumulate degenerate state — orders stay clean across multiple drags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed drag-and-drop validation to prevent invalid placements in hierarchical structures.
  * Improved item ordering stability when concurrent deletions occur, with automatic reordering when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->