### PR TITLE
fix(sidebar): drag-and-drop UX issues

### DIFF
--- a/src/components/sidebar/tree-node.tsx
+++ b/src/components/sidebar/tree-node.tsx
@@ -412,6 +412,8 @@ export function TreeNode({
             className={cn(
               "group relative flex items-center gap-2 w-full text-left py-1 px-2 text-[12px] text-foreground/75 rounded-md transition-colors",
               "hover:bg-foreground/[0.03] hover:text-foreground !cursor-grab active:!cursor-grabbing",
+              // Override the ContextMenuTrigger wrapper's user-select:none so HTML5 dragstart fires on first mousedown (Chromium quirk: draggable rows inheriting user-select:none need a focus pass before drag initiates).
+              "select-text",
               // Audit #015: active row needs two cues, not just background.
               // Adds a 2px primary-color accent bar on the left edge via a
               // before:: pseudo (does not fight the row's existing padding)

--- a/src/stores/tree-store.ts
+++ b/src/stores/tree-store.ts
@@ -225,7 +225,9 @@ export const useTreeStore = create<TreeState>((set, get) => ({
           })
         );
       }
-      console.error("Failed to move page:", error);
+      // Toast is the user-facing surface; no console.error so a name
+      // collision (or any other server-validated message) doesn't trip
+      // the Next.js dev-tools error overlay.
     } finally {
       set((state) => {
         const next = new Set(state.movingPaths);


### PR DESCRIPTION
## Summary

Two bugs in the sidebar's drag-and-drop user experience.

### 1. First drag of an unselected row falls through to a click

The draggable \`<button>\` row lives inside \`<ContextMenuTrigger>\`, which renders a wrapping \`<div>\` with \`class=\"select-none\"\` (\`src/components/ui/context-menu.tsx:26\`). That CSS rule (\`user-select: none\`) inherits onto the button.

In Chromium, an element with \`draggable=\"true\"\` that inherits \`user-select: none\` from an ancestor *won't initiate \`dragstart\` on the very first mousedown* until the element has been focused. So the user's first drag attempt is consumed as a click — the row gets selected, navigated to, and focused — and the *second* drag attempt (now-focused row) fires \`dragstart\` normally.

The user perceives \"the first drag selects the item, the second drag actually moves it\" with no signal as to why, and any cabinet that wasn't already the active one effectively requires two drag attempts to reorder.

Add \`select-text\` on the row \`<button>\` to break the inheritance. Drag fires on first mousedown regardless of focus state. Verified in the running app: \`getComputedStyle(rowEl).userSelect\` now reads \`\"text\"\` (was \`\"none\"\`).

### 2. Move failures trip the Next.js dev-tools error overlay

The \`movePage\` action in \`src/stores/tree-store.ts\` dispatched a toast *and* a \`console.error\` for every failure. Next.js dev mode promotes \`console.error\` to the dev \"Issues\" badge and the in-page error overlay — so any user-correctable condition (name collisions, permissions, etc.) reads to a developer running the app as if it were a programmer bug worth investigating, even though the toast already informed the user and they have a clear next step.

The toast is the user-facing surface; the failed PATCH request is visible in the network tab when more detail is needed. Drop the \`console.error\` for \`movePage\` only — \`renamePage\`'s \`console.error\` stays in place because it has no toast yet, and silent failure would be worse than the overlay noise.

## Test plan

- [ ] In a fresh session, drag an unselected sidebar row 10+px to a new position. The first attempt reorders the row instead of just selecting it.
- [ ] Trigger a move that fails (e.g. drop a row onto an invalid target). A toast appears with the error message. The Next.js \"Issues\" pill at the bottom-left does *not* increment, and no error overlay opens.
- [ ] Right-click on a row still opens the context menu (the \`select-text\` change doesn't break the trigger).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed drag-and-drop functionality to work on first interaction in Chrome-based browsers
  * Improved development experience by removing unnecessary error messages from the console

<!-- end of auto-generated comment: release notes by coderabbit.ai -->