### PR TITLE
fix(sidebar): friendly errors and orphan sweep on cabinet moves

### DIFF
--- a/src/lib/storage/page-io.ts
+++ b/src/lib/storage/page-io.ts
@@ -174,6 +174,13 @@ export async function movePage(
   const isReorder = fromResolved === toResolved;
 
   if (!isReorder) {
+    if (await fileExists(toResolved)) {
+      throw new Error(
+        `An item named "${name}" already exists in ${
+          toParentPath ? `"${toParentPath}"` : "the root"
+        }. Rename or remove it first.`
+      );
+    }
     await ensureDirectory(toDir);
     const fsp = await import("fs/promises");
     try {

--- a/src/lib/storage/page-io.ts
+++ b/src/lib/storage/page-io.ts
@@ -154,6 +154,24 @@ export async function deletePage(virtualPath: string): Promise<void> {
   }
 }
 
+async function isHollowOrphanDir(dir: string): Promise<boolean> {
+  const stack = [dir];
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    let entries;
+    try {
+      entries = await fs.readdir(current, { withFileTypes: true });
+    } catch {
+      return false;
+    }
+    for (const e of entries) {
+      if (e.isDirectory()) stack.push(path.join(current, e.name));
+      else return false;
+    }
+  }
+  return true;
+}
+
 export async function movePage(
   fromPath: string,
   toParentPath: string,
@@ -175,11 +193,18 @@ export async function movePage(
 
   if (!isReorder) {
     if (await fileExists(toResolved)) {
-      throw new Error(
-        `An item named "${name}" already exists in ${
-          toParentPath ? `"${toParentPath}"` : "the root"
-        }. Rename or remove it first.`
-      );
+      // Destination may be empty .agents/ scaffolding the daemon recreated at
+      // the old path after a prior cabinet move — sweep it so rename succeeds.
+      if (await isHollowOrphanDir(toResolved)) {
+        const fsp = await import("fs/promises");
+        await fsp.rm(toResolved, { recursive: true, force: true });
+      } else {
+        throw new Error(
+          `An item named "${name}" already exists in ${
+            toParentPath ? `"${toParentPath}"` : "the root"
+          }. Rename or remove it first.`
+        );
+      }
     }
     await ensureDirectory(toDir);
     const fsp = await import("fs/promises");

--- a/src/lib/storage/page-io.ts
+++ b/src/lib/storage/page-io.ts
@@ -154,8 +154,26 @@ export async function deletePage(virtualPath: string): Promise<void> {
   }
 }
 
+// Hidden dirs scaffolded next to every cabinet (cabinet-scaffold.ts:95-97).
+// A "hollow orphan" is a destination that contains only these dirs and they
+// in turn hold zero files — the daemon's leftovers from a prior cabinet move,
+// not real user content. An empty user-created folder with the same slug as
+// the moving item must NOT match (no scaffolding present).
+const CABINET_SCAFFOLD_NAMES = new Set([".agents", ".jobs", ".cabinet-state"]);
+
 async function isHollowOrphanDir(dir: string): Promise<boolean> {
-  const stack = [dir];
+  let topEntries;
+  try {
+    topEntries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+  if (topEntries.length === 0) return false;
+  for (const e of topEntries) {
+    if (!e.isDirectory()) return false;
+    if (!CABINET_SCAFFOLD_NAMES.has(e.name)) return false;
+  }
+  const stack = topEntries.map((e) => path.join(dir, e.name));
   while (stack.length > 0) {
     const current = stack.pop()!;
     let entries;
@@ -217,6 +235,15 @@ export async function movePage(
         // Fall back to recursive copy + delete.
         await fsp.cp(fromResolved, toResolved, { recursive: true });
         await fsp.rm(fromResolved, { recursive: true, force: true });
+      } else if (code === "ENOTEMPTY" || code === "EEXIST") {
+        // Daemon recreated scaffolding between our hollow-orphan sweep and
+        // this rename. Surface the same friendly message rather than the raw
+        // errno — the user's options are the same either way.
+        throw new Error(
+          `An item named "${name}" already exists in ${
+            toParentPath ? `"${toParentPath}"` : "the root"
+          }. Rename or remove it first.`
+        );
       } else {
         throw err;
       }


### PR DESCRIPTION
## Summary

Make cabinet moves resilient to filesystem destination collisions.

### What was broken

\`movePage\` (\`src/lib/storage/page-io.ts:157\`) called \`fs.rename\` blind. When the destination already existed:

- The raw errno surfaced verbatim. A user dragging a top-level cabinet into a parent that already contained an entry with the same name saw \`\"Failed to move page: ENOTEMPTY: directory not empty, rename '/.../cabinet/getting-started' -> '/.../cabinet/test-subcab/getting-started'\"\`. Useful for a developer reading the code; opaque for everyone else.
- A frequent cause was a \"hollow orphan\" — the destination contained only empty hidden cabinet scaffolding (\`.agents/.conversations/...\`) recreated at the old path by daemon-side processes after a previous cabinet move. Zero file content, but \`fs.rename\` correctly refused to clobber a non-empty directory. The user has no indication that the blocker is empty leftover state, and short of opening a terminal and running \`rm -rf\`, no in-app way to clear it.

### What this changes

Three commits, each refining the previous:

**1. Pre-check the destination with a friendly error.** Before \`fs.rename\`, check \`fileExists(toResolved)\`. If the destination exists, throw a message that names the item and the parent: \`\"An item named \\\"X\\\" already exists in \\\"Y\\\". Rename or remove it first.\"\` The user knows immediately which collision to resolve.

**2. Sweep hollow orphans automatically.** When the colliding destination contains only hidden cabinet scaffolding directories and zero files at any depth, \`fs.rm\` it before the rename. A new helper \`isHollowOrphanDir\` does the recursive walk. Any destination with real content still throws the friendly error from commit 1 — the sweep is conservative by default.

**3. Tighten the sweep, handle the post-sweep race.**
- \`isHollowOrphanDir\` initially treated *any* tree of empty subdirectories as an orphan, which would silently delete a user-created empty folder named the same as the moving item. Restrict to known scaffolding directory names (\`.agents\`, \`.jobs\`, \`.cabinet-state\`) at the top level — the canonical set scaffolded next to every cabinet (\`src/lib/storage/cabinet-scaffold.ts:80-97\`).
- The daemon-side process that recreated the scaffolding can do so again between sweep and rename. If \`fs.rename\` then fails with \`ENOTEMPTY\`/\`EEXIST\`, surface the friendly error from commit 1 instead of letting the raw errno through.

### Why hollow orphans exist (context, not changed here)

Every cabinet has hidden runtime-state siblings — \`.agents/\`, \`.jobs/\`, \`.cabinet-state/\` (\`src/lib/storage/cabinet-scaffold.ts:80-97\`). When a cabinet directory is renamed, \`fs.rename\` relocates the whole tree atomically. But:

- Open file handles held against the old path keep flushing — most visibly to \`.agents/.conversations/{id}/events.log\` (\`src/app/api/agents/conversations/[id]/events-log/route.ts:31\`) and the staging attachments tree (\`src/components/composer/use-composer-attachments.ts:45\`).
- Chokidar watchers registered on \`data/**/.agents/**\` (\`server/cabinet-daemon.ts:1841-1843\`) fire on the unlink half of the rename pair, and downstream handlers can re-touch the old path while updating internal state keyed by absolute path.

The result is an empty \`.agents/.conversations/\` skeleton at the original location after every cabinet move that had any agent activity.

The architecturally correct fix is to notify the daemon on cabinet renames so it can close streams keyed by the old path, rewrite watcher path keys, and seed a short-lived ignore set. That's a separate change targeting \`server/cabinet-daemon.ts\`, the API route, and a typed event channel — happy to follow up with a PR for it. The sweep here is the user-visible band-aid that unblocks moves now, including for users with pre-existing orphans on disk who'd otherwise need shell access to clean them up. Once the daemon-side change lands, the sweep stays useful as a one-time migration path for legacy data and as defense-in-depth (one \`readdir\` per move when the destination already exists; no cost in the common case).

## Test plan

- [ ] Drag a top-level item into a parent whose directory already contains an entry with the same name and real content. Toast: \`\"An item named ... already exists in ... Rename or remove it first.\"\`
- [ ] Drag into a parent where the destination is a hollow \`.agents/.conversations/\` orphan from a prior move. Drag succeeds; the orphan is gone.
- [ ] Drag into a parent where the destination is a user-created empty folder (no scaffolding, no files). Friendly error fires; the empty folder is *not* swept.
- [ ] Manually create \`<dest>/some-file.txt\` inside an otherwise-empty destination. Drag in. Friendly error fires (file present → not hollow → not swept).
- [ ] Cross-device move (linked external cabinet on another mount) still falls through to copy+delete via the existing \`EXDEV\` branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page move operations to handle certain edge cases with existing items at the destination
  * Enhanced error messaging for move operation conflicts, replacing technical errors with user-friendly notifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->