### PR TITLE
fix(sidebar): right-click anywhere in a drawer opens the app menu

### DIFF
--- a/src/components/sidebar/tree-view.tsx
+++ b/src/components/sidebar/tree-view.tsx
@@ -388,7 +388,7 @@ export function TreeView() {
   return (
     <>
     <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-scrollbar]]:w-1.5 [&_[data-slot=scroll-area-scrollbar]]:py-0 [&_[data-slot=scroll-area-scrollbar]]:pr-0 [&_[data-slot=scroll-area-scrollbar]]:pl-0.5 [&_[data-slot=scroll-area-scrollbar]]:border-l-0">
-      <div className="py-1">
+      <div className="flex min-h-full flex-col py-1">
         {/* ── Back to parent cabinet ────────────────────── */}
         {activeCabinet && parentCabinet ? (
           <button
@@ -639,12 +639,14 @@ export function TreeView() {
         </div>
 
         {cabinetExpanded && (
-          <>
+          <div className="flex flex-1 min-h-0 flex-col">
             {agentsExpanded && (
-              <div
-                key="drawer-agents"
-                className="pt-1 animate-in fade-in slide-in-from-top-1 duration-200 ease-out"
-              >
+              <ContextMenu>
+                <ContextMenuTrigger className="flex flex-1 flex-col">
+                  <div
+                    key="drawer-agents"
+                    className="flex flex-1 flex-col pt-1 animate-in fade-in slide-in-from-top-1 duration-200 ease-out"
+                  >
                 {[
                   ...agents.filter((a) => a.slug === "editor"),
                   ...agents.filter((a) => a.slug !== "editor"),
@@ -687,30 +689,72 @@ export function TreeView() {
                     </div>
                   );
                 })}
-              </div>
+                  </div>
+                </ContextMenuTrigger>
+                <ContextMenuContent>
+                  <ContextMenuItem
+                    onClick={() => {
+                      setSection({
+                        type: "agents",
+                        cabinetPath: activeCabinet?.path || ROOT_CABINET_PATH,
+                      });
+                      setTimeout(() => {
+                        window.dispatchEvent(
+                          new CustomEvent("cabinet:open-add-agent")
+                        );
+                      }, 100);
+                    }}
+                  >
+                    <UserPlus className="h-4 w-4 mr-2" />
+                    New Agent
+                  </ContextMenuItem>
+                </ContextMenuContent>
+              </ContextMenu>
             )}
 
             {tasksExpanded && (
-              <div
-                key="drawer-tasks"
-                className="pt-1 animate-in fade-in slide-in-from-top-1 duration-200 ease-out"
-              >
-                <RecentTasks
-                  active
-                  padStyle={pad(1)}
-                  itemClass={itemClass}
-                  cabinetPath={activeCabinet?.path}
-                  agents={agents}
-                />
-              </div>
+              <ContextMenu>
+                <ContextMenuTrigger className="flex flex-1 flex-col">
+                  <div
+                    key="drawer-tasks"
+                    className="flex flex-1 flex-col pt-1 animate-in fade-in slide-in-from-top-1 duration-200 ease-out"
+                  >
+                    <RecentTasks
+                      active
+                      padStyle={pad(1)}
+                      itemClass={itemClass}
+                      cabinetPath={activeCabinet?.path}
+                      agents={agents}
+                    />
+                  </div>
+                </ContextMenuTrigger>
+                <ContextMenuContent>
+                  <ContextMenuItem
+                    onClick={() => {
+                      setSection({
+                        type: "tasks",
+                        cabinetPath: activeCabinet?.path || ROOT_CABINET_PATH,
+                      });
+                      setTimeout(() => {
+                        window.dispatchEvent(
+                          new CustomEvent("cabinet:open-create-task")
+                        );
+                      }, 100);
+                    }}
+                  >
+                    <ListPlus className="h-4 w-4 mr-2" />
+                    New Task
+                  </ContextMenuItem>
+                </ContextMenuContent>
+              </ContextMenu>
             )}
 
             {kbExpanded && (
               <ContextMenu>
-                <ContextMenuTrigger>
+                <ContextMenuTrigger className="flex flex-1 flex-col">
                   <div
                     key="drawer-data"
-                    className="pt-1 animate-in fade-in slide-in-from-top-1 duration-200 ease-out"
+                    className="flex flex-1 flex-col pt-1 animate-in fade-in slide-in-from-top-1 duration-200 ease-out"
                   >
               <>
                 {visibleTreeNodes.length === 0 ? (
@@ -782,7 +826,7 @@ export function TreeView() {
                 </ContextMenuContent>
               </ContextMenu>
             )}
-          </>
+          </div>
         )}
       </div>
     </ScrollArea>


### PR DESCRIPTION
## Problem

Right-clicking on empty space in the sidebar (below the tree, below the agent list, below the task list) showed the browser's native context menu instead of the app's menu. The app menu only appeared when right-clicking directly on an existing entry.

This was reproducible in any cabinet with a short tree where the visible rows didn't fill the sidebar — the entire empty area below them rejected the right-click.

## Root cause

Each drawer body lives inside a `ContextMenuTrigger` from `@base-ui/react/context-menu`. The trigger listens for `contextmenu` events on a single DOM element it renders. That element only sized to its children's content — so when the tree / agent list / task list was shorter than the available sidebar height, the empty area below them was outside the trigger's bounding box, and the browser's default `contextmenu` handler won.

Concretely:

- `ScrollArea`'s viewport is `size-full`, so it fills the available height between the sidebar header and footer.
- The inner `<div className="py-1">` directly inside the viewport had no flex-fill behaviour, so it shrunk to its content.
- Each drawer body (Data / Agents / Tasks) was a sibling block inside that column, also content-sized.
- The `<ContextMenuTrigger>` for the Data drawer wrapped its inner content div, which was again content-sized. Empty area below the tree wasn't part of any trigger.

## Fix

Make the empty area part of each drawer's trigger by setting up a flex chain so the drawer body grows into all remaining viewport space:

1. The outer column inside the viewport becomes `min-h-full flex flex-col` — guarantees it's at least as tall as the viewport, even when content is short.
2. The `cabinetExpanded` fragment becomes a `flex flex-1 min-h-0 flex-col` div that fills the space below the cabinet header rail.
3. Each drawer's `<ContextMenuTrigger>` gets `className="flex flex-1 flex-col"` and its inner div gets `flex flex-1 flex-col` too — so the trigger's element fills the remaining vertical space and registers `contextmenu` events anywhere in that area.

`scrollOverflow` still works: `min-h-full` is a minimum, not a fixed height — when content exceeds the viewport, the column grows past it and the scrollbar engages as before.

## Per-node menus still work

Each `TreeNode` row, each agent row, and the cabinet header all already have their own `<ContextMenu>` triggers. Base-ui (like Radix) calls `event.stopPropagation()` on `contextmenu`, so when the user right-clicks on a row, the inner row trigger wins and opens its own menu; the outer drawer trigger only fires for clicks that didn't hit any nested trigger.

## Drawer-specific menus

- **Data drawer** already had a menu (Add Sub Page / Load Knowledge / Copy Full Path / Open in Finder) — only the layout was changed, items unchanged.
- **Agents drawer** is new: a single `New Agent` item that mirrors the existing `+` button's `onAdd` action exactly (same `setSection` + `cabinet:open-add-agent` event), so nothing diverges.
- **Tasks drawer** is new: a single `New Task` item, same pattern with `cabinet:open-create-task`.

## Files changed

- `src/components/sidebar/tree-view.tsx` — layout + two new drawer-level context menus.

## Test plan

- [ ] Data drawer: right-click on the empty area below the tree → app menu (Add Sub Page, Load Knowledge, Copy Full Path, Open in Finder) appears, browser menu does not.
- [ ] Data drawer: right-click on a tree row → per-node menu still appears (nested trigger).
- [ ] Data drawer empty cabinet: right-click below the "Add cabinet data" / "Add your first page" button → app menu appears.
- [ ] Agents drawer: right-click anywhere in the drawer body → "New Agent" appears; clicking opens the Add Agent dialog (same as the `+` tab affordance).
- [ ] Agents drawer: right-click on an agent row → per-row "Edit agent" menu still appears.
- [ ] Tasks drawer: right-click anywhere in the drawer body → "New Task" appears; clicking opens the Create Task dialog.
- [ ] Tasks drawer with `No tasks yet.` empty state: right-click anywhere below the placeholder → "New Task" appears.
- [ ] Cabinet header context menu (Rename / Copy Full Path / Open in Finder / Delete) still works.
- [ ] Sidebar still scrolls when content exceeds the viewport in any drawer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context menu option to create a new Agent from the Agents drawer
  * Added context menu option to create a new Task from the Tasks drawer

<!-- end of auto-generated comment: release notes by coderabbit.ai -->