### PR TITLE
fix(cabinetai): refuse to bootstrap a cabinet in $HOME or /

### DIFF
--- a/cabinetai/src/lib/scaffold.ts
+++ b/cabinetai/src/lib/scaffold.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import os from "os";
 import path from "path";
 import { ensureDir, findCabinetRoot, slugify } from "./paths.js";
 import {
@@ -121,8 +122,35 @@ export function resolveCabinetRoot(
   };
 }
 
+function refuseBootstrap(label: string, resolved: string): never {
+  // Bootstrapping into HOME or filesystem root scribbles .agents/, .jobs/,
+  // .cabinet-state/, .cabinet, and index.md across the user's most important
+  // directory — and then crashes with ENOTDIR when ensureCabinetHome() tries
+  // to mkdir ~/.cabinet/app on top of the .cabinet manifest file. Refuse
+  // before scaffolding anything.
+  process.stderr.write(
+    `\x1b[31m✗\x1b[0m Refusing to create a cabinet in ${label} (${resolved}).\n` +
+      `  Cabinet would scaffold .agents/, .jobs/, .cabinet-state/, .cabinet, and index.md here.\n\n` +
+      `  Start in an empty directory instead:\n` +
+      `    mkdir my-cabinet && cd my-cabinet && npx cabinetai run\n\n` +
+      `  Or point at a specific empty directory with --data-dir:\n` +
+      `    npx cabinetai run --data-dir <empty-dir>\n`
+  );
+  process.exit(1);
+}
+
+function assertSafeBootstrapTarget(resolved: string): void {
+  if (resolved === path.resolve(os.homedir())) {
+    refuseBootstrap("your home directory", resolved);
+  }
+  if (resolved === path.parse(resolved).root) {
+    refuseBootstrap("the filesystem root", resolved);
+  }
+}
+
 export function bootstrapCabinetAt(targetDir: string): ResolvedCabinetRoot {
   const resolved = path.resolve(targetDir);
+  assertSafeBootstrapTarget(resolved);
   const name = inferCabinetName(resolved);
   scaffoldCabinetDir({
     targetDir: resolved,

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -114,13 +114,20 @@ This makes it possible to attach over CDP and inspect real DOM, network, and scr
 
 ## Cabinetai CLI invariants
 
-The `cabinetai/` and `cli/` packages have a few non-obvious safety rules. Read these before "fixing" anything in their bootstrap path.
+### Where the npx tools live
 
-1. **`cabinetai/src/lib/scaffold.ts::bootstrapCabinetAt()` refuses to scaffold a cabinet when the resolved target is `os.homedir()` or the filesystem root.** Exits 1 with a friendly message recommending an empty subdir or `--data-dir <empty-dir>`. Covers cwd fallthrough, `--data-dir ~`, and `CABINET_DATA_DIR=~`. Closes #59 (PR #71, 2026-05-06).
+Both npm packages ship from this monorepo, not separate repos:
 
-2. **Do NOT "fix" this by relocating `CABINET_HOME`.** Moving it from `~/.cabinet/` to `~/.local/share/cabinetai/` (XDG) or anywhere else makes the historical ENOTDIR crash go away — but the crash was the safety net. Without it, running `cabinetai run` from `~` silently scribbles `.agents/`, `.jobs/`, `.cabinet-state/`, `index.md`, and a `.cabinet` manifest file directly into the user's home directory. PR #60 was closed for exactly this reason. The XDG move is fine as a *convention upgrade*, but it is not a bugfix and must not replace the guard.
+- **`cabinetai/`** — published as [`cabinetai`](https://www.npmjs.com/package/cabinetai). The full CLI: `create`, `run`, `update`, `doctor`, `import`, `list`, `uninstall`, `reset-config`. Built with esbuild from `cabinetai/src/`.
+- **`cli/index.cjs`** — published as [`create-cabinet`](https://www.npmjs.com/package/create-cabinet). A thin wrapper that calls `cabinetai create <dir>` and then `cabinetai run` in the new subdir. Pinned to a matching `cabinetai` version via its `dependencies`.
 
-3. **`create-cabinet` is `cli/index.cjs` in this repo**, not a separate package. Thin wrapper that calls `cabinetai create <dir>` and then `cabinetai run` in the new subdir. It's safe transitively: `cabinetai create` always scaffolds into `cwd/<slug>` and errors on empty slug (so `.`, `..`, `~`, `$HOME` all bounce).
+### Safety rules (read before "fixing" anything in the bootstrap path)
+
+1. **`cabinetai/src/lib/scaffold.ts::bootstrapCabinetAt()` refuses to scaffold a cabinet when the resolved target is `os.homedir()` or the filesystem root.** Exits 1 with a friendly message recommending an empty subdir or `--data-dir <empty-dir>`. Covers cwd fallthrough, `--data-dir ~`, and `CABINET_DATA_DIR=~`. See [#71](https://github.com/hilash/cabinet/pull/71) (closes [#59](https://github.com/hilash/cabinet/issues/59)).
+
+2. **Do NOT "fix" this by relocating `CABINET_HOME`.** That approach was rejected in [#60](https://github.com/hilash/cabinet/pull/60) — read the close comment for the full reasoning. The historical ENOTDIR crash was a safety net; removing it without the guard lets `cabinetai run` from `~` silently scribble `.agents/`, `.jobs/`, `.cabinet-state/`, `index.md`, and a `.cabinet` manifest file directly into the user's home directory.
+
+3. **`create-cabinet` (cli/index.cjs) is safe transitively** — `cabinetai create` always scaffolds into `cwd/<slug>` and errors on empty slug (so `.`, `..`, `~`, `$HOME` all bounce). The post-create `cabinetai run` then runs from the new subdir, never HOME. The guard in #71 is defense-in-depth.
 
 4. **When fixing a crash anywhere in the bootstrap/install path, trace what happens *before* the crash.** If the crash is the only thing stopping a worse silent outcome (HOME pollution, data loss, unrecoverable state), fix the root cause upstream instead of removing the crash.
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -112,6 +112,18 @@ Use `npm run debug:chrome` when you need a debuggable browser session. It launch
 
 This makes it possible to attach over CDP and inspect real DOM, network, and screenshots instead of guessing at frontend state.
 
+## Cabinetai CLI invariants
+
+The `cabinetai/` and `cli/` packages have a few non-obvious safety rules. Read these before "fixing" anything in their bootstrap path.
+
+1. **`cabinetai/src/lib/scaffold.ts::bootstrapCabinetAt()` refuses to scaffold a cabinet when the resolved target is `os.homedir()` or the filesystem root.** Exits 1 with a friendly message recommending an empty subdir or `--data-dir <empty-dir>`. Covers cwd fallthrough, `--data-dir ~`, and `CABINET_DATA_DIR=~`. Closes #59 (PR #71, 2026-05-06).
+
+2. **Do NOT "fix" this by relocating `CABINET_HOME`.** Moving it from `~/.cabinet/` to `~/.local/share/cabinetai/` (XDG) or anywhere else makes the historical ENOTDIR crash go away — but the crash was the safety net. Without it, running `cabinetai run` from `~` silently scribbles `.agents/`, `.jobs/`, `.cabinet-state/`, `index.md`, and a `.cabinet` manifest file directly into the user's home directory. PR #60 was closed for exactly this reason. The XDG move is fine as a *convention upgrade*, but it is not a bugfix and must not replace the guard.
+
+3. **`create-cabinet` is `cli/index.cjs` in this repo**, not a separate package. Thin wrapper that calls `cabinetai create <dir>` and then `cabinetai run` in the new subdir. It's safe transitively: `cabinetai create` always scaffolds into `cwd/<slug>` and errors on empty slug (so `.`, `..`, `~`, `$HOME` all bounce).
+
+4. **When fixing a crash anywhere in the bootstrap/install path, trace what happens *before* the crash.** If the crash is the only thing stopping a worse silent outcome (HOME pollution, data loss, unrecoverable state), fix the root cause upstream instead of removing the crash.
+
 ## Progress Tracking
 
 After every change you make to this project, append an entry to `PROGRESS.md` using this format:


### PR DESCRIPTION
## Summary

`npx cabinetai run` from `~` doesn't just crash — it scribbles `.agents/`, `.jobs/`, `.cabinet-state/`, `index.md`, and a `.cabinet` manifest file directly into the user's home directory **before** the crash. The crash (ENOTDIR when `ensureCabinetHome()` tries to `mkdir ~/.cabinet/app` on top of the `.cabinet` manifest file) is the only thing stopping it from being worse.

## What this changes

A low-level guard in `bootstrapCabinetAt()` that refuses with a clear exit-1 message when the resolved target is the user's home directory or the filesystem root. Because the guard is in the bottom of the stack, it covers all three entry points:

- `cabinetai run` (cwd fallthrough — Gareth/alegmal's case from #59)
- `cabinetai run --data-dir ~`
- `CABINET_DATA_DIR=~ cabinetai run`

## What it looks like

```
$ cd ~ && npx cabinetai run
✗ Refusing to create a cabinet in your home directory (/Users/foo).
  Cabinet would scaffold .agents/, .jobs/, .cabinet-state/, .cabinet, and index.md here.

  Start in an empty directory instead:
    mkdir my-cabinet && cd my-cabinet && npx cabinetai run

  Or point at a specific empty directory with --data-dir:
    npx cabinetai run --data-dir <empty-dir>
```

## Why this and not #60

#60 made the crash go away by moving `CABINET_HOME` from `~/.cabinet` to `~/.local/share/cabinetai` (XDG). That's a sensible long-term move on its own merits, but it doesn't address the underlying problem: with the crash gone, running from `~` would **silently succeed** at turning the user's HOME into a cabinet (creating the directories and manifest listed above). The crash is the safety net.

This PR fixes the actual root cause. After this lands, #60 (or any future XDG migration) becomes a free-standing convention choice rather than a bugfix.

## What about `create-cabinet`?

`create-cabinet` (`cli/index.cjs` in this repo) is a thin wrapper that calls `cabinetai create <dir>` then `cabinetai run` in the new subdir. It's already safe transitively:

- `cabinetai create` always scaffolds into `cwd/<slug>`, never into `cwd` itself, and errors on empty slugs (so `.`, `..`, `~` all bounce).
- The post-create `cabinetai run` then runs from the freshly-created subdir, which is by construction not HOME.

And as defense-in-depth, this PR's guard catches anyone who reaches `bootstrapCabinetAt(os.homedir())` regardless of entry point.

## `cabinetai create` itself

Already safe — always builds `cwd/<slug>`, never `cwd`. Confirmed by inspection of `cabinetai/src/commands/create.ts`.

## Test plan

- [x] Build passes (`npm run build` in `cabinetai/`)
- [x] `cabinetai run --data-dir ~` refuses with exit 1 and the friendly message
- [x] `cabinetai run --data-dir /` refuses with exit 1
- [ ] `cabinetai run` from a normal subdirectory still works (verified by inspection — guard only fires on HOME / root)

Closes #59.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bootstrap process now includes runtime safety checks to prevent installation in unsafe filesystem locations, such as the home directory or system root, protecting the integrity of bootstrap operations.

* **Documentation**
  * New "CLI invariants" documentation section outlines safety requirements for bootstrap procedures, describes package structure and locations, provides four key safety guardrails, and includes guidance for troubleshooting installation failures and crash tracing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->