### PR TITLE
fix(cabinetai): dedupe HOME warning after #71's guard

### DIFF
--- a/cabinetai/src/commands/run.ts
+++ b/cabinetai/src/commands/run.ts
@@ -1,5 +1,4 @@
 import type { Command } from "commander";
-import os from "os";
 import path from "path";
 import fs from "fs";
 import { log, success, error, warning } from "../lib/log.js";
@@ -38,10 +37,13 @@ interface ResolveOptions {
 /**
  * Reasons a directory looks like a poor choice to bootstrap as a cabinet.
  * Returns null for directories that look fine.
+ *
+ * NOTE: HOME and the filesystem root are not handled here — they're hard-
+ * refused by the guard in `bootstrapCabinetAt`. Anything we return from this
+ * function is a *soft* warning where the user can still proceed.
  */
 function looksRiskyForBootstrap(dir: string): string | null {
   const resolved = path.resolve(dir);
-  if (resolved === os.homedir()) return "this is your home directory";
   const base = path.basename(resolved).toLowerCase();
   const devNames = new Set([
     "developer",

--- a/cabinetai/src/lib/scaffold.ts
+++ b/cabinetai/src/lib/scaffold.ts
@@ -130,11 +130,12 @@ function refuseBootstrap(label: string, resolved: string): never {
   // before scaffolding anything.
   process.stderr.write(
     `\x1b[31m✗\x1b[0m Refusing to create a cabinet in ${label} (${resolved}).\n` +
-      `  Cabinet would scaffold .agents/, .jobs/, .cabinet-state/, .cabinet, and index.md here.\n\n` +
-      `  Start in an empty directory instead:\n` +
-      `    mkdir my-cabinet && cd my-cabinet && npx cabinetai run\n\n` +
-      `  Or point at a specific empty directory with --data-dir:\n` +
-      `    npx cabinetai run --data-dir <empty-dir>\n`
+      `  Cabinet indexes every supported file under the cabinet directory and\n` +
+      `  would scaffold .agents/, .jobs/, .cabinet-state/, .cabinet, and index.md here.\n\n` +
+      `  Recommended: pick a fresh empty folder, e.g. ~/Documents/Cabinet:\n` +
+      `    mkdir -p ~/Documents/Cabinet && cd ~/Documents/Cabinet && npx cabinetai run\n\n` +
+      `  Or point at a specific directory with --data-dir:\n` +
+      `    npx cabinetai run --data-dir ~/Documents/Cabinet\n`
   );
   process.exit(1);
 }


### PR DESCRIPTION
## Summary

Follow-up to #71. With the hard-refusal guard in \`bootstrapCabinetAt\`, the soft HOME branch in \`looksRiskyForBootstrap\` now creates a confusing UX: the user sees a yellow warning + \"Continue?\" prompt (default yes), confirms, and then gets refused anyway. Saying \"yes\" should not fail.

Verified locally (running \`cabinetai run\` from \`~\` before this PR):

\`\`\`
! About to make this directory a cabinet — but this is your home directory.
    target:   /Users/mybiblepath
  Cabinet indexes every supported file under the cabinet directory.
  ...
✗ Refusing to create a cabinet in your home directory (/Users/mybiblepath).
  ...
\`\`\`

Two near-identical messages. After this PR, just the red refusal.

## Changes

- Drop the HOME branch from \`looksRiskyForBootstrap\` in \`run.ts\`. Comment explains that HOME / FS-root are hard-refused by the guard; this function returns soft warnings only (dev-folder names, >50 subdirs) which are unchanged.
- Port the *\"Recommended: ~/Documents/Cabinet\"* hint from the now-removed yellow warning into the guard's message in \`scaffold.ts\` — that recommendation was nicer than my generic \"empty subdir\" example.
- Drop the now-unused \`os\` import from \`run.ts\`.

## Verified

\`\`\`
$ cd ~ && node cabinetai/dist/index.js run
✗ Refusing to create a cabinet in your home directory (/Users/mybiblepath).
  Cabinet indexes every supported file under the cabinet directory and
  would scaffold .agents/, .jobs/, .cabinet-state/, .cabinet, and index.md here.

  Recommended: pick a fresh empty folder, e.g. ~/Documents/Cabinet:
    mkdir -p ~/Documents/Cabinet && cd ~/Documents/Cabinet && npx cabinetai run

  Or point at a specific directory with --data-dir:
    npx cabinetai run --data-dir ~/Documents/Cabinet
exit code: 1
HOME unchanged.
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages when bootstrap encounters restricted directories, now with detailed guidance on using the --data-dir flag, starting in fresh folders, and handling indexing.
  * Improved bootstrap risk detection to provide informative warnings for certain directory scenarios instead of immediate failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->