### PR TITLE
fix(agents): editable heartbeat row + real toggle switch on schedule UI

### DIFF
--- a/src/components/agents/agent-detail-v2.tsx
+++ b/src/components/agents/agent-detail-v2.tsx
@@ -78,6 +78,8 @@ import { cronToHuman } from "@/lib/agents/cron-utils";
 import { getAgentColor, tintFromHex } from "@/lib/agents/cron-compute";
 import { ScheduleCalendar } from "@/components/cabinets/schedule-calendar";
 import { NewRoutineDialog } from "@/components/agents/new-routine-dialog";
+import { HeartbeatDialog } from "@/components/agents/heartbeat-dialog";
+import { Switch } from "@/components/ui/switch";
 import type { JobConfig } from "@/types/jobs";
 import {
   TaskRuntimePicker,
@@ -517,8 +519,8 @@ function TopBar({
           />
           <TooltipContent>
             {persona.active
-              ? "Stop this agent — pauses heartbeat and all scheduled jobs. Manual chats still work."
-              : "Resume this agent — re-enables heartbeat and scheduled jobs."}
+              ? "Pause this agent's heartbeat. Scheduled routines below keep running unless you turn each one off. Manual chats still work."
+              : "Resume this agent's heartbeat."}
           </TooltipContent>
         </Tooltip>
 
@@ -1393,6 +1395,7 @@ function ScheduleSection({
   onRunJob,
   onAddRoutine,
   onEditRoutine,
+  onEditHeartbeat,
   onRunHeartbeat,
   onToggleActive,
   onManage,
@@ -1403,6 +1406,7 @@ function ScheduleSection({
   onRunJob: (id: string) => void;
   onAddRoutine: () => void;
   onEditRoutine: (job: AgentJob) => void;
+  onEditHeartbeat: () => void;
   onRunHeartbeat: () => void;
   onToggleActive: () => void;
   onManage: () => void;
@@ -1423,23 +1427,23 @@ function ScheduleSection({
       <ul className="space-y-0">
         {/* Heartbeat */}
         <li className="flex items-center gap-3 px-2 py-2.5 -mx-2 rounded-md hover:bg-accent/30 transition-colors">
-          <Zap className={cn("h-3.5 w-3.5 shrink-0", persona.active ? "text-amber-500" : "text-muted-foreground/40")} />
-          <span className={cn("flex-1 text-[13px]", !persona.active && "text-muted-foreground/60")}>Heartbeat</span>
-          <span className="text-[11px] text-muted-foreground tabular-nums">
-            {cronToHuman(persona.heartbeat)}
-          </span>
           <button
-            onClick={onToggleActive}
-            className={cn(
-              "text-[10px] uppercase tracking-wider font-medium px-1.5 py-0.5 rounded transition-colors",
-              persona.active
-                ? "bg-green-500/10 text-green-600 dark:text-green-400"
-                : "bg-muted text-muted-foreground"
-            )}
-            title={persona.active ? "Pause heartbeat (stops all scheduled jobs)" : "Resume heartbeat"}
+            type="button"
+            onClick={onEditHeartbeat}
+            className="flex flex-1 items-center gap-3 text-left"
+            title="Edit heartbeat"
           >
-            {persona.active ? "on" : "off"}
+            <Zap className={cn("h-3.5 w-3.5 shrink-0", persona.active ? "text-amber-500" : "text-muted-foreground/40")} />
+            <span className={cn("flex-1 text-[13px]", !persona.active && "text-muted-foreground/60")}>Heartbeat</span>
+            <span className="text-[11px] text-muted-foreground tabular-nums">
+              {cronToHuman(persona.heartbeat)}
+            </span>
           </button>
+          <Switch
+            checked={persona.active}
+            onCheckedChange={onToggleActive}
+            aria-label={persona.active ? "Pause heartbeat" : "Resume heartbeat"}
+          />
           <Button
             variant="ghost"
             size="icon-sm"
@@ -1469,17 +1473,11 @@ function ScheduleSection({
                 {cronToHuman(job.schedule)}
               </span>
             </button>
-            <button
-              onClick={() => onToggleJob(job.id)}
-              className={cn(
-                "text-[10px] uppercase tracking-wider font-medium px-1.5 py-0.5 rounded transition-colors",
-                job.enabled
-                  ? "bg-green-500/10 text-green-600 dark:text-green-400"
-                  : "bg-muted text-muted-foreground"
-              )}
-            >
-              {job.enabled ? "on" : "off"}
-            </button>
+            <Switch
+              checked={job.enabled}
+              onCheckedChange={() => onToggleJob(job.id)}
+              aria-label={job.enabled ? `Disable ${job.name}` : `Enable ${job.name}`}
+            />
             <Button
               variant="ghost"
               size="icon-sm"
@@ -2178,6 +2176,7 @@ export function AgentDetailV2({
   const [startingTaskId, setStartingTaskId] = useState<string | null>(null);
   const [routineDialogOpen, setRoutineDialogOpen] = useState(false);
   const [routineEditJob, setRoutineEditJob] = useState<JobConfig | null>(null);
+  const [heartbeatDialogOpen, setHeartbeatDialogOpen] = useState(false);
 
   // Schedule handoff — lets the user convert the current composer draft into
   // a recurring routine or heartbeat by opening StartWorkDialog seeded with
@@ -2603,6 +2602,7 @@ export function AgentDetailV2({
                   setRoutineEditJob(job as unknown as JobConfig);
                   setRoutineDialogOpen(true);
                 }}
+                onEditHeartbeat={() => setHeartbeatDialogOpen(true)}
                 onRunHeartbeat={runHeartbeat}
                 onToggleActive={togglingActive ? () => {} : toggleActive}
                 onManage={() => setScheduleOpen(true)}
@@ -2640,6 +2640,23 @@ export function AgentDetailV2({
           onDeleted={() => {
             setRoutineEditJob(null);
             void refresh();
+          }}
+        />
+
+        <HeartbeatDialog
+          open={heartbeatDialogOpen}
+          onOpenChange={setHeartbeatDialogOpen}
+          agent={{
+            slug: persona.slug,
+            name: persona.name,
+            role: persona.role,
+            cabinetPath: persona.cabinetPath || effectiveCabinetPath || "",
+          }}
+          initialHeartbeat={persona.heartbeat}
+          initialActive={persona.active}
+          onSaved={() => void refresh()}
+          onToggledActive={(active) => {
+            setPersona((prev) => (prev ? { ...prev, active } : prev));
           }}
         />
 

--- a/src/components/agents/schedule-row.tsx
+++ b/src/components/agents/schedule-row.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useState, type KeyboardEvent, type MouseEvent } from "react";
-import { Check, Loader2, Play, Power, Trash2, X } from "lucide-react";
+import { Check, Loader2, Play, Trash2, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { AgentAvatar } from "@/components/agents/agent-avatar";
+import { Switch } from "@/components/ui/switch";
 import { cronToHuman } from "@/lib/agents/cron-utils";
 import type { AgentListItem } from "@/types/agents";
 import type { JobConfig } from "@/types/jobs";
@@ -49,8 +50,7 @@ function ScheduleRow({
     }
   }
 
-  async function handleToggle(e: MouseEvent) {
-    e.stopPropagation();
+  async function handleToggle() {
     if (toggling) return;
     setToggling(true);
     try {
@@ -85,7 +85,10 @@ function ScheduleRow({
     }
   }
 
-  const actionSlotWidth = onDelete ? "w-[92px]" : "w-[64px]";
+  const actionSlotWidth = onDelete ? "w-[64px]" : "w-[36px]";
+  const toggleLabel = disabled
+    ? toggleVerb === "pause" ? "Resume" : "Enable"
+    : toggleVerb === "pause" ? "Pause" : "Disable";
 
   return (
     <div
@@ -166,25 +169,6 @@ function ScheduleRow({
                 <Play className="size-3.5" />
               )}
             </button>
-            <button
-              type="button"
-              onClick={handleToggle}
-              disabled={toggling}
-              className={cn(
-                "inline-flex size-7 items-center justify-center rounded-md opacity-0 transition-opacity hover:bg-muted focus:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100 disabled:opacity-60",
-                disabled
-                  ? "text-muted-foreground hover:text-emerald-500"
-                  : "text-emerald-500 hover:text-muted-foreground"
-              )}
-              aria-label={disabled ? (toggleVerb === "pause" ? "Resume" : "Enable") : (toggleVerb === "pause" ? "Pause" : "Disable")}
-              title={disabled ? (toggleVerb === "pause" ? "Resume" : "Enable") : (toggleVerb === "pause" ? "Pause" : "Disable")}
-            >
-              {toggling ? (
-                <Loader2 className="size-3.5 animate-spin" />
-              ) : (
-                <Power className="size-3.5" />
-              )}
-            </button>
             {onDelete ? (
               <button
                 type="button"
@@ -205,14 +189,19 @@ function ScheduleRow({
         <span className="whitespace-nowrap text-[11px] text-muted-foreground">
           {schedule ? cronToHuman(schedule) : ""}
         </span>
-        <span
-          className={cn(
-            "size-1.5 rounded-full",
-            disabled ? "bg-muted-foreground/40" : "bg-emerald-500"
-          )}
-          aria-label={disabled ? "Disabled" : "Active"}
-          title={disabled ? "Disabled" : "Active"}
-        />
+        <div
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+          aria-label={toggleLabel}
+          title={toggleLabel}
+        >
+          <Switch
+            checked={!disabled}
+            onCheckedChange={() => void handleToggle()}
+            disabled={toggling}
+            aria-label={toggleLabel}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Switch as SwitchPrimitive } from "@base-ui/react/switch";
+import { cn } from "@/lib/utils";
+
+function Switch({
+  className,
+  ...props
+}: SwitchPrimitive.Root.Props) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "peer relative inline-flex h-4 w-7 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50",
+        "data-[checked]:bg-emerald-500/80 data-[unchecked]:bg-muted-foreground/30",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        className={cn(
+          "pointer-events-none block size-3 rounded-full bg-background shadow-sm ring-0 transition-transform",
+          "data-[checked]:translate-x-3.5 data-[unchecked]:translate-x-0.5"
+        )}
+      />
+    </SwitchPrimitive.Root>
+  );
+}
+
+export { Switch };


### PR DESCRIPTION
## Summary

Three related fixes around agent routines + heartbeats, surfaced in Discord by frozar and Collin:

- **Heartbeat row in agent settings is now editable.** Previously the Heartbeat row in the Schedule section had no `onClick` handler at all (`agent-detail-v2.tsx:1424–1453`) — clicking it did nothing. It now opens `HeartbeatDialog`, same as routines open `NewRoutineDialog`.
- **Replaced text-pill on/off + hover-only Power icon with a real toggle Switch.** The badges read as status, not affordance. New `src/components/ui/switch.tsx` wraps `@base-ui/react/switch`. Used in:
  - `agent-detail-v2.tsx` Schedule section (heartbeat + each routine row)
  - `schedule-row.tsx` (the `/agents` view's `RoutineRow` + `HeartbeatRow`)
- **Honest tooltip on the top-right Active/Stopped button.** It claimed it pauses "heartbeat and all scheduled jobs," but the daemon (`server/cabinet-daemon.ts:1268`) only gates on `job.enabled`, not `agent.active` — so a "Stopped" agent's enabled routines kept firing. Reworded to match reality: the toggle pauses the heartbeat; routines below keep running unless you turn each one off.

## Out of scope (intentional)

The deeper fix would be to give the heartbeat its own `enabled` flag, separate from `agent.active`, so the top-level toggle can truly stop everything without removing the ability to disable just the heartbeat. That's a data-model change touching persona schema, daemon scheduling, and `cron-compute.ts` — kept it out of this PR. Today's behavior (Active toggle == heartbeat toggle, routines independent) is now at least documented.

## Scope note

User asked to also cover "main cabinet view" (`#/home`). That route renders `HomeScreen` which has no on/off toggles — so nothing to change there. Coverage is the agent detail page + the `/agents` workspace.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` on changed files clean (existing unrelated warnings remain)
- [x] In a real browser (Chrome via chrome-devtools MCP):
  - [x] `/agents` heartbeats list shows always-visible Switches; clicking one toggles state and updates server
  - [x] Agent detail Schedule section: clicking the Heartbeat row opens the heartbeat edit dialog
  - [x] Agent detail Schedule section: Switch toggles in sync with the top-right Active/Stopped button (both reflect `agent.active`)
  - [x] Toggling the Switch off disables the Run-now button as expected
  - [x] No console errors / warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Heartbeat configuration is now directly editable with a dedicated management dialog in the agent detail view.

* **Style**
  * Schedule toggle controls improved with switch component for enhanced accessibility and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->