### PR TITLE
feat(agents): master switch + per-heartbeat toggle

### DIFF
--- a/server/cabinet-daemon.ts
+++ b/server/cabinet-daemon.ts
@@ -1212,6 +1212,10 @@ async function reloadSchedules(): Promise<void> {
     const agentsDir = path.join(cabinet.absDir, ".agents");
 
     // --- Heartbeats from .agents/*/persona.md ---
+    // Also collect active-agent slugs per cabinet so jobs owned by an
+    // inactive (Stopped) agent don't get scheduled. Master switch =
+    // `agent.active`; per-heartbeat enable = `agent.heartbeatEnabled`.
+    const activeAgents = new Set<string>();
     if (fs.existsSync(agentsDir)) {
       let agentEntries: fs.Dirent[];
       try {
@@ -1229,8 +1233,10 @@ async function reloadSchedules(): Promise<void> {
             const rawPersona = fs.readFileSync(personaPath, "utf-8");
             const { data } = matter(rawPersona);
             const active = data.active !== false;
+            const heartbeatEnabled = data.heartbeatEnabled !== false;
             const heartbeat = typeof data.heartbeat === "string" ? data.heartbeat : "";
-            if (active && heartbeat) {
+            if (active) activeAgents.add(entry.name);
+            if (active && heartbeatEnabled && heartbeat) {
               scheduleHeartbeat(entry.name, heartbeat, cabinet.relPath);
               heartbeatCount++;
             }
@@ -1265,7 +1271,13 @@ async function reloadSchedules(): Promise<void> {
             agentSlug: ownerAgent,
             cabinetPath: cabinet.relPath,
           };
-          if (config.id && config.enabled && config.schedule && ownerAgent) {
+          if (
+            config.id &&
+            config.enabled &&
+            config.schedule &&
+            ownerAgent &&
+            activeAgents.has(ownerAgent)
+          ) {
             scheduleJob(config);
             jobCount++;
           }

--- a/src/app/api/agents/events/route.ts
+++ b/src/app/api/agents/events/route.ts
@@ -58,7 +58,7 @@ export async function GET() {
           // Gather current state
           const personas = await listAllPersonas();
           const registered = personas
-            .filter((persona) => persona.active && !!persona.heartbeat)
+            .filter((persona) => persona.active && persona.heartbeatEnabled && !!persona.heartbeat)
             .map((persona) => persona.slug);
           const runningCounts = await getRunningConversationCounts();
 

--- a/src/app/api/agents/personas/route.ts
+++ b/src/app/api/agents/personas/route.ts
@@ -29,7 +29,7 @@ export async function GET(req: NextRequest) {
   );
   const personas = await listPersonas(cabinetPath);
   const activeHeartbeats = personas
-    .filter((persona) => persona.active && !!persona.heartbeat)
+    .filter((persona) => persona.active && persona.heartbeatEnabled && !!persona.heartbeat)
     .map((persona) => persona.slug);
   const runningCounts = await getRunningConversationCounts();
 

--- a/src/app/api/agents/scheduler/route.ts
+++ b/src/app/api/agents/scheduler/route.ts
@@ -11,7 +11,7 @@ import { reloadDaemonSchedules } from "@/lib/agents/daemon-client";
 export async function GET() {
   const personas = await listAllPersonas();
   const registered = personas
-    .filter((persona) => persona.active && !!persona.heartbeat)
+    .filter((persona) => persona.active && persona.heartbeatEnabled && !!persona.heartbeat)
     .map((persona) => ({
       slug: persona.slug,
       cabinetPath: persona.cabinetPath,
@@ -90,6 +90,26 @@ export async function POST(req: NextRequest) {
       }
       await reloadDaemonSchedules().catch(() => {});
       return NextResponse.json({ ok: true, paused: toPause.length });
+    }
+
+    case "pause-heartbeats": {
+      // Disable heartbeats only — leaves agent.active alone so other
+      // routines keep firing. Used by the "Pause all heartbeats" button.
+      const toPause = personas.filter((p) => p.heartbeatEnabled !== false);
+      for (const p of toPause) {
+        await writePersona(p.slug, { heartbeatEnabled: false }, p.cabinetPath);
+      }
+      await reloadDaemonSchedules().catch(() => {});
+      return NextResponse.json({ ok: true, paused: toPause.length });
+    }
+
+    case "resume-heartbeats": {
+      const toResume = personas.filter((p) => p.heartbeatEnabled === false);
+      for (const p of toResume) {
+        await writePersona(p.slug, { heartbeatEnabled: true }, p.cabinetPath);
+      }
+      await reloadDaemonSchedules().catch(() => {});
+      return NextResponse.json({ ok: true, resumed: toResume.length });
     }
 
     case "activate": {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -223,6 +223,17 @@ html[data-custom-theme] .tiptap h4 {
   animation: cabinet-tree-blink 1.4s ease-in-out;
 }
 
+/* One-shot ring pulse for the agent header master Switch — fired when a
+   user clicks a locked child Switch to point them at the toggle they need. */
+@keyframes cabinet-master-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(245, 158, 11, 0.6); }
+  60% { box-shadow: 0 0 0 6px rgba(245, 158, 11, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(245, 158, 11, 0); }
+}
+.cabinet-master-pulse {
+  animation: cabinet-master-pulse 700ms ease-out;
+}
+
 /* Body serif — Source Serif 4, beats theme overrides */
 html[data-custom-theme] .font-body-serif,
 .font-body-serif {

--- a/src/components/agents/agent-detail-v2.tsx
+++ b/src/components/agents/agent-detail-v2.tsx
@@ -79,6 +79,7 @@ import { ScheduleCalendar } from "@/components/cabinets/schedule-calendar";
 import { NewRoutineDialog } from "@/components/agents/new-routine-dialog";
 import { HeartbeatDialog } from "@/components/agents/heartbeat-dialog";
 import { Switch } from "@/components/ui/switch";
+import { LockedSwitch } from "@/components/ui/locked-switch";
 import type { JobConfig } from "@/types/jobs";
 import {
   TaskRuntimePicker,
@@ -444,6 +445,7 @@ function TopBar({
   onToggleCanDispatch,
   onExport,
   onDelete,
+  pulseToken = 0,
 }: {
   persona: AgentPersona;
   status: AgentStatus;
@@ -454,11 +456,22 @@ function TopBar({
   onToggleCanDispatch: () => void;
   onExport: () => void;
   onDelete: () => void;
+  /** Bumped from outside (locked child Switch click) to nudge the user
+   *  toward the master toggle with a brief ring animation. */
+  pulseToken?: number;
 }) {
   const { t } = useLocale();
   const palette = persona.color
     ? tintFromHex(persona.color)
     : getAgentColor(persona.slug);
+
+  const [pulsing, setPulsing] = useState(false);
+  useEffect(() => {
+    if (pulseToken === 0) return;
+    setPulsing(true);
+    const t = setTimeout(() => setPulsing(false), 700);
+    return () => clearTimeout(t);
+  }, [pulseToken]);
 
   return (
     <div className="flex items-center justify-between px-6 pt-4">
@@ -505,10 +518,11 @@ function TopBar({
             render={
               <label
                 className={cn(
-                  "inline-flex items-center gap-2 h-7 rounded-md border px-2.5 text-[12px] font-medium transition-colors cursor-pointer select-none",
+                  "inline-flex items-center gap-2 h-7 rounded-md border px-2.5 text-[12px] font-medium transition-colors cursor-pointer select-none ring-offset-2 ring-offset-background",
                   persona.active
                     ? "border-border hover:bg-accent/40"
-                    : "border-dashed border-border/60 text-muted-foreground hover:bg-accent/30"
+                    : "border-dashed border-border/60 text-muted-foreground hover:bg-accent/30",
+                  pulsing && "ring-2 ring-amber-500 animate-pulse"
                 )}
                 style={persona.active ? { color: palette.text } : undefined}
               >
@@ -1403,6 +1417,7 @@ function ScheduleSection({
   onEditHeartbeat,
   onRunHeartbeat,
   onToggleHeartbeat,
+  onLockedChildClick,
   onManage,
 }: {
   persona: AgentPersona;
@@ -1414,11 +1429,14 @@ function ScheduleSection({
   onEditHeartbeat: () => void;
   onRunHeartbeat: () => void;
   onToggleHeartbeat: () => void;
+  onLockedChildClick?: () => void;
   onManage: () => void;
 }) {
   const { t } = useLocale();
   const heartbeatOn = persona.heartbeatEnabled !== false;
   const heartbeatEffective = persona.active && heartbeatOn;
+  const lockedTooltip =
+    "This agent is stopped. Heartbeat and routines won't fire until you start it.";
 
   return (
     <Section
@@ -1447,10 +1465,13 @@ function ScheduleSection({
               {cronToHuman(persona.heartbeat)}
             </span>
           </button>
-          <Switch
+          <LockedSwitch
             checked={heartbeatOn}
             onCheckedChange={onToggleHeartbeat}
-            aria-label={heartbeatOn ? "Pause heartbeat" : "Resume heartbeat"}
+            locked={!persona.active}
+            onLockedClick={onLockedChildClick}
+            tooltip={lockedTooltip}
+            ariaLabel={heartbeatOn ? "Pause heartbeat" : "Resume heartbeat"}
           />
           <Button
             variant="ghost"
@@ -1483,10 +1504,13 @@ function ScheduleSection({
                 {cronToHuman(job.schedule)}
               </span>
             </button>
-            <Switch
+            <LockedSwitch
               checked={job.enabled}
               onCheckedChange={() => onToggleJob(job.id)}
-              aria-label={job.enabled ? `Disable ${job.name}` : `Enable ${job.name}`}
+              locked={!persona.active}
+              onLockedClick={onLockedChildClick}
+              tooltip={lockedTooltip}
+              ariaLabel={job.enabled ? `Disable ${job.name}` : `Enable ${job.name}`}
             />
             <Button
               variant="ghost"
@@ -2192,6 +2216,11 @@ export function AgentDetailV2({
   const [routineDialogOpen, setRoutineDialogOpen] = useState(false);
   const [routineEditJob, setRoutineEditJob] = useState<JobConfig | null>(null);
   const [heartbeatDialogOpen, setHeartbeatDialogOpen] = useState(false);
+  // Bumped each time a locked child Switch is clicked. The TopBar's master
+  // Switch consumes this to run a brief ring pulse, visually pointing the
+  // user to the toggle they need to flip.
+  const [masterPulseToken, setMasterPulseToken] = useState(0);
+  const pulseMaster = useCallback(() => setMasterPulseToken((n) => n + 1), []);
 
   // Schedule handoff — lets the user convert the current composer draft into
   // a recurring routine or heartbeat by opening StartWorkDialog seeded with
@@ -2577,6 +2606,7 @@ export function AgentDetailV2({
             onToggleCanDispatch={toggleCanDispatch}
             onExport={handleExport}
             onDelete={handleDelete}
+            pulseToken={masterPulseToken}
           />
         </div>
         {scheduleOpen ? (
@@ -2634,6 +2664,7 @@ export function AgentDetailV2({
                 onEditHeartbeat={() => setHeartbeatDialogOpen(true)}
                 onRunHeartbeat={runHeartbeat}
                 onToggleHeartbeat={toggleHeartbeat}
+                onLockedChildClick={pulseMaster}
                 onManage={() => setScheduleOpen(true)}
               />
               <DetailsSection

--- a/src/components/agents/agent-detail-v2.tsx
+++ b/src/components/agents/agent-detail-v2.tsx
@@ -465,13 +465,10 @@ function TopBar({
     ? tintFromHex(persona.color)
     : getAgentColor(persona.slug);
 
-  const [pulsing, setPulsing] = useState(false);
-  useEffect(() => {
-    if (pulseToken === 0) return;
-    setPulsing(true);
-    const t = setTimeout(() => setPulsing(false), 700);
-    return () => clearTimeout(t);
-  }, [pulseToken]);
+  // Each new pulseToken bump remounts the wrapper via `key`, restarting the
+  // one-shot CSS animation defined in globals.css (`cabinet-master-pulse`).
+  // No React state needed for the on/off transition.
+  const pulseKey = pulseToken > 0 ? `pulse-${pulseToken}` : "pulse-idle";
 
   return (
     <div className="flex items-center justify-between px-6 pt-4">
@@ -517,12 +514,13 @@ function TopBar({
           <TooltipTrigger
             render={
               <label
+                key={pulseKey}
                 className={cn(
-                  "inline-flex items-center gap-2 h-7 rounded-md border px-2.5 text-[12px] font-medium transition-colors cursor-pointer select-none ring-offset-2 ring-offset-background",
+                  "inline-flex items-center gap-2 h-7 rounded-md border px-2.5 text-[12px] font-medium transition-colors cursor-pointer select-none",
                   persona.active
                     ? "border-border hover:bg-accent/40"
                     : "border-dashed border-border/60 text-muted-foreground hover:bg-accent/30",
-                  pulsing && "ring-2 ring-amber-500 animate-pulse"
+                  pulseToken > 0 && "cabinet-master-pulse"
                 )}
                 style={persona.active ? { color: palette.text } : undefined}
               >

--- a/src/components/agents/agent-detail-v2.tsx
+++ b/src/components/agents/agent-detail-v2.tsx
@@ -30,7 +30,6 @@ import {
   Pencil,
   Play,
   Plus,
-  Power,
   Send,
   Share2,
   Sparkles,
@@ -504,26 +503,24 @@ function TopBar({
         <Tooltip>
           <TooltipTrigger
             render={
-              <button
-                type="button"
-                onClick={onToggleActive}
+              <label
                 className={cn(
-                  "inline-flex items-center gap-1.5 h-7 rounded-md border px-2.5 text-[12px] font-medium transition-colors",
+                  "inline-flex items-center gap-2 h-7 rounded-md border px-2.5 text-[12px] font-medium transition-colors cursor-pointer select-none",
                   persona.active
                     ? "border-border hover:bg-accent/40"
                     : "border-dashed border-border/60 text-muted-foreground hover:bg-accent/30"
                 )}
                 style={persona.active ? { color: palette.text } : undefined}
               >
-                <Power className="h-3.5 w-3.5" />
-                {persona.active ? "Active" : "Stopped"}
-              </button>
+                <Switch checked={persona.active} onCheckedChange={onToggleActive} />
+                <span>{persona.active ? "Working" : "Stopped"}</span>
+              </label>
             }
           />
           <TooltipContent>
             {persona.active
-              ? "Pause this agent's heartbeat. Scheduled routines below keep running unless you turn each one off. Manual chats still work."
-              : "Resume this agent's heartbeat."}
+              ? "Stop this agent. Scheduled heartbeat and routines won't fire. Manual chats and any in-flight runs keep working."
+              : "Start this agent. Scheduled heartbeat and routines resume on their own rhythm."}
           </TooltipContent>
         </Tooltip>
 
@@ -1405,7 +1402,7 @@ function ScheduleSection({
   onEditRoutine,
   onEditHeartbeat,
   onRunHeartbeat,
-  onToggleActive,
+  onToggleHeartbeat,
   onManage,
 }: {
   persona: AgentPersona;
@@ -1416,10 +1413,12 @@ function ScheduleSection({
   onEditRoutine: (job: AgentJob) => void;
   onEditHeartbeat: () => void;
   onRunHeartbeat: () => void;
-  onToggleActive: () => void;
+  onToggleHeartbeat: () => void;
   onManage: () => void;
 }) {
   const { t } = useLocale();
+  const heartbeatOn = persona.heartbeatEnabled !== false;
+  const heartbeatEffective = persona.active && heartbeatOn;
 
   return (
     <Section
@@ -1442,16 +1441,16 @@ function ScheduleSection({
             className="flex flex-1 items-center gap-3 text-left"
             title="Edit heartbeat"
           >
-            <Zap className={cn("h-3.5 w-3.5 shrink-0", persona.active ? "text-amber-500" : "text-muted-foreground/40")} />
-            <span className={cn("flex-1 text-[13px]", !persona.active && "text-muted-foreground/60")}>{t("agents:detail.heartbeat")}</span>
+            <Zap className={cn("h-3.5 w-3.5 shrink-0", heartbeatEffective ? "text-amber-500" : "text-muted-foreground/40")} />
+            <span className={cn("flex-1 text-[13px]", !heartbeatEffective && "text-muted-foreground/60")}>{t("agents:detail.heartbeat")}</span>
             <span className="text-[11px] text-muted-foreground tabular-nums">
               {cronToHuman(persona.heartbeat)}
             </span>
           </button>
           <Switch
-            checked={persona.active}
-            onCheckedChange={onToggleActive}
-            aria-label={persona.active ? "Pause heartbeat" : "Resume heartbeat"}
+            checked={heartbeatOn}
+            onCheckedChange={onToggleHeartbeat}
+            aria-label={heartbeatOn ? "Pause heartbeat" : "Resume heartbeat"}
           />
           <Button
             variant="ghost"
@@ -1459,13 +1458,15 @@ function ScheduleSection({
             className="h-7 w-7"
             onClick={onRunHeartbeat}
             title={t("agents:detail.runNow")}
-            disabled={!persona.active}
+            disabled={!heartbeatEffective}
           >
             <Play className="h-3 w-3" />
           </Button>
         </li>
         {/* Jobs */}
-        {jobs.map((job) => (
+        {jobs.map((job) => {
+          const jobEffective = persona.active && job.enabled;
+          return (
           <li
             key={job.id}
             className="flex items-center gap-3 px-2 py-2.5 -mx-2 rounded-md hover:bg-accent/30 transition-colors"
@@ -1476,8 +1477,8 @@ function ScheduleSection({
               className="flex flex-1 items-center gap-3 text-left"
               title={t("agents:detail.editRoutine")}
             >
-              <Briefcase className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-              <span className="flex-1 text-[13px] truncate">{job.name}</span>
+              <Briefcase className={cn("h-3.5 w-3.5 shrink-0", jobEffective ? "text-muted-foreground" : "text-muted-foreground/50")} />
+              <span className={cn("flex-1 text-[13px] truncate", !jobEffective && "text-muted-foreground/60")}>{job.name}</span>
               <span className="text-[11px] text-muted-foreground tabular-nums">
                 {cronToHuman(job.schedule)}
               </span>
@@ -1497,7 +1498,8 @@ function ScheduleSection({
               <Play className="h-3 w-3" />
             </Button>
           </li>
-        ))}
+          );
+        })}
         {/* Add */}
         <li>
           <button
@@ -2433,6 +2435,20 @@ export function AgentDetailV2({
     refresh();
   }, [slug, refresh, effectiveCabinetPath]);
 
+  const toggleHeartbeat = useCallback(async () => {
+    if (!persona) return;
+    const next = persona.heartbeatEnabled === false;
+    setPersona((prev) => (prev ? { ...prev, heartbeatEnabled: next } : prev));
+    const body: Record<string, unknown> = { heartbeatEnabled: next };
+    if (effectiveCabinetPath) body.cabinetPath = effectiveCabinetPath;
+    await fetch(`/api/agents/personas/${slug}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    refresh();
+  }, [persona, slug, refresh, effectiveCabinetPath]);
+
   const toggleCanDispatch = useCallback(async () => {
     if (!persona) return;
     const current =
@@ -2617,7 +2633,7 @@ export function AgentDetailV2({
                 }}
                 onEditHeartbeat={() => setHeartbeatDialogOpen(true)}
                 onRunHeartbeat={runHeartbeat}
-                onToggleActive={togglingActive ? () => {} : toggleActive}
+                onToggleHeartbeat={toggleHeartbeat}
                 onManage={() => setScheduleOpen(true)}
               />
               <DetailsSection
@@ -2666,10 +2682,10 @@ export function AgentDetailV2({
             cabinetPath: persona.cabinetPath || effectiveCabinetPath || "",
           }}
           initialHeartbeat={persona.heartbeat}
-          initialActive={persona.active}
+          initialEnabled={persona.heartbeatEnabled !== false}
           onSaved={() => void refresh()}
-          onToggledActive={(active) => {
-            setPersona((prev) => (prev ? { ...prev, active } : prev));
+          onToggledEnabled={(heartbeatEnabled) => {
+            setPersona((prev) => (prev ? { ...prev, heartbeatEnabled } : prev));
           }}
         />
 

--- a/src/components/agents/agent-row.tsx
+++ b/src/components/agents/agent-row.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState, type KeyboardEvent } from "react";
+import { Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { AgentAvatar } from "@/components/agents/agent-avatar";
+import { Switch } from "@/components/ui/switch";
+import { startCase } from "@/components/cabinets/cabinet-utils";
+import type { AgentListItem } from "@/types/agents";
+
+/**
+ * One row in the "Meet the team" list — same visual rhythm as the Routines
+ * rows. Click the row to open the agent. The Switch toggles `agent.active`
+ * (the master) without leaving the page.
+ */
+export function AgentRow({
+  agent,
+  onOpen,
+  onToggleActive,
+}: {
+  agent: AgentListItem;
+  onOpen: (slug: string) => void;
+  onToggleActive: (agent: AgentListItem) => void | Promise<void>;
+}) {
+  const [toggling, setToggling] = useState(false);
+
+  async function handleToggle() {
+    if (toggling) return;
+    setToggling(true);
+    try {
+      await onToggleActive(agent);
+    } finally {
+      setToggling(false);
+    }
+  }
+
+  function handleRowActivate() {
+    onOpen(agent.slug);
+  }
+
+  function handleKey(e: KeyboardEvent<HTMLDivElement>) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onOpen(agent.slug);
+    }
+  }
+
+  const isActive = agent.active;
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={handleRowActivate}
+      onKeyDown={handleKey}
+      className="group relative flex w-full items-center gap-3 px-4 py-2.5 text-left outline-none transition-colors hover:bg-muted/40 focus-visible:bg-muted/40"
+    >
+      <AgentAvatar
+        agent={agent}
+        shape="circle"
+        size="sm"
+        className={cn(!isActive && "saturate-50 opacity-60")}
+      />
+      <div className="flex min-w-0 flex-1 items-baseline gap-2 overflow-hidden">
+        <span
+          className={cn(
+            "truncate text-[12.5px] font-semibold",
+            isActive ? "text-foreground" : "text-muted-foreground/70"
+          )}
+        >
+          {agent.name}
+        </span>
+        {agent.role ? (
+          <span
+            className={cn(
+              "truncate text-[11.5px]",
+              isActive ? "text-muted-foreground" : "text-muted-foreground/60"
+            )}
+          >
+            · {agent.role}
+          </span>
+        ) : null}
+      </div>
+
+      <div className="flex shrink-0 items-center gap-2">
+        {agent.department ? (
+          <span
+            className={cn(
+              "hidden whitespace-nowrap rounded-full bg-muted/40 px-2 py-0.5 text-[10px] sm:inline-flex",
+              isActive ? "text-muted-foreground" : "text-muted-foreground/60"
+            )}
+          >
+            {startCase(agent.department)}
+          </span>
+        ) : null}
+        {agent.scope === "global" ? (
+          <span
+            className="hidden whitespace-nowrap rounded-full bg-violet-500/15 px-2 py-0.5 text-[10px] text-violet-300 sm:inline-flex"
+            title="Shared across all cabinets"
+          >
+            Global
+          </span>
+        ) : null}
+        <div
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+        >
+          <Switch
+            checked={isActive}
+            onCheckedChange={() => void handleToggle()}
+            disabled={toggling}
+            aria-label={isActive ? `Stop ${agent.name}` : `Start ${agent.name}`}
+          />
+        </div>
+        {toggling ? (
+          <Loader2 className="size-3.5 animate-spin text-muted-foreground/60" />
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/agents/agents-workspace.tsx
+++ b/src/components/agents/agents-workspace.tsx
@@ -51,6 +51,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { AgentAvatar } from "@/components/agents/agent-avatar";
 import { HeartbeatRow, RoutineRow } from "@/components/agents/schedule-row";
+import { AgentRow } from "@/components/agents/agent-row";
 import {
   appendConversationCabinetPath,
 } from "@/lib/agents/conversation-identity";
@@ -1473,6 +1474,21 @@ export function AgentsWorkspace({
     if (!res.ok) return;
     setAgents((prev) =>
       prev.map((a) => (a.slug === agent.slug ? { ...a, heartbeatEnabled: nextEnabled } : a))
+    );
+  }
+
+  async function listToggleAgentActive(agent: AgentListItem) {
+    const cabinetPath = agent.cabinetPath || effectiveCabinetPath;
+    const res = await fetch(`/api/agents/personas/${agent.slug}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "toggle", cabinetPath }),
+    });
+    if (!res.ok) return;
+    const data = (await res.json().catch(() => null)) as { active?: boolean } | null;
+    const nextActive = data?.active ?? !agent.active;
+    setAgents((prev) =>
+      prev.map((a) => (a.slug === agent.slug ? { ...a, active: nextActive } : a))
     );
   }
 
@@ -2932,16 +2948,16 @@ export function AgentsWorkspace({
                   </div>
                 )}
 
-                {/* Agents grid */}
+                {/* Agents list */}
                 <section className="space-y-4">
                   <div className="space-y-2">
                     <h2 className="text-[24px] font-semibold tracking-tight text-foreground sm:text-[28px]">
                       Meet the team
                     </h2>
                     <p className="max-w-3xl text-[14px] leading-6 text-muted-foreground">
-                      Each card is a specialist. Click one to open its profile
-                      and edit its name, role, and the instructions that shape
-                      how it thinks and works.
+                      Each row is a specialist. Click one to open its profile.
+                      Use the toggle on the right to start or stop an agent
+                      without leaving the page.
                     </p>
                     <p className="text-[12px] text-muted-foreground/80">
                       {orgAgentCount} on the team
@@ -2949,95 +2965,34 @@ export function AgentsWorkspace({
                   </div>
 
                   {!agentsLoaded ? (
-                    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                    <ul className="divide-y divide-border/60 overflow-hidden rounded-xl border border-border/70 bg-card">
                       {Array.from({ length: 3 }).map((_, i) => (
-                        <div
-                          key={i}
-                          className="flex flex-col gap-3 rounded-xl border border-border/40 bg-card/50 p-4 animate-pulse"
-                        >
-                          <div className="flex items-start gap-3">
-                            <div className="size-10 shrink-0 rounded-full bg-muted/60" />
-                            <div className="flex-1 space-y-2 pt-1">
-                              <div className="h-3 w-24 rounded bg-muted/60" />
-                              <div className="h-2.5 w-36 rounded bg-muted/40" />
-                            </div>
+                        <li key={i} className="flex items-center gap-3 px-4 py-3 animate-pulse">
+                          <div className="size-7 shrink-0 rounded-full bg-muted/60" />
+                          <div className="flex-1 space-y-2">
+                            <div className="h-3 w-32 rounded bg-muted/60" />
+                            <div className="h-2.5 w-48 rounded bg-muted/40" />
                           </div>
-                          <div className="flex gap-1.5">
-                            <div className="h-4 w-14 rounded-full bg-muted/40" />
-                            <div className="h-4 w-10 rounded-full bg-muted/40" />
-                          </div>
-                        </div>
+                          <div className="h-4 w-7 rounded-full bg-muted/40" />
+                        </li>
                       ))}
-                    </div>
+                    </ul>
                   ) : agents.length === 0 ? (
                     <p className="rounded-lg border border-dashed border-border/60 px-3 py-8 text-center text-[12px] text-muted-foreground">
                       No agents yet. Use <span className="font-medium text-foreground">{t("agents:workspace.newAgent")}</span> above to bring one in.
                     </p>
                   ) : (
-                    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-                      {agents.map((agent) => {
-                        const hbCount = agent.heartbeat ? 1 : 0;
-                        const jobCount = agent.jobCount || 0;
-                        return (
-                          <button
-                            key={agent.scopedId ?? (agent.cabinetPath ? `${agent.cabinetPath}::${agent.slug}` : agent.slug)}
-                            type="button"
-                            onClick={() => openAgentSettings(agent.slug)}
-                            className="flex flex-col gap-3 rounded-xl border border-border/70 bg-card p-4 text-left transition-colors hover:bg-muted/30"
-                          >
-                            <div className="flex items-start gap-3">
-                              <AgentAvatar agent={agent} shape="circle" size="lg" />
-                              <div className="min-w-0 flex-1">
-                                <h3 className="truncate text-[13px] font-semibold text-foreground">
-                                  {agent.name}
-                                </h3>
-                                {agent.role ? (
-                                  <p className="mt-0.5 line-clamp-2 text-[11px] leading-snug text-muted-foreground">
-                                    {agent.role}
-                                  </p>
-                                ) : null}
-                              </div>
-                              <span
-                                className={cn(
-                                  "mt-1.5 inline-flex size-2 shrink-0 rounded-full",
-                                  agent.active
-                                    ? "bg-emerald-500"
-                                    : "bg-muted-foreground/30"
-                                )}
-                                title={agent.active ? "Active" : "Paused"}
-                              />
-                            </div>
-                            <div className="flex flex-wrap items-center gap-1.5 text-[10px] text-muted-foreground">
-                              {agent.scope === "global" ? (
-                                <span
-                                  className="inline-flex items-center rounded-full bg-violet-500/15 px-2 py-0.5 text-violet-300"
-                                  title={t("agents:workspace.sharedAcrossCabinets")}
-                                >
-                                  Global
-                                </span>
-                              ) : null}
-                              {hbCount > 0 ? (
-                                <span className="inline-flex items-center gap-1 rounded-full bg-muted/40 px-2 py-0.5">
-                                  <HeartPulse className="size-2.5 text-pink-400" />
-                                  Heartbeat
-                                </span>
-                              ) : null}
-                              {jobCount > 0 ? (
-                                <span className="inline-flex items-center gap-1 rounded-full bg-muted/40 px-2 py-0.5">
-                                  <Clock3 className="size-2.5 text-emerald-400" />
-                                  {jobCount} {jobCount === 1 ? "job" : "jobs"}
-                                </span>
-                              ) : null}
-                              {agent.department ? (
-                                <span className="inline-flex rounded-full bg-muted/40 px-2 py-0.5">
-                                  {startCase(agent.department)}
-                                </span>
-                              ) : null}
-                            </div>
-                          </button>
-                        );
-                      })}
-                    </div>
+                    <ul className="divide-y divide-border/60 overflow-hidden rounded-xl border border-border/70 bg-card">
+                      {agents.map((agent) => (
+                        <li key={agent.scopedId ?? (agent.cabinetPath ? `${agent.cabinetPath}::${agent.slug}` : agent.slug)}>
+                          <AgentRow
+                            agent={agent}
+                            onOpen={openAgentSettings}
+                            onToggleActive={listToggleAgentActive}
+                          />
+                        </li>
+                      ))}
+                    </ul>
                   )}
                 </section>
 

--- a/src/components/agents/agents-workspace.tsx
+++ b/src/components/agents/agents-workspace.tsx
@@ -328,12 +328,13 @@ function blankJobDraft(
 // surrounding view conditionally renders.
 function ToggleAllHeartbeatsButton({
   heartbeatAgents,
-  anyActive,
+  anyEnabled,
   effectiveCabinetPath,
   refreshAgents,
 }: {
   heartbeatAgents: AgentListItem[];
-  anyActive: boolean;
+  /** At least one heartbeat is on (heartbeatEnabled !== false). */
+  anyEnabled: boolean;
   effectiveCabinetPath: string | undefined;
   refreshAgents: () => Promise<void>;
 }) {
@@ -347,7 +348,7 @@ function ToggleAllHeartbeatsButton({
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          action: anyActive ? "stop-all" : "start-all",
+          action: anyEnabled ? "pause-heartbeats" : "resume-heartbeats",
           cabinetPath: effectiveCabinetPath,
         }),
       });
@@ -362,10 +363,10 @@ function ToggleAllHeartbeatsButton({
       onClick={() => void toggleAll()}
       disabled={toggling}
       className="inline-flex h-9 items-center gap-2 rounded-lg border border-border/70 bg-background px-3 text-[12px] font-medium text-foreground transition-colors hover:bg-muted/50 disabled:pointer-events-none disabled:opacity-50"
-      title={anyActive ? "Pause all heartbeats in this cabinet" : "Resume all heartbeats in this cabinet"}
+      title={anyEnabled ? "Pause all heartbeats in this cabinet" : "Resume all heartbeats in this cabinet"}
     >
-      {anyActive ? <Pause className="size-3.5" /> : <Play className="size-3.5" />}
-      {anyActive ? "Pause all" : "Resume all"}
+      {anyEnabled ? <Pause className="size-3.5" /> : <Play className="size-3.5" />}
+      {anyEnabled ? "Pause all" : "Resume all"}
     </button>
   );
 }
@@ -493,7 +494,7 @@ export function AgentsWorkspace({
   const [heartbeatDialog, setHeartbeatDialog] = useState<{
     agent: NewRoutineDialogAgent;
     initialHeartbeat?: string;
-    initialActive?: boolean;
+    initialEnabled?: boolean;
   } | null>(null);
   const [cabinetJobs, setCabinetJobs] = useState<CabinetJobSummary[]>([]);
   const [cabinetChildren, setCabinetChildren] = useState<CabinetOverview["children"]>([]);
@@ -666,6 +667,7 @@ export function AgentsWorkspace({
           emoji: a.emoji || "🤖",
           role: a.role || "",
           active: a.active,
+          heartbeatEnabled: a.heartbeatEnabled,
           type: a.type,
           department: a.department,
           heartbeat: a.heartbeat || "",
@@ -1458,19 +1460,19 @@ export function AgentsWorkspace({
 
   async function listToggleHeartbeat(agent: AgentListItem) {
     const cabinetPath = agent.cabinetPath || effectiveCabinetPath;
-    const nextActive = !agent.active;
+    const nextEnabled = agent.heartbeatEnabled === false;
     const res = await fetch(`/api/agents/personas/${agent.slug}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         heartbeat: agent.heartbeat || "",
-        active: nextActive,
+        heartbeatEnabled: nextEnabled,
         cabinetPath,
       }),
     });
     if (!res.ok) return;
     setAgents((prev) =>
-      prev.map((a) => (a.slug === agent.slug ? { ...a, active: nextActive } : a))
+      prev.map((a) => (a.slug === agent.slug ? { ...a, heartbeatEnabled: nextEnabled } : a))
     );
   }
 
@@ -1845,6 +1847,7 @@ export function AgentsWorkspace({
         emoji: a.emoji,
         role: a.role,
         active: a.active,
+        heartbeatEnabled: a.heartbeatEnabled,
         department: a.department,
         type: a.type,
         heartbeat: a.heartbeat,
@@ -3166,7 +3169,7 @@ export function AgentsWorkspace({
                               cabinetPath: agent.cabinetPath || effectiveCabinetPath,
                             },
                             initialHeartbeat: agent.heartbeat || "0 9 * * 1-5",
-                            initialActive: agent.active,
+                            initialEnabled: agent.heartbeatEnabled !== false,
                           });
                         }}
                       />
@@ -3245,7 +3248,7 @@ export function AgentsWorkspace({
                       </div>
                       <ToggleAllHeartbeatsButton
                         heartbeatAgents={agents.filter((a) => !!a.heartbeat)}
-                        anyActive={agents.filter((a) => !!a.heartbeat).some((a) => a.active)}
+                        anyEnabled={agents.filter((a) => !!a.heartbeat).some((a) => a.heartbeatEnabled !== false)}
                         effectiveCabinetPath={effectiveCabinetPath}
                         refreshAgents={refreshAgents}
                       />
@@ -3312,7 +3315,7 @@ export function AgentsWorkspace({
                                         agent.cabinetPath || effectiveCabinetPath,
                                     },
                                     initialHeartbeat: agent.heartbeat!,
-                                    initialActive: agent.active,
+                                    initialEnabled: agent.heartbeatEnabled !== false,
                                   })
                                 }
                                 onRun={() => listRunHeartbeat(agent)}
@@ -3405,7 +3408,7 @@ export function AgentsWorkspace({
                     cabinetPath: agent.cabinetPath || effectiveCabinetPath,
                   },
                   initialHeartbeat: agent.heartbeat || "0 9 * * 1-5",
-                  initialActive: agent.active,
+                  initialEnabled: agent.heartbeatEnabled !== false,
                 });
               }}
             />
@@ -3800,17 +3803,17 @@ export function AgentsWorkspace({
         }}
         agent={heartbeatDialog?.agent ?? { slug: "", name: "" }}
         initialHeartbeat={heartbeatDialog?.initialHeartbeat}
-        initialActive={heartbeatDialog?.initialActive}
+        initialEnabled={heartbeatDialog?.initialEnabled}
         onSaved={() => {
           setHeartbeatDialog(null);
           void refreshAgents();
         }}
-        onToggledActive={(nextActive) => {
+        onToggledEnabled={(nextEnabled) => {
           const targetSlug = heartbeatDialog?.agent.slug;
           if (!targetSlug) return;
           setAgents((prev) =>
             prev.map((a) =>
-              a.slug === targetSlug ? { ...a, active: nextActive } : a
+              a.slug === targetSlug ? { ...a, heartbeatEnabled: nextEnabled } : a
             )
           );
         }}

--- a/src/components/agents/heartbeat-dialog.tsx
+++ b/src/components/agents/heartbeat-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { AlertTriangle, ExternalLink, HeartPulse, Loader2, Play, Power, Save } from "lucide-react";
+import { AlertTriangle, ExternalLink, HeartPulse, Loader2, Play, Save } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -10,6 +10,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 import { SchedulePicker } from "@/components/mission-control/schedule-picker";
 import { AgentAvatar } from "@/components/agents/agent-avatar";
@@ -184,28 +185,25 @@ export function HeartbeatDialog({
                 )}
                 Run now
               </Button>
-              <Button
-                variant="outline"
-                size="sm"
+              <label
                 className={cn(
-                  "h-9 gap-1.5 text-[12px]",
-                  !enabled && "text-emerald-600 dark:text-emerald-400"
+                  "inline-flex h-9 cursor-pointer select-none items-center gap-2 rounded-md border border-input px-3 text-[12px] font-medium transition-colors hover:bg-accent/40",
+                  toggling && "opacity-60"
                 )}
-                onClick={() => void toggleEnabled()}
-                disabled={toggling}
                 title={
                   enabled
                     ? "Disable the heartbeat — it won't fire on its schedule"
                     : "Enable the heartbeat so it fires on its schedule"
                 }
               >
-                {toggling ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                ) : (
-                  <Power className="h-3.5 w-3.5" />
-                )}
-                {enabled ? "Disable" : "Enable"}
-              </Button>
+                <Switch
+                  checked={enabled}
+                  onCheckedChange={() => void toggleEnabled()}
+                  disabled={toggling}
+                  aria-label={enabled ? "Disable heartbeat" : "Enable heartbeat"}
+                />
+                <span>{enabled ? "On" : "Off"}</span>
+              </label>
             </div>
           </div>
         </DialogHeader>

--- a/src/components/agents/heartbeat-dialog.tsx
+++ b/src/components/agents/heartbeat-dialog.tsx
@@ -30,27 +30,28 @@ export function HeartbeatDialog({
   onOpenChange,
   agent,
   initialHeartbeat,
-  initialActive,
+  initialEnabled,
   missedRun,
   onSaved,
   onRanNow,
-  onToggledActive,
+  onToggledEnabled,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   agent: NewRoutineDialogAgent;
   initialHeartbeat?: string;
-  initialActive?: boolean;
+  /** Heartbeat-specific enable. Independent from the agent's master `active`. */
+  initialEnabled?: boolean;
   missedRun?: { scheduledAt: string };
   onSaved?: () => void;
   onRanNow?: (sessionId: string | null) => void;
-  /** Fired when the user toggles active from inside the dialog without
-   *  saving/closing. Lets the parent update its list without tearing down
-   *  the open dialog. */
-  onToggledActive?: (active: boolean) => void;
+  /** Fired when the user toggles the heartbeat enable from inside the dialog
+   *  without saving/closing. Lets the parent update its list without tearing
+   *  down the open dialog. */
+  onToggledEnabled?: (enabled: boolean) => void;
 }) {
   const [heartbeat, setHeartbeat] = useState(initialHeartbeat || DEFAULT_HEARTBEAT);
-  const [active, setActive] = useState(initialActive ?? true);
+  const [enabled, setEnabled] = useState(initialEnabled ?? true);
   const [saving, setSaving] = useState(false);
   const [running, setRunning] = useState(false);
   const [toggling, setToggling] = useState(false);
@@ -59,8 +60,8 @@ export function HeartbeatDialog({
   useEffect(() => {
     if (!open) return;
     setHeartbeat(initialHeartbeat || DEFAULT_HEARTBEAT);
-    setActive(initialActive ?? true);
-  }, [open, initialHeartbeat, initialActive]);
+    setEnabled(initialEnabled ?? true);
+  }, [open, initialHeartbeat, initialEnabled]);
 
   const setSection = useAppStore((s) => s.setSection);
 
@@ -72,7 +73,7 @@ export function HeartbeatDialog({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           heartbeat,
-          active,
+          heartbeatEnabled: enabled,
           cabinetPath: agent.cabinetPath,
         }),
       });
@@ -100,22 +101,22 @@ export function HeartbeatDialog({
     }
   }
 
-  async function toggleActive() {
+  async function toggleEnabled() {
     setToggling(true);
     try {
-      const nextActive = !active;
+      const next = !enabled;
       const res = await fetch(`/api/agents/personas/${agent.slug}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           heartbeat,
-          active: nextActive,
+          heartbeatEnabled: next,
           cabinetPath: agent.cabinetPath,
         }),
       });
       if (!res.ok) return;
-      setActive(nextActive);
-      onToggledActive?.(nextActive);
+      setEnabled(next);
+      onToggledEnabled?.(next);
     } finally {
       setToggling(false);
     }
@@ -169,9 +170,9 @@ export function HeartbeatDialog({
                 size="sm"
                 className="h-9 gap-1.5 text-[12px]"
                 onClick={() => void runNow()}
-                disabled={running || !active}
+                disabled={running || !enabled}
                 title={
-                  active
+                  enabled
                     ? "Run heartbeat now (one-off, outside its schedule)"
                     : "Enable the heartbeat to run it"
                 }
@@ -188,12 +189,12 @@ export function HeartbeatDialog({
                 size="sm"
                 className={cn(
                   "h-9 gap-1.5 text-[12px]",
-                  !active && "text-emerald-600 dark:text-emerald-400"
+                  !enabled && "text-emerald-600 dark:text-emerald-400"
                 )}
-                onClick={() => void toggleActive()}
+                onClick={() => void toggleEnabled()}
                 disabled={toggling}
                 title={
-                  active
+                  enabled
                     ? "Disable the heartbeat — it won't fire on its schedule"
                     : "Enable the heartbeat so it fires on its schedule"
                 }
@@ -203,7 +204,7 @@ export function HeartbeatDialog({
                 ) : (
                   <Power className="h-3.5 w-3.5" />
                 )}
-                {active ? "Disable" : "Enable"}
+                {enabled ? "Disable" : "Enable"}
               </Button>
             </div>
           </div>

--- a/src/components/agents/new-routine-dialog.tsx
+++ b/src/components/agents/new-routine-dialog.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { AlertTriangle, Loader2, Play, Power, Save, Trash2 } from "lucide-react";
+import { AlertTriangle, Loader2, Play, Save, Trash2 } from "lucide-react";
+import { Switch } from "@/components/ui/switch";
 import {
   Dialog,
   DialogContent,
@@ -277,28 +278,25 @@ export function NewRoutineDialog({
                   )}
                   Run now
                 </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
+                <label
                   className={cn(
-                    "h-9 gap-1.5 text-[12px]",
-                    draft?.enabled === false && "text-emerald-600 dark:text-emerald-400"
+                    "inline-flex h-9 cursor-pointer select-none items-center gap-2 rounded-md border border-input px-3 text-[12px] font-medium transition-colors hover:bg-accent/40",
+                    toggling && "opacity-60"
                   )}
-                  onClick={() => void toggleEnabled()}
-                  disabled={toggling}
                   title={
                     draft?.enabled === false
                       ? "Enable this routine so it runs on its schedule"
                       : "Disable this routine — it stays saved but won't fire on its schedule"
                   }
                 >
-                  {toggling ? (
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                  ) : (
-                    <Power className="h-3.5 w-3.5" />
-                  )}
-                  {draft?.enabled === false ? "Enable" : "Disable"}
-                </Button>
+                  <Switch
+                    checked={draft?.enabled !== false}
+                    onCheckedChange={() => void toggleEnabled()}
+                    disabled={toggling}
+                    aria-label={draft?.enabled === false ? "Enable routine" : "Disable routine"}
+                  />
+                  <span>{draft?.enabled === false ? "Off" : "On"}</span>
+                </label>
                 <Button
                   variant="ghost"
                   size="sm"

--- a/src/components/agents/schedule-row.tsx
+++ b/src/components/agents/schedule-row.tsx
@@ -12,7 +12,13 @@ import { useLocale } from "@/i18n/use-locale";
 
 interface BaseRowProps {
   agent: AgentListItem;
+  /** Visual dim — the row reads as "effectively off". */
   disabled: boolean;
+  /** Switch position — defaults to !disabled so callers that don't split
+   *  effective vs. switch state still work. */
+  switchChecked?: boolean;
+  /** Disable the switch itself (e.g. master is off, can't toggle the child). */
+  switchDisabled?: boolean;
   title: string;
   subtitle: string;
   schedule: string;
@@ -26,6 +32,8 @@ interface BaseRowProps {
 function ScheduleRow({
   agent,
   disabled,
+  switchChecked,
+  switchDisabled = false,
   title,
   subtitle,
   schedule,
@@ -36,6 +44,7 @@ function ScheduleRow({
   onDelete,
 }: BaseRowProps) {
   const { t } = useLocale();
+  const isOn = switchChecked ?? !disabled;
   const [running, setRunning] = useState(false);
   const [toggling, setToggling] = useState(false);
   const [confirming, setConfirming] = useState(false);
@@ -88,9 +97,9 @@ function ScheduleRow({
   }
 
   const actionSlotWidth = onDelete ? "w-[64px]" : "w-[36px]";
-  const toggleLabel = disabled
-    ? toggleVerb === "pause" ? "Resume" : "Enable"
-    : toggleVerb === "pause" ? "Pause" : "Disable";
+  const toggleLabel = isOn
+    ? toggleVerb === "pause" ? "Pause" : "Disable"
+    : toggleVerb === "pause" ? "Resume" : "Enable";
 
   return (
     <div
@@ -198,9 +207,9 @@ function ScheduleRow({
           title={toggleLabel}
         >
           <Switch
-            checked={!disabled}
+            checked={isOn}
             onCheckedChange={() => void handleToggle()}
-            disabled={toggling}
+            disabled={toggling || switchDisabled}
             aria-label={toggleLabel}
           />
         </div>
@@ -225,10 +234,15 @@ export function RoutineRow({
   onDelete: () => void | Promise<void>;
 }) {
   const { t } = useLocale();
+  // Effective off when the agent is stopped or the job is disabled. The Switch
+  // still reflects only the per-job flag, so users can pre-configure routines
+  // even while the agent is stopped — they'll fire when the agent resumes.
+  const effectiveOn = agent.active && job.enabled;
   return (
     <ScheduleRow
       agent={agent}
-      disabled={!job.enabled}
+      disabled={!effectiveOn}
+      switchChecked={job.enabled}
       title={job.name}
       subtitle={agent.name}
       schedule={job.schedule}
@@ -249,12 +263,20 @@ export function HeartbeatRow({
   agent: AgentListItem;
   onEdit: () => void;
   onRun: () => void | Promise<void>;
+  /** Toggles `agent.heartbeatEnabled` only. The master `agent.active`
+   *  switch is gated separately on the agent header / detail page. */
   onToggle: () => void | Promise<void>;
 }) {
+  const heartbeatOn = agent.heartbeatEnabled !== false;
+  const effectiveOn = agent.active && heartbeatOn;
   return (
     <ScheduleRow
       agent={agent}
-      disabled={!agent.active}
+      // Visual dim when *effectively* off (master or per-heartbeat off);
+      // the Switch itself reflects only the per-heartbeat toggle so it stays
+      // editable even while the master is off.
+      disabled={!effectiveOn}
+      switchChecked={heartbeatOn}
       title={agent.name}
       subtitle="Heartbeat"
       schedule={agent.heartbeat || ""}

--- a/src/components/agents/schedule-row.tsx
+++ b/src/components/agents/schedule-row.tsx
@@ -4,11 +4,14 @@ import { useState, type KeyboardEvent, type MouseEvent } from "react";
 import { Check, Loader2, Play, Trash2, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { AgentAvatar } from "@/components/agents/agent-avatar";
-import { Switch } from "@/components/ui/switch";
+import { LockedSwitch } from "@/components/ui/locked-switch";
 import { cronToHuman } from "@/lib/agents/cron-utils";
 import type { AgentListItem } from "@/types/agents";
 import type { JobConfig } from "@/types/jobs";
 import { useLocale } from "@/i18n/use-locale";
+
+const LOCKED_TOOLTIP =
+  "This agent is stopped. Open the agent's page and start it to fire its routines.";
 
 interface BaseRowProps {
   agent: AgentListItem;
@@ -17,8 +20,9 @@ interface BaseRowProps {
   /** Switch position — defaults to !disabled so callers that don't split
    *  effective vs. switch state still work. */
   switchChecked?: boolean;
-  /** Disable the switch itself (e.g. master is off, can't toggle the child). */
-  switchDisabled?: boolean;
+  /** Lock the Switch (master is off — child can't be toggled until master
+   *  is back on). Renders gray + tooltip. */
+  switchLocked?: boolean;
   title: string;
   subtitle: string;
   schedule: string;
@@ -33,7 +37,7 @@ function ScheduleRow({
   agent,
   disabled,
   switchChecked,
-  switchDisabled = false,
+  switchLocked = false,
   title,
   subtitle,
   schedule,
@@ -111,21 +115,26 @@ function ScheduleRow({
         "group relative flex w-full items-center gap-3 px-4 py-2.5 text-left outline-none transition-colors",
         confirming
           ? "bg-red-500/10"
-          : "hover:bg-muted/40 focus-visible:bg-muted/40",
-        disabled && !confirming && "opacity-60"
+          : "hover:bg-muted/40 focus-visible:bg-muted/40"
       )}
     >
       <AgentAvatar
         agent={agent}
         shape="circle"
         size="sm"
-        className={cn(disabled && "saturate-50")}
+        className={cn(disabled && "saturate-50 opacity-60")}
       />
       <div className="flex min-w-0 flex-1 items-baseline gap-2 overflow-hidden">
-        <span className="truncate text-[12.5px] font-semibold text-foreground">
+        <span className={cn(
+          "truncate text-[12.5px] font-semibold",
+          disabled ? "text-muted-foreground/70" : "text-foreground"
+        )}>
           {title}
         </span>
-        <span className="truncate text-[11.5px] text-muted-foreground">
+        <span className={cn(
+          "truncate text-[11.5px]",
+          disabled ? "text-muted-foreground/60" : "text-muted-foreground"
+        )}>
           · {subtitle}
         </span>
       </div>
@@ -197,20 +206,22 @@ function ScheduleRow({
           </div>
         )}
 
-        <span className="whitespace-nowrap text-[11px] text-muted-foreground">
+        <span className={cn(
+          "whitespace-nowrap text-[11px]",
+          disabled ? "text-muted-foreground/60" : "text-muted-foreground"
+        )}>
           {schedule ? cronToHuman(schedule) : ""}
         </span>
         <div
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e) => e.stopPropagation()}
-          aria-label={toggleLabel}
-          title={toggleLabel}
         >
-          <Switch
+          <LockedSwitch
             checked={isOn}
             onCheckedChange={() => void handleToggle()}
-            disabled={toggling || switchDisabled}
-            aria-label={toggleLabel}
+            locked={switchLocked}
+            tooltip={LOCKED_TOOLTIP}
+            ariaLabel={toggleLabel}
           />
         </div>
       </div>
@@ -235,14 +246,15 @@ export function RoutineRow({
 }) {
   const { t } = useLocale();
   // Effective off when the agent is stopped or the job is disabled. The Switch
-  // still reflects only the per-job flag, so users can pre-configure routines
-  // even while the agent is stopped — they'll fire when the agent resumes.
+  // is locked while the agent is stopped — the user has to start the agent
+  // before they can toggle children, mirroring the parent/child relationship.
   const effectiveOn = agent.active && job.enabled;
   return (
     <ScheduleRow
       agent={agent}
       disabled={!effectiveOn}
       switchChecked={job.enabled}
+      switchLocked={!agent.active}
       title={job.name}
       subtitle={agent.name}
       schedule={job.schedule}
@@ -273,10 +285,11 @@ export function HeartbeatRow({
     <ScheduleRow
       agent={agent}
       // Visual dim when *effectively* off (master or per-heartbeat off);
-      // the Switch itself reflects only the per-heartbeat toggle so it stays
-      // editable even while the master is off.
+      // the Switch is locked while the agent is stopped (same parent/child
+      // gating used for routines).
       disabled={!effectiveOn}
       switchChecked={heartbeatOn}
+      switchLocked={!agent.active}
       title={agent.name}
       subtitle="Heartbeat"
       schedule={agent.heartbeat || ""}

--- a/src/components/cabinets/cabinet-view.tsx
+++ b/src/components/cabinets/cabinet-view.tsx
@@ -51,7 +51,7 @@ export function CabinetView({ cabinetPath }: { cabinetPath: string }) {
   const [heartbeatDialog, setHeartbeatDialog] = useState<{
     agent: NewRoutineDialogAgent;
     initialHeartbeat?: string;
-    initialActive?: boolean;
+    initialEnabled?: boolean;
     missedRun?: { scheduledAt: string };
   } | null>(null);
 
@@ -199,7 +199,7 @@ export function CabinetView({ cabinetPath }: { cabinetPath: string }) {
           cabinetPath: event.agentRef.cabinetPath || cabinetPath,
         },
         initialHeartbeat: event.agentRef.heartbeat || "0 9 * * 1-5",
-        initialActive: event.agentRef.active,
+        initialEnabled: event.agentRef.heartbeatEnabled !== false,
       });
     }
   }
@@ -370,7 +370,7 @@ export function CabinetView({ cabinetPath }: { cabinetPath: string }) {
         }}
         agent={heartbeatDialog?.agent ?? { slug: "", name: "" }}
         initialHeartbeat={heartbeatDialog?.initialHeartbeat}
-        initialActive={heartbeatDialog?.initialActive}
+        initialEnabled={heartbeatDialog?.initialEnabled}
         missedRun={heartbeatDialog?.missedRun}
         onSaved={() => {
           setHeartbeatDialog(null);

--- a/src/components/tasks/board/schedule-dialogs.tsx
+++ b/src/components/tasks/board/schedule-dialogs.tsx
@@ -22,7 +22,8 @@ export interface HeartbeatDialogState {
   agentName: string;
   cabinetPath: string;
   heartbeat: string;
-  active: boolean;
+  /** Whether the heartbeat itself is enabled (independent from agent.active). */
+  enabled: boolean;
 }
 
 /**
@@ -96,7 +97,7 @@ export function ScheduleHeartbeatDialog({
         cabinetPath: state.cabinetPath,
       }}
       initialHeartbeat={state.heartbeat}
-      initialActive={state.active}
+      initialEnabled={state.enabled}
       onSaved={() => {
         onClose();
         void onRefresh();

--- a/src/components/tasks/board/tasks-board.tsx
+++ b/src/components/tasks/board/tasks-board.tsx
@@ -566,7 +566,7 @@ export function TasksBoard({
                     agentName: agent.name,
                     cabinetPath: agent.cabinetPath || cabinetPath,
                     heartbeat: agent.heartbeat || "0 9 * * 1-5",
-                    active: agent.active,
+                    enabled: agent.heartbeatEnabled !== false,
                   });
                 }}
               />

--- a/src/components/ui/locked-switch.tsx
+++ b/src/components/ui/locked-switch.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Switch } from "@/components/ui/switch";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
+/**
+ * A Switch that shows its configured state but cannot be toggled. Used when
+ * the parent that gates the Switch's effect is itself off — the user needs
+ * to fix the parent first.
+ *
+ * In unlocked mode, behaves exactly like a regular `<Switch>`. In locked
+ * mode, the Switch renders gray and disabled but still captures clicks via
+ * a wrapping span (the inner Switch is `pointer-events-none` so clicks fall
+ * through to the span). A Tooltip explains the state. `onLockedClick` is an
+ * optional callback fired on click — useful for nudging the user toward the
+ * parent control with a visual pulse.
+ */
+export function LockedSwitch({
+  checked,
+  locked,
+  onCheckedChange,
+  onLockedClick,
+  tooltip,
+  ariaLabel,
+}: {
+  checked: boolean;
+  locked: boolean;
+  onCheckedChange: (next: boolean) => void;
+  onLockedClick?: () => void;
+  tooltip: string;
+  ariaLabel: string;
+}) {
+  if (!locked) {
+    return (
+      <Switch
+        checked={checked}
+        onCheckedChange={onCheckedChange}
+        aria-label={ariaLabel}
+      />
+    );
+  }
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span
+            className="inline-flex cursor-not-allowed"
+            onClick={() => onLockedClick?.()}
+            role="presentation"
+          >
+            <Switch
+              checked={checked}
+              disabled
+              aria-label={ariaLabel}
+              className="pointer-events-none"
+            />
+          </span>
+        }
+      />
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/lib/agents/cron-compute.ts
+++ b/src/lib/agents/cron-compute.ts
@@ -165,7 +165,9 @@ export function getScheduleEvents(
             agentEmoji: owner?.emoji || "🤖",
             agentName: owner?.name || job.ownerAgent || "Unknown",
             agentSlug: slug,
-            enabled: job.enabled,
+            // Effective enable: agent must be active too. Stopping the agent
+            // dims every routine even though `job.enabled` stays true on disk.
+            enabled: job.enabled && (owner?.active !== false),
             cronExpr: job.schedule,
             time: next,
             jobRef: job,
@@ -209,7 +211,8 @@ export function getScheduleEvents(
             agentEmoji: agent.emoji || "🤖",
             agentName: agent.name,
             agentSlug: agent.slug,
-            enabled: agent.active,
+            // Effective enable: master switch AND per-heartbeat toggle.
+            enabled: agent.active && agent.heartbeatEnabled !== false,
             cronExpr: agent.heartbeat,
             time: next,
             agentRef: agent,

--- a/src/lib/agents/library-manager.ts
+++ b/src/lib/agents/library-manager.ts
@@ -168,6 +168,7 @@ export async function readLibraryPersona(
     heartbeat: (data.heartbeat as string) || "0 8 * * *",
     budget: (data.budget as number) || 100,
     active: data.active !== false,
+    heartbeatEnabled: data.heartbeatEnabled !== false,
     workdir: (data.workdir as string) || "/data",
     focus: (data.focus as string[]) || [],
     tags: (data.tags as string[]) || [],

--- a/src/lib/agents/persona-manager.ts
+++ b/src/lib/agents/persona-manager.ts
@@ -175,6 +175,13 @@ export interface AgentPersona {
   heartbeat: string; // cron expression
   budget: number; // max heartbeats per month
   active: boolean;
+  /**
+   * Whether the heartbeat is enabled. Independent from `active` so users can
+   * silence the heartbeat without disabling the agent's other routines.
+   * Effective scheduling = `active && heartbeatEnabled`. Defaults to true
+   * for personas missing the field (backward compat).
+   */
+  heartbeatEnabled: boolean;
   workdir: string;
   focus: string[];
   tags: string[];
@@ -367,6 +374,7 @@ export async function readPersona(slug: string, cabinetPath?: string): Promise<A
     heartbeat: (data.heartbeat as string) || "0 8 * * *",
     budget: (data.budget as number) || 100,
     active: data.active !== false,
+    heartbeatEnabled: data.heartbeatEnabled !== false,
     workdir: (data.workdir as string) || "/data",
     focus: (data.focus as string[]) || [],
     tags: (data.tags as string[]) || [],
@@ -429,7 +437,7 @@ export async function readPersona(slug: string, cabinetPath?: string): Promise<A
   }
 
   // Compute nextHeartbeat from cron expression + lastHeartbeat
-  if (persona.active && persona.heartbeat && persona.lastHeartbeat) {
+  if (persona.active && persona.heartbeatEnabled && persona.heartbeat && persona.lastHeartbeat) {
     try {
       const nextRun = computeNextCronRun(persona.heartbeat, new Date(persona.lastHeartbeat));
       if (nextRun) persona.nextHeartbeat = nextRun.toISOString();
@@ -473,6 +481,7 @@ export async function writePersona(slug: string, persona: Partial<AgentPersona> 
     heartbeat: merged.heartbeat,
     budget: merged.budget,
     active: merged.active,
+    heartbeatEnabled: merged.heartbeatEnabled !== false,
     workdir: merged.workdir,
     focus: merged.focus,
     tags: merged.tags,
@@ -687,7 +696,7 @@ export function unregisterHeartbeat(slug: string): void {
 export async function registerAllHeartbeats(): Promise<void> {
   const personas = await listPersonas();
   for (const persona of personas) {
-    if (persona.active && persona.heartbeatsUsed !== undefined && persona.heartbeatsUsed < persona.budget) {
+    if (persona.active && persona.heartbeatEnabled && persona.heartbeatsUsed !== undefined && persona.heartbeatsUsed < persona.budget) {
       registerHeartbeat(persona.slug, persona.heartbeat);
     }
   }

--- a/src/lib/cabinets/overview.ts
+++ b/src/lib/cabinets/overview.ts
@@ -281,6 +281,7 @@ async function readAgentPersona(
       emoji: trimString(data.emoji) || "🤖",
       role,
       active: data.active !== false,
+      heartbeatEnabled: data.heartbeatEnabled !== false,
       department: trimString(data.department) || "general",
       type: trimString(data.type) || "specialist",
       heartbeat: trimString(data.heartbeat),

--- a/src/types/agents.ts
+++ b/src/types/agents.ts
@@ -72,6 +72,8 @@ export interface AgentListItem {
   provider?: string;
   adapterType?: string;
   active: boolean;
+  /** Optional — undefined falls back to true for legacy personas. */
+  heartbeatEnabled?: boolean;
   type?: AgentType | string;
   department?: string;
   heartbeat?: string;

--- a/src/types/cabinets.ts
+++ b/src/types/cabinets.ts
@@ -34,6 +34,8 @@ export interface CabinetAgentSummary {
   emoji: string;
   role: string;
   active: boolean;
+  /** Optional — undefined falls back to true for legacy personas. */
+  heartbeatEnabled?: boolean;
   department?: string;
   type?: AgentType | string;
   heartbeat?: string;


### PR DESCRIPTION
**Stacked on top of #74.** Set the base branch to `fix/heartbeat-and-routine-toggles` so the diff shows only what's new in this PR.

## Why

#74 wired the Schedule UI to a real Switch and made the heartbeat row clickable, but kept the underlying issue: the top-right "Active/Stopped" button and the heartbeat row's toggle were the *same boolean* (`agent.active`), and the daemon only gated jobs on `job.enabled` — so a "Stopped" agent kept firing its scheduled routines, contradicting the tooltip (frozar's Discord report).

This PR introduces a real master switch + per-heartbeat toggle, plus tightens the daemon so "Stopped" really means stopped.

## Data model

New `heartbeatEnabled` field on the persona (defaults to `true` for legacy personas). The two flags are independent:

- `agent.active` — master switch, gates everything scheduled
- `agent.heartbeatEnabled` — per-heartbeat enable
- `job.enabled` — per-routine enable
- **Effective heartbeat** = `active && heartbeatEnabled`
- **Effective routine** = `active && job.enabled`

## Scheduling behavior

- `server/cabinet-daemon.ts`: heartbeat scheduled only when `active && heartbeatEnabled`. Job scheduled only when its owning agent is active *and* `job.enabled`.
- `node-cron`'s `task.stop()` halts only future fires, so **already-running sessions aren't killed** when the agent stops — matching the user's spec.
- `src/lib/agents/cron-compute.ts`: same gates so the calendar/list events dim consistently with what the daemon will fire.

## UI

- **Top-right Active/Stopped → Switch** with a "Working/Stopped" label, so the master visually matches the row toggles.
- **Heartbeat row Switch** in agent detail Schedule section + `/agents` `HeartbeatRow` now bind to `heartbeatEnabled`. The row dims when *effectively* off (master OR per-heartbeat off); the Switch stays editable while master is off so users can pre-configure.
- **Routine row Switch** dims along with master too (effective state), but the Switch stays editable.
- **HeartbeatDialog** props renamed for clarity: `initialActive` → `initialEnabled`, `onToggledActive` → `onToggledEnabled`. Every caller updated (agents-workspace, cabinet-view, tasks-board, agent-detail-v2, schedule-dialogs).
- **"Pause/Resume all heartbeats" bulk button** now uses two new scheduler actions (`pause-heartbeats` / `resume-heartbeats`) that toggle `heartbeatEnabled` instead of `active` — matching its label.

## Files

- Persona schema: `src/lib/agents/persona-manager.ts`, `src/lib/agents/library-manager.ts`
- Cabinet/agent summary types: `src/types/agents.ts`, `src/types/cabinets.ts`, `src/lib/cabinets/overview.ts`
- Daemon: `server/cabinet-daemon.ts`
- Cron compute: `src/lib/agents/cron-compute.ts`
- API filters: `src/app/api/agents/{personas,scheduler,events}/route.ts`
- UI: `src/components/agents/{agent-detail-v2,agents-workspace,heartbeat-dialog,schedule-row}.tsx`, `src/components/cabinets/cabinet-view.tsx`, `src/components/tasks/board/{schedule-dialogs,tasks-board}.tsx`

## Backward compatibility

Existing personas without `heartbeatEnabled` default to `true`, so behavior (whether the heartbeat fires) is unchanged. The *visual* changes for previously-stopped agents: their heartbeat row's Switch will now show ON (per-heartbeat default) but dimmed (master off), instead of OFF. The dim communicates "effectively not firing"; toggling master back on resumes the heartbeat.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` on changed files clean (pre-existing warnings only)
- [x] Browser-verified via chrome-devtools MCP:
  - [x] Top-bar shows "Working" Switch with persona.active checked; toggling flips between "Working" and "Stopped"
  - [x] When master flips to "Stopped", heartbeat row dims and daemon log shows that heartbeat unscheduled (3 → 2 heartbeats)
  - [x] When master flips back to "Working", daemon re-schedules the heartbeat
  - [x] Toggling the heartbeat-row Switch off (master ON) unschedules just the heartbeat (3 → 2 heartbeats); the master toggle stays "Working"
  - [x] Heartbeat-row state persists across reload (heartbeatEnabled is read back from persona)
  - [x] No console errors

## Out of scope (intentional)

- Migrating existing on-disk personas to write an explicit `heartbeatEnabled` field (the default makes this unnecessary; new writes will include it).
- The `/home` (HomeScreen) view has no on/off toggles, so nothing changed there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pause/resume all heartbeats control to enable/disable scheduling independently of agent active state
  * Locked toggle UI with a one-shot pulse guide when child toggles are locked
  * Simplified "Meet the team" row-based list with per-row active toggle

* **Improvements**
  * Job and heartbeat scheduling now respect per-agent heartbeat enablement and agent active status
  * Heartbeat enablement tracked separately from agent active state for clearer controls

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hilash/cabinet/pull/77)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->