### PR TITLE
feat(editor): word count in the status bar

### DIFF
--- a/src/components/layout/status-bar.tsx
+++ b/src/components/layout/status-bar.tsx
@@ -52,6 +52,23 @@ function installUrlForProvider(id: string): string {
   );
 }
 
+// Word counter for the open page. The editor stores the page body as
+// markdown, so we strip markdown syntax that shouldn't count as prose
+// (code fences, inline code, link/image URLs, emphasis markers, raw HTML)
+// before splitting on whitespace. Frontmatter lives on a separate field,
+// so it isn't in `content`.
+function countWords(content: string): number {
+  if (!content) return 0;
+  let text = content.replace(/```[\s\S]*?```/g, " ");
+  text = text.replace(/`[^`]*`/g, " ");
+  text = text.replace(/!?\[([^\]]*)\]\([^)]*\)/g, "$1");
+  text = text.replace(/<[^>]+>/g, " ");
+  text = text.replace(/[#*_~>`]/g, " ");
+  const trimmed = text.trim();
+  if (!trimmed) return 0;
+  return trimmed.split(/\s+/).length;
+}
+
 function describeUncommittedStatus(s: "M" | "?" | "A" | "D" | "R"): string {
   switch (s) {
     case "M":
@@ -128,6 +145,8 @@ function formatRelativeSavedAgo(ts: number, now: number): string {
 export function StatusBar() {
   const { saveStatus, currentPath, isDirty, lastSavedAt } = useEditorStore();
   const retrySave = useEditorStore((s) => s.save);
+  const editorContent = useEditorStore((s) => s.content);
+  const wordCount = useMemo(() => countWords(editorContent), [editorContent]);
 
   // Audit #018: rerender every 10s so the relative timestamp ticks. The
   // indicator only mounts when a page is open, so this isn't a global cost.
@@ -742,6 +761,15 @@ export function StatusBar() {
               Saved · {savedAgoLabel}
             </span>
           ) : null
+        )}
+        {currentPath && (
+          <span
+            className="text-muted-foreground/60 tabular-nums"
+            title="Word count for this page (markdown syntax excluded)"
+            aria-label={`${wordCount} ${wordCount === 1 ? "word" : "words"}`}
+          >
+            {wordCount.toLocaleString()} {wordCount === 1 ? "word" : "words"}
+          </span>
         )}
         {pullStatus === "pulling" && (
           <span className="flex items-center gap-1 text-blue-400">

--- a/src/components/layout/status-bar.tsx
+++ b/src/components/layout/status-bar.tsx
@@ -146,7 +146,13 @@ export function StatusBar() {
   const { saveStatus, currentPath, isDirty, lastSavedAt } = useEditorStore();
   const retrySave = useEditorStore((s) => s.save);
   const editorContent = useEditorStore((s) => s.content);
+  const editorLoadStatus = useEditorStore((s) => s.loadStatus);
   const wordCount = useMemo(() => countWords(editorContent), [editorContent]);
+  // Only meaningful for the markdown editor surface — viewers (PDF, CSV,
+  // image, media, office) never populate the editor store's content, so
+  // the count would always read 0 there. loadStatus === "ok" means a
+  // markdown page actually loaded.
+  const showWordCount = !!currentPath && editorLoadStatus === "ok";
 
   // Audit #018: rerender every 10s so the relative timestamp ticks. The
   // indicator only mounts when a page is open, so this isn't a global cost.
@@ -762,7 +768,7 @@ export function StatusBar() {
             </span>
           ) : null
         )}
-        {currentPath && (
+        {showWordCount && (
           <span
             className="text-muted-foreground/60 tabular-nums"
             title="Word count for this page (markdown syntax excluded)"


### PR DESCRIPTION
## Summary
- Adds a word counter next to the save indicator in the bottom status bar, for when a page has a target word count (e.g. an assignment, a chapter, a pitch).
- Counts whitespace-separated tokens from the page markdown after stripping code fences, inline code, link/image URLs, raw HTML tags, and emphasis markers (`# * _ ~ > \``). Frontmatter is on a separate field and is not counted.
- Only shown for actual markdown pages (`loadStatus === \"ok\"`), so it stays hidden on PDF/CSV/image/media/office viewers where the editor store is empty.

## Test plan
- [ ] Open a markdown page → bottom bar shows `N words` next to `Saved · …`.
- [ ] Type / delete text → count updates live, singular `1 word` at 1.
- [ ] Open a non-markdown file (PDF, CSV, image) → counter is hidden.
- [ ] Dashboard / no page selected → counter is hidden.
- [ ] Page with code fences → fenced code is excluded from the count.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a markdown word count metric in the status bar that displays the word count of your current page, excluding code blocks, inline code, links, and formatting markers. The word count only appears when a page is open and the editor is fully loaded.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hilash/cabinet/pull/82)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->