### PR TITLE
feat(agents): tabbed Team page (Agents/Routines/Heartbeats/Schedule)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,5 +1,7 @@
 # Progress
 
+[2026-05-07] Expanded `docs/PROVIDER-CLI.md` §13 "Adding a new provider" from a 5-step bullet to a complete touch-list — added the previously undocumented edits (`legacy-ids.ts`, `status-bar.tsx` PROVIDER_INSTALL_URLS, test files) and an explicit "do not enumerate providers in components" note. Surfaces that read `/api/agents/providers` (Settings, composer picker, onboarding grid, providers-demo) are called out as automatic.
+
 [2026-04-28] **Skills**: browse skills.sh, attach per agent, or `@`-mention per task. Bundles are mounted into Claude via `--plugin-dir` so they register as proper plugin skills (not just `--add-dir` files); continuation turns re-merge the mount so mid-conversation `@`-mentions take effect on the next reply. **API Keys**: a `.cabinet.env` file at the project root, edited from a preset-driven UI (OpenAI, Anthropic, GitHub, Google AI, plus Custom). Values masked as `••••<last4>`, file written `0600`, gitignored. Spawn-time merge into `withAdapterRuntimeEnv` and the PTY manager forwards keys to every CLI, so skills like `imagegen` read `OPENAI_API_KEY` without a restart. Cabinet backups gained two opt-in toggles for the same files, both defaulting off.
 
 [2026-04-25] Pinned Node 22 as the dev runtime via `.nvmrc`. Silences the `EBADENGINE` warning from transitive `chevrotain@12` (pulled in by `mermaid → langium`) which declares `engines: ">=22"`. README "Requirements" updated to recommend Node 22 LTS with `nvm use`.

--- a/docs/PROVIDER-CLI.md
+++ b/docs/PROVIDER-CLI.md
@@ -373,7 +373,31 @@ Current UX: users edit `skills: [slug, slug]` directly in the agent's markdown f
 
 ## 13. Operational Notes
 
-- **Adding a new provider**: (1) drop metadata in `providers/<id>.ts`, (2) add an adapter in `adapters/<type>-local.ts`, (3) register both, (4) drop an SVG in `public/providers/`, (5) ensure the final install step is a `Verify setup` command that exits 0 on success. UI surfaces (composer picker, Settings, onboarding, glyph, demo) pick the provider up automatically.
+### Adding a new provider
+
+The full file map is in §10. Minimum touch-list:
+
+**New files**
+- `src/lib/agents/providers/<id>.ts` — provider metadata. Must declare `iconAsset: "/providers/<id>.svg"` (§8) so the glyph picks it up without further wiring.
+- `src/lib/agents/adapters/<id>-local.ts` — adapter implementation.
+- `src/lib/agents/adapters/<id>-stream.ts` — only if the CLI emits structured streaming output (NDJSON / stream-json).
+- `public/providers/<id>.svg` — logo asset.
+- `src/lib/agents/adapters/<id>-local.test.ts` (+ `<id>-stream.test.ts` and `test/fixtures/<id>-stream/*.ndjson` for streaming providers).
+
+**Edits**
+- `src/lib/agents/provider-registry.ts` — import + `providerRegistry.register(...)`.
+- `src/lib/agents/adapters/registry.ts` — four spots: `LEGACY_ADAPTER_BY_PROVIDER_ID`, `DEFAULT_ADAPTER_BY_PROVIDER_ID`, legacy adapter factory, `register()` call.
+- `src/lib/agents/adapters/legacy-ids.ts` — add `<id>_legacy` to `LEGACY_ADAPTER_TYPES`. Plus add the provider id to `PROVIDERS_WITH_TERMINAL_RESUME` if the CLI supports `--resume` / `--session` (gates the "new session" advisory in the task viewer).
+- `src/components/layout/status-bar.tsx` — `PROVIDER_INSTALL_URLS` (powers the "Install" button in the System Status popover).
+- `test/provider-launch-mode.test.ts` — launch-mode case.
+- `src/lib/agents/adapters/registry.test.ts` — adapter presence assertion.
+
+**Install-step contract:** the final entry of `installSteps` must be a `Verify setup` command that exits 0 on success. The in-UI verifier (§6) runs it as the canonical health check.
+
+**Do NOT add the new id to component-level lists.** The Settings page, composer picker (Native + Terminal tabs), onboarding grid, providers-demo, and troubleshooter all read `/api/agents/providers` and discover the provider via `iconAsset`, `runtimeModes`, and `supportsTerminalResume` flags on its metadata. If you find yourself editing `task-runtime-picker.tsx`, `settings-page.tsx`, or `onboarding-wizard.tsx` to enumerate providers, that's a smell.
+
+### Other notes
+
 - **Unready providers** stay visible in Settings (`includeUnavailable`) but are hidden in the composer picker by default. Users can always see what's available vs. installable from Settings.
 - **Verify failures** surface the failing step title + hint inline — users know whether to install, authenticate, pay, or wait out a quota without reading raw stderr.
 - **Debugging a provider**: open `/providers-demo` from Settings → Providers → **Troubleshoot AI providers**. Runs every provider API end-to-end with live logs.

--- a/server/cabinet-daemon.ts
+++ b/server/cabinet-daemon.ts
@@ -1212,6 +1212,10 @@ async function reloadSchedules(): Promise<void> {
     const agentsDir = path.join(cabinet.absDir, ".agents");
 
     // --- Heartbeats from .agents/*/persona.md ---
+    // Also collect active-agent slugs per cabinet so jobs owned by an
+    // inactive (Stopped) agent don't get scheduled. Master switch =
+    // `agent.active`; per-heartbeat enable = `agent.heartbeatEnabled`.
+    const activeAgents = new Set<string>();
     if (fs.existsSync(agentsDir)) {
       let agentEntries: fs.Dirent[];
       try {
@@ -1229,8 +1233,10 @@ async function reloadSchedules(): Promise<void> {
             const rawPersona = fs.readFileSync(personaPath, "utf-8");
             const { data } = matter(rawPersona);
             const active = data.active !== false;
+            const heartbeatEnabled = data.heartbeatEnabled !== false;
             const heartbeat = typeof data.heartbeat === "string" ? data.heartbeat : "";
-            if (active && heartbeat) {
+            if (active) activeAgents.add(entry.name);
+            if (active && heartbeatEnabled && heartbeat) {
               scheduleHeartbeat(entry.name, heartbeat, cabinet.relPath);
               heartbeatCount++;
             }
@@ -1265,7 +1271,13 @@ async function reloadSchedules(): Promise<void> {
             agentSlug: ownerAgent,
             cabinetPath: cabinet.relPath,
           };
-          if (config.id && config.enabled && config.schedule && ownerAgent) {
+          if (
+            config.id &&
+            config.enabled &&
+            config.schedule &&
+            ownerAgent &&
+            activeAgents.has(ownerAgent)
+          ) {
             scheduleJob(config);
             jobCount++;
           }

--- a/src/app/agents-demo/agents/page.tsx
+++ b/src/app/agents-demo/agents/page.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Calendar as CalendarIcon, HeartPulse, Network } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Switch } from "@/components/ui/switch";
+import { AgentAvatar } from "@/components/agents/agent-avatar";
+import { startCase } from "@/components/cabinets/cabinet-utils";
+import { cronToHuman } from "@/lib/agents/cron-utils";
+import type { CabinetAgentSummary, CabinetJobSummary } from "@/types/cabinets";
+import { useAgentsDemo } from "../store";
+import { FilterChip, ListShell } from "../list-shell";
+import { TabExplainer } from "../tab-explainer";
+
+export default function AgentsTab() {
+  const { loading, agents, jobs, toggleAgentActive } = useAgentsDemo();
+  const [query, setQuery] = useState("");
+  const [deptFilter, setDeptFilter] = useState<string | "all">("all");
+  const [activeFilter, setActiveFilter] = useState<"all" | "active" | "stopped">(
+    "all"
+  );
+
+  const jobsByAgent = useMemo(() => {
+    const m = new Map<string, CabinetJobSummary[]>();
+    for (const job of jobs) {
+      const slug = job.ownerAgent || "";
+      if (!slug) continue;
+      const list = m.get(slug) || [];
+      list.push(job);
+      m.set(slug, list);
+    }
+    return m;
+  }, [jobs]);
+
+  const departments = useMemo(() => {
+    const set = new Set<string>();
+    for (const a of agents) if (a.department) set.add(a.department);
+    return ["all" as const, ...Array.from(set).sort()];
+  }, [agents]);
+
+  const activeCount = useMemo(
+    () => agents.filter((a) => a.active).length,
+    [agents]
+  );
+  const departmentCount = useMemo(
+    () => new Set(agents.map((a) => a.department).filter(Boolean)).size,
+    [agents]
+  );
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return agents.filter((a) => {
+      if (deptFilter !== "all" && a.department !== deptFilter) return false;
+      if (activeFilter === "active" && !a.active) return false;
+      if (activeFilter === "stopped" && a.active) return false;
+      if (q) {
+        const hay = [a.name, a.role, a.department]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    });
+  }, [agents, query, deptFilter, activeFilter]);
+
+  return (
+    <ListShell
+      explainer={
+        <TabExplainer
+          id="agents"
+          ariaLabel="About your agents"
+          body={
+            <>
+              <p>
+                Your AI teammates. Each one has a specialty — a writer, a
+                researcher, a planner. Click any agent to set them up or read
+                what they&apos;ve been doing.
+              </p>
+              <p>
+                The switch on each row is the agent&apos;s on / off button.
+                When it&apos;s on, the agent does its scheduled work on its
+                own. When it&apos;s off, nothing fires automatically — but
+                you can still chat with the agent any time.
+              </p>
+            </>
+          }
+        />
+      }
+      stats={
+        <>
+          <span className="tabular-nums text-foreground">{activeCount}</span>{" "}
+          active
+          {" · "}
+          <span className="tabular-nums text-foreground">{departmentCount}</span>{" "}
+          departments
+        </>
+      }
+      query={query}
+      setQuery={setQuery}
+      searchPlaceholder="Search by name, role, or department"
+      filters={
+        <>
+          <FilterChip
+            value={deptFilter}
+            onChange={(v) => setDeptFilter(v as string | "all")}
+            options={departments.map((d) => ({
+              value: d,
+              label: d === "all" ? "All departments" : startCase(d),
+            }))}
+          />
+          <FilterChip
+            value={activeFilter}
+            onChange={(v) => setActiveFilter(v as typeof activeFilter)}
+            options={[
+              { value: "all", label: "All" },
+              { value: "active", label: "Active only" },
+              { value: "stopped", label: "Stopped only" },
+            ]}
+          />
+        </>
+      }
+      trailingActions={
+        <button
+          type="button"
+          title="Open org chart (demo: not wired)"
+          className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border/70 bg-background px-2.5 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
+        >
+          <Network className="size-3.5" />
+          Org chart
+        </button>
+      }
+      loading={loading}
+      empty={{
+        title: "No agents match your filters.",
+        hint: agents.length > 0 ? "Try clearing a filter." : undefined,
+      }}
+    >
+      {filtered.length === 0 ? (
+        []
+      ) : (
+        <ul className="divide-y divide-border/60">
+          {filtered.map((agent) => (
+            <li key={agent.scopedId}>
+              <AgentRow
+                agent={agent}
+                routines={jobsByAgent.get(agent.slug) || []}
+                onToggleActive={() => toggleAgentActive(agent)}
+                onOpen={() => {
+                  window.location.hash = `#/a/${agent.slug}`;
+                }}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </ListShell>
+  );
+}
+
+function AgentRow({
+  agent,
+  routines,
+  onToggleActive,
+  onOpen,
+}: {
+  agent: CabinetAgentSummary;
+  routines: CabinetJobSummary[];
+  onToggleActive: () => void;
+  onOpen: () => void;
+}) {
+  const heartbeatOn = agent.active && agent.heartbeatEnabled !== false;
+  const heartbeatLabel = agent.heartbeat ? cronToHuman(agent.heartbeat) : "off";
+  const routinesOff = routines.filter((r) => !r.enabled).length;
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onOpen}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+      className="group flex h-10 items-center gap-3 px-3 text-left outline-none transition-colors hover:bg-muted/40 focus-visible:bg-muted/40"
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
+        <Switch
+          checked={agent.active}
+          onCheckedChange={onToggleActive}
+          aria-label={agent.active ? `Stop ${agent.name}` : `Start ${agent.name}`}
+        />
+      </div>
+
+      <AgentAvatar
+        agent={agent}
+        shape="circle"
+        size="sm"
+        className={cn(!agent.active && "saturate-50 opacity-60")}
+      />
+
+      <div className="flex min-w-0 flex-1 items-baseline gap-2 overflow-hidden">
+        <span
+          className={cn(
+            "truncate text-[12.5px] font-semibold",
+            agent.active ? "text-foreground" : "text-muted-foreground/70"
+          )}
+        >
+          {agent.name}
+        </span>
+        {agent.role ? (
+          <span
+            className={cn(
+              "truncate text-[11.5px]",
+              agent.active ? "text-muted-foreground" : "text-muted-foreground/60"
+            )}
+          >
+            · {agent.role}
+          </span>
+        ) : null}
+      </div>
+
+      {agent.department ? (
+        <span
+          className={cn(
+            "hidden whitespace-nowrap rounded-full bg-muted/40 px-2 py-0.5 text-[10px] sm:inline-flex",
+            agent.active ? "text-muted-foreground" : "text-muted-foreground/60"
+          )}
+        >
+          {startCase(agent.department)}
+        </span>
+      ) : null}
+
+      <span
+        className={cn(
+          "hidden items-center gap-1 whitespace-nowrap rounded-full px-2 py-0.5 text-[10px] sm:inline-flex",
+          heartbeatOn
+            ? "bg-pink-500/10 text-pink-600 dark:text-pink-400"
+            : "bg-muted/40 text-muted-foreground/70"
+        )}
+        title={heartbeatOn ? `Heartbeat: ${heartbeatLabel}` : "Heartbeat off"}
+      >
+        <HeartPulse className="size-2.5" />
+        {agent.heartbeat ? heartbeatLabel : "off"}
+      </span>
+
+      <span
+        className={cn(
+          "hidden items-center gap-1 whitespace-nowrap rounded-full px-2 py-0.5 text-[10px] sm:inline-flex",
+          routines.length > 0
+            ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+            : "bg-muted/40 text-muted-foreground/70"
+        )}
+        title={
+          routines.length === 0
+            ? "No routines"
+            : routinesOff > 0
+              ? `${routines.length} routines · ${routinesOff} off`
+              : `${routines.length} routines`
+        }
+      >
+        <CalendarIcon className="size-2.5" />
+        {routines.length === 0
+          ? "0"
+          : routinesOff > 0
+            ? `${routines.length} · ${routinesOff} off`
+            : `${routines.length}`}
+      </span>
+    </div>
+  );
+}

--- a/src/app/agents-demo/heartbeats/page.tsx
+++ b/src/app/agents-demo/heartbeats/page.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { HeartPulse, Pause } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { LockedSwitch } from "@/components/ui/locked-switch";
+import { AgentAvatar } from "@/components/agents/agent-avatar";
+import { cronToHuman } from "@/lib/agents/cron-utils";
+import type { CabinetAgentSummary } from "@/types/cabinets";
+import { useAgentsDemo } from "../store";
+import { FilterChip, ListShell } from "../list-shell";
+import { TabExplainer } from "../tab-explainer";
+
+export default function HeartbeatsTab() {
+  const { loading, agents, toggleHeartbeatEnabled } = useAgentsDemo();
+  const [query, setQuery] = useState("");
+  const [statusFilter, setStatusFilter] =
+    useState<"all" | "firing" | "off" | "locked">("all");
+
+  // Only agents with a heartbeat configured.
+  const heartbeats = useMemo(
+    () => agents.filter((a) => !!a.heartbeat),
+    [agents]
+  );
+
+  const stats = useMemo(() => {
+    let firing = 0;
+    let off = 0;
+    let locked = 0;
+    for (const a of heartbeats) {
+      const enabled = a.heartbeatEnabled !== false;
+      if (!a.active) locked++;
+      else if (enabled) firing++;
+      else off++;
+    }
+    return { firing, off, locked };
+  }, [heartbeats]);
+
+  const anyEnabled = heartbeats.some((a) => a.heartbeatEnabled !== false);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return heartbeats.filter((a) => {
+      const enabled = a.heartbeatEnabled !== false;
+      const firing = a.active && enabled;
+      const locked = !a.active; // master off
+      if (statusFilter === "firing" && !firing) return false;
+      if (statusFilter === "off" && (locked || enabled)) return false;
+      if (statusFilter === "locked" && !locked) return false;
+      if (q) {
+        const hay = [a.name, a.role, a.department]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    });
+  }, [heartbeats, query, statusFilter]);
+
+  return (
+    <ListShell
+      explainer={
+        <TabExplainer
+          id="heartbeats"
+          ariaLabel="About heartbeats"
+          body={
+            <>
+              <p>
+                A heartbeat is what makes your agent feel alive. Every time
+                it ticks, the agent wakes up, looks around, and decides what
+                to do next — no instructions needed. It&apos;s the
+                difference between an agent that waits to be told and one
+                that takes initiative.
+              </p>
+              <p>
+                Pick a rhythm that fits the work — every few minutes for
+                fast-moving things, once a day for quieter ones. Switch it
+                off any time to give the agent a break without stopping it
+                completely.
+              </p>
+            </>
+          }
+        />
+      }
+      stats={
+        <>
+          <span className="tabular-nums text-foreground">{stats.firing}</span>{" "}
+          firing
+          {" · "}
+          <span className="tabular-nums text-foreground">{stats.off}</span> off
+          {" · "}
+          <span className="tabular-nums text-foreground">{stats.locked}</span>{" "}
+          locked
+        </>
+      }
+      query={query}
+      setQuery={setQuery}
+      searchPlaceholder="Search by agent name or role"
+      filters={
+        <FilterChip
+          value={statusFilter}
+          onChange={(v) => setStatusFilter(v as typeof statusFilter)}
+          options={[
+            { value: "all", label: "All states" },
+            { value: "firing", label: "Firing" },
+            { value: "off", label: "Off" },
+            { value: "locked", label: "Locked (agent stopped)" },
+          ]}
+        />
+      }
+      trailingActions={
+        <button
+          type="button"
+          title={anyEnabled ? "Pause every heartbeat" : "Resume every heartbeat"}
+          className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border/70 bg-background px-2.5 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
+        >
+          <Pause className="size-3.5" />
+          {anyEnabled ? "Pause all" : "Resume all"}
+        </button>
+      }
+      loading={loading}
+      empty={{
+        title: "No heartbeats here.",
+        hint:
+          heartbeats.length === 0
+            ? "No agents have a heartbeat configured yet."
+            : "Try clearing a filter.",
+      }}
+    >
+      {filtered.length === 0 ? (
+        []
+      ) : (
+        <ul className="divide-y divide-border/60">
+          {filtered.map((agent) => (
+            <li key={agent.scopedId}>
+              <HeartbeatRow
+                agent={agent}
+                onToggle={() => toggleHeartbeatEnabled(agent)}
+                onOpen={() => {
+                  window.location.hash = `#/a/${agent.slug}`;
+                }}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </ListShell>
+  );
+}
+
+function HeartbeatRow({
+  agent,
+  onToggle,
+  onOpen,
+}: {
+  agent: CabinetAgentSummary;
+  onToggle: () => void;
+  onOpen: () => void;
+}) {
+  const enabled = agent.heartbeatEnabled !== false;
+  const firing = agent.active && enabled;
+  const locked = !agent.active;
+  const schedule = agent.heartbeat ? cronToHuman(agent.heartbeat) : "";
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onOpen}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+      className="group flex h-10 items-center gap-3 px-3 outline-none transition-colors hover:bg-muted/40 focus-visible:bg-muted/40"
+    >
+      <HeartPulse
+        className={cn(
+          "size-3.5 shrink-0",
+          firing ? "text-pink-500" : "text-muted-foreground/40"
+        )}
+      />
+      <AgentAvatar
+        agent={agent}
+        shape="circle"
+        size="sm"
+        className={cn(!firing && "saturate-50 opacity-60")}
+      />
+      <div className="flex min-w-0 flex-1 items-baseline gap-2 overflow-hidden">
+        <span
+          className={cn(
+            "truncate text-[12.5px] font-semibold",
+            firing ? "text-foreground" : "text-muted-foreground/70"
+          )}
+        >
+          {agent.name}
+        </span>
+        <span
+          className={cn(
+            "truncate text-[11.5px]",
+            firing ? "text-muted-foreground" : "text-muted-foreground/60"
+          )}
+        >
+          · Heartbeat
+        </span>
+      </div>
+      <span
+        className={cn(
+          "whitespace-nowrap text-[11px] tabular-nums",
+          firing ? "text-muted-foreground" : "text-muted-foreground/60"
+        )}
+      >
+        {schedule}
+      </span>
+      <div
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
+        <LockedSwitch
+          checked={enabled}
+          onCheckedChange={onToggle}
+          locked={locked}
+          tooltip="This agent is stopped. Start it on the Agents tab to enable the heartbeat."
+          ariaLabel={enabled ? `Pause ${agent.name} heartbeat` : `Resume ${agent.name} heartbeat`}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/agents-demo/layout.tsx
+++ b/src/app/agents-demo/layout.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import {
+  Calendar as CalendarIcon,
+  ChevronDown,
+  Clock3,
+  HeartPulse,
+  Loader2,
+  Plus,
+  RefreshCw,
+  Users,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { AgentsDemoProvider, useAgentsDemo } from "./store";
+
+// Order: Agents (entities) → Routines (familiar concept) → Heartbeats
+// (novel concept, needs the metaphor) → Schedule (cross-cutting view).
+const TABS = [
+  { href: "/agents-demo/agents", label: "Agents", icon: Users },
+  { href: "/agents-demo/routines", label: "Routines", icon: Clock3 },
+  { href: "/agents-demo/heartbeats", label: "Heartbeats", icon: HeartPulse },
+  { href: "/agents-demo/schedule", label: "Schedule", icon: CalendarIcon },
+] as const;
+
+// Context-aware "+ New" button per tab. Schedule has no creation action.
+const NEW_BUTTON: Record<string, string | null> = {
+  "/agents-demo/agents": "New Agent",
+  "/agents-demo/routines": "New Routine",
+  "/agents-demo/heartbeats": "Configure heartbeat",
+  "/agents-demo/schedule": null,
+};
+
+export default function AgentsDemoLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <AgentsDemoProvider>
+      <div className="flex h-dvh flex-col">
+        <TopBar />
+        <div className="mx-auto min-h-0 w-full max-w-6xl flex-1 overflow-hidden px-6 pb-8 pt-4">
+          {children}
+        </div>
+      </div>
+    </AgentsDemoProvider>
+  );
+}
+
+function TopBar() {
+  const { loading } = useAgentsDemo();
+  return (
+    <header className="sticky top-0 z-10 flex h-12 shrink-0 items-center gap-3 border-b border-border/70 bg-background/95 px-4 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+      <h1 className="text-[14px] font-semibold tracking-tight">Team</h1>
+      {loading && (
+        <Loader2 className="size-3.5 animate-spin text-muted-foreground" />
+      )}
+      <div className="ml-2 flex items-center gap-2">
+        <TabStrip />
+      </div>
+      <div className="ml-auto flex items-center gap-2">
+        <ScopePicker />
+        <Divider />
+        <RefreshButton />
+        <NewButton />
+      </div>
+    </header>
+  );
+}
+
+function Divider() {
+  return <div className="h-3.5 w-px bg-border/60" aria-hidden />;
+}
+
+function TabStrip() {
+  const pathname = usePathname();
+  const { agents, jobs } = useAgentsDemo();
+  const counts: Record<string, number> = {
+    "/agents-demo/agents": agents.length,
+    "/agents-demo/routines": jobs.length,
+    "/agents-demo/heartbeats": agents.filter((a) => !!a.heartbeat).length,
+  };
+  return (
+    <nav
+      className="flex h-7 items-center rounded-lg border border-border/60 p-0.5"
+      role="tablist"
+    >
+      {TABS.map((tab) => {
+        const active =
+          pathname === tab.href || pathname?.startsWith(tab.href + "/");
+        const Icon = tab.icon;
+        const count = counts[tab.href];
+        return (
+          <Link
+            key={tab.href}
+            href={tab.href}
+            role="tab"
+            aria-selected={active}
+            className={cn(
+              "flex items-center gap-1.5 rounded-md px-2.5 py-1 text-[11px] font-medium transition-colors",
+              active
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:text-foreground"
+            )}
+          >
+            <Icon className="size-3.5" />
+            {tab.label}
+            {typeof count === "number" ? (
+              <span
+                className={cn(
+                  "rounded-full px-1.5 py-px text-[9.5px] font-semibold tabular-nums",
+                  active
+                    ? "bg-primary-foreground/20 text-primary-foreground"
+                    : "bg-muted/60 text-muted-foreground/80"
+                )}
+              >
+                {count}
+              </span>
+            ) : null}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+
+function ScopePicker() {
+  // Demo: stub. In production this is the real cabinet visibility picker
+  // (Own / All / This cabinet only / Children) wired to the store.
+  return (
+    <button
+      type="button"
+      title="Cabinet scope (demo: not wired)"
+      className="inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+    >
+      <span className="size-3 rounded-sm border border-current" />
+      Own
+      <ChevronDown className="size-3" />
+    </button>
+  );
+}
+
+function RefreshButton() {
+  const router = useRouter();
+  return (
+    <button
+      type="button"
+      onClick={() => router.refresh()}
+      title="Refresh"
+      aria-label="Refresh"
+      className="inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+    >
+      <RefreshCw className="size-3.5" />
+    </button>
+  );
+}
+
+function NewButton() {
+  const pathname = usePathname() ?? "";
+  const label = NEW_BUTTON[pathname];
+  if (!label) return null;
+  return (
+    <button
+      type="button"
+      title={label}
+      className="inline-flex h-7 items-center gap-1.5 rounded-md bg-primary px-2.5 text-[11.5px] font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
+    >
+      <Plus className="size-3.5" />
+      {label}
+    </button>
+  );
+}

--- a/src/app/agents-demo/list-shell.tsx
+++ b/src/app/agents-demo/list-shell.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { ChevronDown, ListFilter, Search } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/** Search input + N filter chips + list pane shell, shared across all tabs. */
+export function ListShell({
+  explainer,
+  stats,
+  query,
+  setQuery,
+  searchPlaceholder = "Search",
+  filters,
+  trailingActions,
+  loading,
+  empty,
+  children,
+}: {
+  /** Either a plain string (rendered as a one-line muted paragraph) or a
+   *  ReactNode (e.g. a `<TabExplainer>`) that the tab fully owns. */
+  explainer: ReactNode;
+  /** Optional sub-header line above the filter row, e.g. mini-stats
+   *  ("12 firing · 4 off · 3 locked") or facets ("50 active · 36 depts"). */
+  stats?: ReactNode;
+  query: string;
+  setQuery: (q: string) => void;
+  searchPlaceholder?: string;
+  filters?: ReactNode;
+  /** Action(s) anchored to the right of the filter row (e.g. "Pause all
+   *  heartbeats" on the Heartbeats tab, "Org chart" on the Agents tab). */
+  trailingActions?: ReactNode;
+  loading: boolean;
+  /** Shown when not loading and the list has no items. */
+  empty: { title: string; hint?: string };
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-3">
+      {typeof explainer === "string" ? (
+        <p className="text-[12px] text-muted-foreground">{explainer}</p>
+      ) : (
+        explainer
+      )}
+
+      {stats ? (
+        <p className="text-[11.5px] text-muted-foreground/80">{stats}</p>
+      ) : null}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="relative min-w-[200px] flex-1">
+          <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+          <input
+            type="text"
+            placeholder={searchPlaceholder}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="h-8 w-full rounded-md border border-border/70 bg-background pl-8 pr-3 text-[12.5px] outline-none placeholder:text-muted-foreground focus:border-ring"
+          />
+        </div>
+        {filters}
+        {trailingActions ? (
+          <div className="ml-auto flex items-center gap-1.5">{trailingActions}</div>
+        ) : null}
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto rounded-xl border border-border/70 bg-card">
+        {loading ? (
+          <div className="divide-y divide-border/60">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div
+                key={i}
+                className="flex h-9 animate-pulse items-center gap-3 px-3"
+              >
+                <div className="size-4 rounded-full bg-muted/60" />
+                <div className="size-5 shrink-0 rounded-full bg-muted/60" />
+                <div className="h-2.5 w-32 rounded bg-muted/60" />
+                <div className="ml-auto h-2.5 w-20 rounded bg-muted/40" />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <EmptyOrChildren empty={empty}>{children}</EmptyOrChildren>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EmptyOrChildren({
+  empty,
+  children,
+}: {
+  empty: { title: string; hint?: string };
+  children: ReactNode;
+}) {
+  // Children may be a list — if it's a non-array (e.g. a single <ul/>), let
+  // the parent decide. If it's an empty array we paint the empty state.
+  const isEmpty = Array.isArray(children) && children.length === 0;
+  if (isEmpty) {
+    return (
+      <div className="flex h-full min-h-[160px] flex-col items-center justify-center gap-2 text-center">
+        <ListFilter className="size-5 text-muted-foreground/60" />
+        <p className="text-[13px] text-muted-foreground">{empty.title}</p>
+        {empty.hint ? (
+          <p className="text-[11.5px] text-muted-foreground/70">{empty.hint}</p>
+        ) : null}
+      </div>
+    );
+  }
+  return <>{children}</>;
+}
+
+export function FilterChip<V extends string>({
+  options,
+  value,
+  onChange,
+}: {
+  options: { value: V; label: string }[];
+  value: V;
+  onChange: (v: V) => void;
+}) {
+  return (
+    <div className="relative">
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value as V)}
+        className={cn(
+          "h-8 cursor-pointer appearance-none rounded-md border border-border/70 bg-background pl-3 pr-7 text-[12.5px] outline-none focus:border-ring"
+        )}
+      >
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+      <ChevronDown className="pointer-events-none absolute right-2 top-1/2 size-3 -translate-y-1/2 text-muted-foreground" />
+    </div>
+  );
+}

--- a/src/app/agents-demo/page.tsx
+++ b/src/app/agents-demo/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function AgentsDemoIndex() {
+  redirect("/agents-demo/agents");
+}

--- a/src/app/agents-demo/routines/page.tsx
+++ b/src/app/agents-demo/routines/page.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Clock3, Play } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { LockedSwitch } from "@/components/ui/locked-switch";
+import { AgentAvatar } from "@/components/agents/agent-avatar";
+import { cronToHuman } from "@/lib/agents/cron-utils";
+import type { CabinetAgentSummary, CabinetJobSummary } from "@/types/cabinets";
+import { useAgentsDemo } from "../store";
+import { FilterChip, ListShell } from "../list-shell";
+import { TabExplainer } from "../tab-explainer";
+
+export default function RoutinesTab() {
+  const { loading, agents, jobs, toggleJobEnabled } = useAgentsDemo();
+  const [query, setQuery] = useState("");
+  const [agentFilter, setAgentFilter] = useState<string | "all">("all");
+  const [statusFilter, setStatusFilter] =
+    useState<"all" | "firing" | "off" | "locked">("all");
+
+  const agentBySlug = useMemo(() => {
+    const m = new Map<string, CabinetAgentSummary>();
+    for (const a of agents) m.set(a.slug, a);
+    return m;
+  }, [agents]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return jobs.filter((job) => {
+      const owner = agentBySlug.get(job.ownerAgent || "");
+      const masterOn = owner?.active ?? false;
+      const firing = masterOn && job.enabled;
+      const locked = !masterOn;
+
+      if (agentFilter !== "all" && job.ownerAgent !== agentFilter) return false;
+      if (statusFilter === "firing" && !firing) return false;
+      if (statusFilter === "off" && (locked || job.enabled)) return false;
+      if (statusFilter === "locked" && !locked) return false;
+      if (q) {
+        const hay = [job.name, owner?.name, owner?.role]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    });
+  }, [jobs, agentBySlug, query, agentFilter, statusFilter]);
+
+  const stats = useMemo(() => {
+    let firing = 0;
+    let off = 0;
+    let locked = 0;
+    for (const job of jobs) {
+      const masterOn = agentBySlug.get(job.ownerAgent || "")?.active ?? false;
+      if (!masterOn) locked++;
+      else if (job.enabled) firing++;
+      else off++;
+    }
+    return { firing, off, locked };
+  }, [jobs, agentBySlug]);
+
+  const agentOptions = useMemo(
+    () => [
+      { value: "all" as const, label: "All agents" },
+      ...agents
+        .filter((a) => jobs.some((j) => j.ownerAgent === a.slug))
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map((a) => ({ value: a.slug, label: a.name })),
+    ],
+    [agents, jobs]
+  );
+
+  return (
+    <ListShell
+      explainer={
+        <TabExplainer
+          id="routines"
+          ariaLabel="About routines"
+          body={
+            <>
+              <p>
+                A routine is a recurring task you give an agent. Write it
+                once, pick when it should run, and your agent handles it on
+                schedule — like <em>&ldquo;every weekday at 9am, summarize
+                yesterday&rsquo;s work.&rdquo;</em>
+              </p>
+              <p>
+                Switch a routine off to pause it without losing the prompt.
+                If the agent itself is stopped, its routines wait until you
+                start it again.
+              </p>
+            </>
+          }
+        />
+      }
+      stats={
+        <>
+          <span className="tabular-nums text-foreground">{stats.firing}</span>{" "}
+          firing
+          {" · "}
+          <span className="tabular-nums text-foreground">{stats.off}</span> off
+          {" · "}
+          <span className="tabular-nums text-foreground">{stats.locked}</span>{" "}
+          locked
+        </>
+      }
+      query={query}
+      setQuery={setQuery}
+      searchPlaceholder="Search by routine name or agent"
+      filters={
+        <>
+          <FilterChip
+            value={agentFilter}
+            onChange={(v) => setAgentFilter(v as string | "all")}
+            options={agentOptions}
+          />
+          <FilterChip
+            value={statusFilter}
+            onChange={(v) => setStatusFilter(v as typeof statusFilter)}
+            options={[
+              { value: "all", label: "All states" },
+              { value: "firing", label: "Firing" },
+              { value: "off", label: "Off" },
+              { value: "locked", label: "Locked (agent stopped)" },
+            ]}
+          />
+        </>
+      }
+      loading={loading}
+      empty={{
+        title: "No routines here.",
+        hint:
+          jobs.length === 0
+            ? "Add a routine on any agent's page to see it here."
+            : "Try clearing a filter.",
+      }}
+    >
+      {filtered.length === 0 ? (
+        []
+      ) : (
+        <ul className="divide-y divide-border/60">
+          {filtered.map((job) => {
+            const owner = agentBySlug.get(job.ownerAgent || "");
+            return (
+              <li key={job.scopedId}>
+                <RoutineRow
+                  job={job}
+                  owner={owner}
+                  onToggle={() => toggleJobEnabled(job)}
+                  onOpen={() => {
+                    if (owner) window.location.hash = `#/a/${owner.slug}`;
+                  }}
+                />
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </ListShell>
+  );
+}
+
+function RoutineRow({
+  job,
+  owner,
+  onToggle,
+  onOpen,
+}: {
+  job: CabinetJobSummary;
+  owner: CabinetAgentSummary | undefined;
+  onToggle: () => void;
+  onOpen: () => void;
+}) {
+  const masterOn = owner?.active ?? false;
+  const firing = masterOn && job.enabled;
+  const locked = !masterOn;
+  const schedule = job.schedule ? cronToHuman(job.schedule) : "";
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onOpen}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+      className="group flex h-10 items-center gap-3 px-3 outline-none transition-colors hover:bg-muted/40 focus-visible:bg-muted/40"
+    >
+      <Clock3
+        className={cn(
+          "size-3.5 shrink-0",
+          firing ? "text-emerald-500" : "text-muted-foreground/40"
+        )}
+      />
+      {owner ? (
+        <AgentAvatar
+          agent={owner}
+          shape="circle"
+          size="sm"
+          className={cn(!firing && "saturate-50 opacity-60")}
+        />
+      ) : (
+        <div className="size-5 shrink-0 rounded-full bg-muted/40" />
+      )}
+      <div className="flex min-w-0 flex-1 items-baseline gap-2 overflow-hidden">
+        <span
+          className={cn(
+            "truncate text-[12.5px] font-semibold",
+            firing ? "text-foreground" : "text-muted-foreground/70"
+          )}
+        >
+          {job.name || "(untitled routine)"}
+        </span>
+        {owner ? (
+          <span
+            className={cn(
+              "truncate text-[11.5px]",
+              firing ? "text-muted-foreground" : "text-muted-foreground/60"
+            )}
+          >
+            · {owner.name}
+          </span>
+        ) : null}
+      </div>
+      <span
+        className={cn(
+          "whitespace-nowrap text-[11px] tabular-nums",
+          firing ? "text-muted-foreground" : "text-muted-foreground/60"
+        )}
+      >
+        {schedule}
+      </span>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+        disabled
+        title="Run now (demo: not wired)"
+        className="inline-flex size-7 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100 disabled:cursor-not-allowed"
+      >
+        <Play className="size-3.5" />
+      </button>
+      <div
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
+        <LockedSwitch
+          checked={job.enabled}
+          onCheckedChange={onToggle}
+          locked={locked}
+          tooltip="This agent is stopped. Start it on the Agents tab to enable its routines."
+          ariaLabel={
+            job.enabled
+              ? `Disable routine ${job.name}`
+              : `Enable routine ${job.name}`
+          }
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/agents-demo/schedule/page.tsx
+++ b/src/app/agents-demo/schedule/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState } from "react";
+import { ScheduleCalendar } from "@/components/cabinets/schedule-calendar";
+import { useAgentsDemo } from "../store";
+import { TabExplainer } from "../tab-explainer";
+
+type Mode = "day" | "week" | "month";
+
+export default function ScheduleTab() {
+  const { agents, jobs } = useAgentsDemo();
+  const [mode, setMode] = useState<Mode>("week");
+  const [anchor] = useState(() => new Date());
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <TabExplainer
+            id="schedule"
+            ariaLabel="About the schedule"
+            body={
+              <>
+                <p>
+                  Everything your team is doing this week, on one calendar.
+                  Pink is a heartbeat, green is a routine. Click any pill to
+                  edit it.
+                </p>
+                <p>
+                  Use this tab to spot conflicts, find quiet stretches, or
+                  just see at a glance how busy the team is.
+                </p>
+              </>
+            }
+          />
+        </div>
+        <div className="inline-flex shrink-0 items-center rounded-md border border-border/70 bg-background p-0.5">
+          {(["day", "week", "month"] as const).map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => setMode(m)}
+              className={
+                mode === m
+                  ? "rounded px-2.5 py-1 text-[11.5px] font-medium bg-foreground text-background"
+                  : "rounded px-2.5 py-1 text-[11.5px] font-medium text-muted-foreground hover:text-foreground"
+              }
+            >
+              {m[0].toUpperCase() + m.slice(1)}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="min-h-0 flex-1 overflow-hidden rounded-xl border border-border/70 bg-card">
+        <ScheduleCalendar
+          mode={mode}
+          anchor={anchor}
+          agents={agents}
+          jobs={jobs}
+          fullscreen
+          onEventClick={() => {
+            // Demo: no-op.
+          }}
+          onDayClick={() => {
+            // Demo: no-op.
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/agents-demo/store.tsx
+++ b/src/app/agents-demo/store.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+/**
+ * Shared client store for the /agents-demo redesign. Mounted at the layout
+ * level so all four tab routes share one fetch + one source of truth for
+ * toggles. Replace with the production store + Zustand wiring when this
+ * lands in the real app shell.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import type {
+  CabinetAgentSummary,
+  CabinetJobSummary,
+  CabinetOverview,
+} from "@/types/cabinets";
+
+interface DemoStore {
+  loading: boolean;
+  agents: CabinetAgentSummary[];
+  jobs: CabinetJobSummary[];
+  toggleAgentActive: (agent: CabinetAgentSummary) => Promise<void>;
+  toggleHeartbeatEnabled: (agent: CabinetAgentSummary) => Promise<void>;
+  toggleJobEnabled: (job: CabinetJobSummary) => Promise<void>;
+}
+
+const Ctx = createContext<DemoStore | null>(null);
+
+export function AgentsDemoProvider({ children }: { children: React.ReactNode }) {
+  const [agents, setAgents] = useState<CabinetAgentSummary[]>([]);
+  const [jobs, setJobs] = useState<CabinetJobSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancel = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/cabinets/overview?path=.&visibility=own");
+        if (!res.ok) return;
+        const data = (await res.json()) as CabinetOverview;
+        if (cancel) return;
+        setAgents(data.agents || []);
+        setJobs(data.jobs || []);
+      } finally {
+        if (!cancel) setLoading(false);
+      }
+    })();
+    return () => {
+      cancel = true;
+    };
+  }, []);
+
+  const toggleAgentActive = useCallback(async (agent: CabinetAgentSummary) => {
+    setAgents((prev) =>
+      prev.map((a) => (a.slug === agent.slug ? { ...a, active: !a.active } : a))
+    );
+    await fetch(`/api/agents/personas/${agent.slug}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        action: "toggle",
+        cabinetPath: agent.cabinetPath || ".",
+      }),
+    }).catch(() => {});
+  }, []);
+
+  const toggleHeartbeatEnabled = useCallback(
+    async (agent: CabinetAgentSummary) => {
+      const next = agent.heartbeatEnabled === false;
+      setAgents((prev) =>
+        prev.map((a) =>
+          a.slug === agent.slug ? { ...a, heartbeatEnabled: next } : a
+        )
+      );
+      await fetch(`/api/agents/personas/${agent.slug}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          heartbeat: agent.heartbeat || "",
+          heartbeatEnabled: next,
+          cabinetPath: agent.cabinetPath || ".",
+        }),
+      }).catch(() => {});
+    },
+    []
+  );
+
+  const toggleJobEnabled = useCallback(async (job: CabinetJobSummary) => {
+    const next = !job.enabled;
+    setJobs((prev) =>
+      prev.map((j) => (j.scopedId === job.scopedId ? { ...j, enabled: next } : j))
+    );
+    const ownerSlug = job.ownerAgent || "";
+    if (!ownerSlug) return;
+    await fetch(`/api/agents/${ownerSlug}/jobs/${job.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        action: "update",
+        cabinetPath: job.cabinetPath || ".",
+        enabled: next,
+      }),
+    }).catch(() => {});
+  }, []);
+
+  const value = useMemo(
+    () => ({ loading, agents, jobs, toggleAgentActive, toggleHeartbeatEnabled, toggleJobEnabled }),
+    [loading, agents, jobs, toggleAgentActive, toggleHeartbeatEnabled, toggleJobEnabled]
+  );
+
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+export function useAgentsDemo(): DemoStore {
+  const ctx = useContext(Ctx);
+  if (!ctx) {
+    throw new Error("useAgentsDemo must be used inside AgentsDemoProvider");
+  }
+  return ctx;
+}

--- a/src/app/agents-demo/tab-explainer.tsx
+++ b/src/app/agents-demo/tab-explainer.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useState, type ReactNode } from "react";
+import { Info, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const STORAGE_PREFIX = "cabinet.agents-demo.explainer.";
+
+/**
+ * Per-tab onboarding card. Visible by default on first visit, dismissible.
+ * After dismissal a small `ⓘ` button stays inline next to the page heading
+ * and re-opens the card on click. Dismissal is persisted per-tab via
+ * localStorage so each tab onboards independently.
+ *
+ * No heading inside the card — the prose carries it. Soft styling (subtle
+ * border, no background tint) so it feels like product chrome, not a
+ * warning banner.
+ */
+export function TabExplainer({
+  id,
+  body,
+  ariaLabel,
+}: {
+  /** Stable ID per tab; used as the localStorage key suffix. */
+  id: string;
+  /** The conversational copy. Use short paragraphs, plain language. */
+  body: ReactNode;
+  /** Used on the toggle button for screen readers. */
+  ariaLabel: string;
+}) {
+  const storageKey = STORAGE_PREFIX + id;
+  // `null` = haven't checked localStorage yet (SSR-safe initial render).
+  const [open, setOpen] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let dismissed = false;
+    try {
+      dismissed = window.localStorage.getItem(storageKey) === "1";
+    } catch {
+      dismissed = false;
+    }
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setOpen(!dismissed);
+  }, [storageKey]);
+
+  function dismiss() {
+    setOpen(false);
+    try {
+      window.localStorage.setItem(storageKey, "1");
+    } catch {
+      // Quota / private mode — non-fatal.
+    }
+  }
+
+  function reopen() {
+    setOpen(true);
+  }
+
+  const isOpen = open === true;
+
+  if (!isOpen) {
+    return (
+      <button
+        type="button"
+        onClick={reopen}
+        aria-label={ariaLabel}
+        title={ariaLabel}
+        className="inline-flex size-5 shrink-0 items-center justify-center rounded-full text-muted-foreground/60 transition-colors hover:bg-muted/40 hover:text-foreground focus-visible:bg-muted/40 focus-visible:text-foreground focus-visible:outline-none"
+      >
+        <Info className="size-3.5" />
+      </button>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "relative rounded-lg border border-border/50 bg-muted/20 px-4 py-3",
+        "animate-in fade-in slide-in-from-top-1 duration-200"
+      )}
+    >
+      <button
+        type="button"
+        onClick={dismiss}
+        aria-label="Dismiss"
+        title="Dismiss"
+        className="absolute right-1.5 top-1.5 inline-flex size-6 items-center justify-center rounded-md text-muted-foreground/60 transition-colors hover:bg-muted/40 hover:text-foreground"
+      >
+        <X className="size-3.5" />
+      </button>
+      <div className="space-y-1.5 pr-6 text-[12.5px] leading-relaxed text-foreground/80">
+        {body}
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/agents/events/route.ts
+++ b/src/app/api/agents/events/route.ts
@@ -58,7 +58,7 @@ export async function GET() {
           // Gather current state
           const personas = await listAllPersonas();
           const registered = personas
-            .filter((persona) => persona.active && !!persona.heartbeat)
+            .filter((persona) => persona.active && persona.heartbeatEnabled && !!persona.heartbeat)
             .map((persona) => persona.slug);
           const runningCounts = await getRunningConversationCounts();
 

--- a/src/app/api/agents/personas/route.ts
+++ b/src/app/api/agents/personas/route.ts
@@ -29,7 +29,7 @@ export async function GET(req: NextRequest) {
   );
   const personas = await listPersonas(cabinetPath);
   const activeHeartbeats = personas
-    .filter((persona) => persona.active && !!persona.heartbeat)
+    .filter((persona) => persona.active && persona.heartbeatEnabled && !!persona.heartbeat)
     .map((persona) => persona.slug);
   const runningCounts = await getRunningConversationCounts();
 

--- a/src/app/api/agents/scheduler/route.ts
+++ b/src/app/api/agents/scheduler/route.ts
@@ -11,7 +11,7 @@ import { reloadDaemonSchedules } from "@/lib/agents/daemon-client";
 export async function GET() {
   const personas = await listAllPersonas();
   const registered = personas
-    .filter((persona) => persona.active && !!persona.heartbeat)
+    .filter((persona) => persona.active && persona.heartbeatEnabled && !!persona.heartbeat)
     .map((persona) => ({
       slug: persona.slug,
       cabinetPath: persona.cabinetPath,
@@ -90,6 +90,26 @@ export async function POST(req: NextRequest) {
       }
       await reloadDaemonSchedules().catch(() => {});
       return NextResponse.json({ ok: true, paused: toPause.length });
+    }
+
+    case "pause-heartbeats": {
+      // Disable heartbeats only — leaves agent.active alone so other
+      // routines keep firing. Used by the "Pause all heartbeats" button.
+      const toPause = personas.filter((p) => p.heartbeatEnabled !== false);
+      for (const p of toPause) {
+        await writePersona(p.slug, { heartbeatEnabled: false }, p.cabinetPath);
+      }
+      await reloadDaemonSchedules().catch(() => {});
+      return NextResponse.json({ ok: true, paused: toPause.length });
+    }
+
+    case "resume-heartbeats": {
+      const toResume = personas.filter((p) => p.heartbeatEnabled === false);
+      for (const p of toResume) {
+        await writePersona(p.slug, { heartbeatEnabled: true }, p.cabinetPath);
+      }
+      await reloadDaemonSchedules().catch(() => {});
+      return NextResponse.json({ ok: true, resumed: toResume.length });
     }
 
     case "activate": {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -223,6 +223,17 @@ html[data-custom-theme] .tiptap h4 {
   animation: cabinet-tree-blink 1.4s ease-in-out;
 }
 
+/* One-shot ring pulse for the agent header master Switch — fired when a
+   user clicks a locked child Switch to point them at the toggle they need. */
+@keyframes cabinet-master-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(245, 158, 11, 0.6); }
+  60% { box-shadow: 0 0 0 6px rgba(245, 158, 11, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(245, 158, 11, 0); }
+}
+.cabinet-master-pulse {
+  animation: cabinet-master-pulse 700ms ease-out;
+}
+
 /* Body serif — Source Serif 4, beats theme overrides */
 html[data-custom-theme] .font-body-serif,
 .font-body-serif {

--- a/src/components/agents/agent-detail-v2.tsx
+++ b/src/components/agents/agent-detail-v2.tsx
@@ -79,6 +79,7 @@ import { ScheduleCalendar } from "@/components/cabinets/schedule-calendar";
 import { NewRoutineDialog } from "@/components/agents/new-routine-dialog";
 import { HeartbeatDialog } from "@/components/agents/heartbeat-dialog";
 import { Switch } from "@/components/ui/switch";
+import { LockedSwitch } from "@/components/ui/locked-switch";
 import type { JobConfig } from "@/types/jobs";
 import {
   TaskRuntimePicker,
@@ -444,6 +445,7 @@ function TopBar({
   onToggleCanDispatch,
   onExport,
   onDelete,
+  pulseToken = 0,
 }: {
   persona: AgentPersona;
   status: AgentStatus;
@@ -454,11 +456,22 @@ function TopBar({
   onToggleCanDispatch: () => void;
   onExport: () => void;
   onDelete: () => void;
+  /** Bumped from outside (locked child Switch click) to nudge the user
+   *  toward the master toggle with a brief ring animation. */
+  pulseToken?: number;
 }) {
   const { t } = useLocale();
   const palette = persona.color
     ? tintFromHex(persona.color)
     : getAgentColor(persona.slug);
+
+  const [pulsing, setPulsing] = useState(false);
+  useEffect(() => {
+    if (pulseToken === 0) return;
+    setPulsing(true);
+    const t = setTimeout(() => setPulsing(false), 700);
+    return () => clearTimeout(t);
+  }, [pulseToken]);
 
   return (
     <div className="flex items-center justify-between px-6 pt-4">
@@ -505,10 +518,11 @@ function TopBar({
             render={
               <label
                 className={cn(
-                  "inline-flex items-center gap-2 h-7 rounded-md border px-2.5 text-[12px] font-medium transition-colors cursor-pointer select-none",
+                  "inline-flex items-center gap-2 h-7 rounded-md border px-2.5 text-[12px] font-medium transition-colors cursor-pointer select-none ring-offset-2 ring-offset-background",
                   persona.active
                     ? "border-border hover:bg-accent/40"
-                    : "border-dashed border-border/60 text-muted-foreground hover:bg-accent/30"
+                    : "border-dashed border-border/60 text-muted-foreground hover:bg-accent/30",
+                  pulsing && "ring-2 ring-amber-500 animate-pulse"
                 )}
                 style={persona.active ? { color: palette.text } : undefined}
               >
@@ -1403,6 +1417,7 @@ function ScheduleSection({
   onEditHeartbeat,
   onRunHeartbeat,
   onToggleHeartbeat,
+  onLockedChildClick,
   onManage,
 }: {
   persona: AgentPersona;
@@ -1414,11 +1429,14 @@ function ScheduleSection({
   onEditHeartbeat: () => void;
   onRunHeartbeat: () => void;
   onToggleHeartbeat: () => void;
+  onLockedChildClick?: () => void;
   onManage: () => void;
 }) {
   const { t } = useLocale();
   const heartbeatOn = persona.heartbeatEnabled !== false;
   const heartbeatEffective = persona.active && heartbeatOn;
+  const lockedTooltip =
+    "This agent is stopped. Heartbeat and routines won't fire until you start it.";
 
   return (
     <Section
@@ -1447,10 +1465,13 @@ function ScheduleSection({
               {cronToHuman(persona.heartbeat)}
             </span>
           </button>
-          <Switch
+          <LockedSwitch
             checked={heartbeatOn}
             onCheckedChange={onToggleHeartbeat}
-            aria-label={heartbeatOn ? "Pause heartbeat" : "Resume heartbeat"}
+            locked={!persona.active}
+            onLockedClick={onLockedChildClick}
+            tooltip={lockedTooltip}
+            ariaLabel={heartbeatOn ? "Pause heartbeat" : "Resume heartbeat"}
           />
           <Button
             variant="ghost"
@@ -1483,10 +1504,13 @@ function ScheduleSection({
                 {cronToHuman(job.schedule)}
               </span>
             </button>
-            <Switch
+            <LockedSwitch
               checked={job.enabled}
               onCheckedChange={() => onToggleJob(job.id)}
-              aria-label={job.enabled ? `Disable ${job.name}` : `Enable ${job.name}`}
+              locked={!persona.active}
+              onLockedClick={onLockedChildClick}
+              tooltip={lockedTooltip}
+              ariaLabel={job.enabled ? `Disable ${job.name}` : `Enable ${job.name}`}
             />
             <Button
               variant="ghost"
@@ -2192,6 +2216,11 @@ export function AgentDetailV2({
   const [routineDialogOpen, setRoutineDialogOpen] = useState(false);
   const [routineEditJob, setRoutineEditJob] = useState<JobConfig | null>(null);
   const [heartbeatDialogOpen, setHeartbeatDialogOpen] = useState(false);
+  // Bumped each time a locked child Switch is clicked. The TopBar's master
+  // Switch consumes this to run a brief ring pulse, visually pointing the
+  // user to the toggle they need to flip.
+  const [masterPulseToken, setMasterPulseToken] = useState(0);
+  const pulseMaster = useCallback(() => setMasterPulseToken((n) => n + 1), []);
 
   // Schedule handoff — lets the user convert the current composer draft into
   // a recurring routine or heartbeat by opening StartWorkDialog seeded with
@@ -2577,6 +2606,7 @@ export function AgentDetailV2({
             onToggleCanDispatch={toggleCanDispatch}
             onExport={handleExport}
             onDelete={handleDelete}
+            pulseToken={masterPulseToken}
           />
         </div>
         {scheduleOpen ? (
@@ -2634,6 +2664,7 @@ export function AgentDetailV2({
                 onEditHeartbeat={() => setHeartbeatDialogOpen(true)}
                 onRunHeartbeat={runHeartbeat}
                 onToggleHeartbeat={toggleHeartbeat}
+                onLockedChildClick={pulseMaster}
                 onManage={() => setScheduleOpen(true)}
               />
               <DetailsSection

--- a/src/components/agents/agent-detail-v2.tsx
+++ b/src/components/agents/agent-detail-v2.tsx
@@ -465,13 +465,10 @@ function TopBar({
     ? tintFromHex(persona.color)
     : getAgentColor(persona.slug);
 
-  const [pulsing, setPulsing] = useState(false);
-  useEffect(() => {
-    if (pulseToken === 0) return;
-    setPulsing(true);
-    const t = setTimeout(() => setPulsing(false), 700);
-    return () => clearTimeout(t);
-  }, [pulseToken]);
+  // Each new pulseToken bump remounts the wrapper via `key`, restarting the
+  // one-shot CSS animation defined in globals.css (`cabinet-master-pulse`).
+  // No React state needed for the on/off transition.
+  const pulseKey = pulseToken > 0 ? `pulse-${pulseToken}` : "pulse-idle";
 
   return (
     <div className="flex items-center justify-between px-6 pt-4">
@@ -517,12 +514,13 @@ function TopBar({
           <TooltipTrigger
             render={
               <label
+                key={pulseKey}
                 className={cn(
-                  "inline-flex items-center gap-2 h-7 rounded-md border px-2.5 text-[12px] font-medium transition-colors cursor-pointer select-none ring-offset-2 ring-offset-background",
+                  "inline-flex items-center gap-2 h-7 rounded-md border px-2.5 text-[12px] font-medium transition-colors cursor-pointer select-none",
                   persona.active
                     ? "border-border hover:bg-accent/40"
                     : "border-dashed border-border/60 text-muted-foreground hover:bg-accent/30",
-                  pulsing && "ring-2 ring-amber-500 animate-pulse"
+                  pulseToken > 0 && "cabinet-master-pulse"
                 )}
                 style={persona.active ? { color: palette.text } : undefined}
               >

--- a/src/components/agents/agent-detail-v2.tsx
+++ b/src/components/agents/agent-detail-v2.tsx
@@ -30,7 +30,6 @@ import {
   Pencil,
   Play,
   Plus,
-  Power,
   Send,
   Share2,
   Sparkles,
@@ -504,26 +503,24 @@ function TopBar({
         <Tooltip>
           <TooltipTrigger
             render={
-              <button
-                type="button"
-                onClick={onToggleActive}
+              <label
                 className={cn(
-                  "inline-flex items-center gap-1.5 h-7 rounded-md border px-2.5 text-[12px] font-medium transition-colors",
+                  "inline-flex items-center gap-2 h-7 rounded-md border px-2.5 text-[12px] font-medium transition-colors cursor-pointer select-none",
                   persona.active
                     ? "border-border hover:bg-accent/40"
                     : "border-dashed border-border/60 text-muted-foreground hover:bg-accent/30"
                 )}
                 style={persona.active ? { color: palette.text } : undefined}
               >
-                <Power className="h-3.5 w-3.5" />
-                {persona.active ? "Active" : "Stopped"}
-              </button>
+                <Switch checked={persona.active} onCheckedChange={onToggleActive} />
+                <span>{persona.active ? "Working" : "Stopped"}</span>
+              </label>
             }
           />
           <TooltipContent>
             {persona.active
-              ? "Pause this agent's heartbeat. Scheduled routines below keep running unless you turn each one off. Manual chats still work."
-              : "Resume this agent's heartbeat."}
+              ? "Stop this agent. Scheduled heartbeat and routines won't fire. Manual chats and any in-flight runs keep working."
+              : "Start this agent. Scheduled heartbeat and routines resume on their own rhythm."}
           </TooltipContent>
         </Tooltip>
 
@@ -1405,7 +1402,7 @@ function ScheduleSection({
   onEditRoutine,
   onEditHeartbeat,
   onRunHeartbeat,
-  onToggleActive,
+  onToggleHeartbeat,
   onManage,
 }: {
   persona: AgentPersona;
@@ -1416,10 +1413,12 @@ function ScheduleSection({
   onEditRoutine: (job: AgentJob) => void;
   onEditHeartbeat: () => void;
   onRunHeartbeat: () => void;
-  onToggleActive: () => void;
+  onToggleHeartbeat: () => void;
   onManage: () => void;
 }) {
   const { t } = useLocale();
+  const heartbeatOn = persona.heartbeatEnabled !== false;
+  const heartbeatEffective = persona.active && heartbeatOn;
 
   return (
     <Section
@@ -1442,16 +1441,16 @@ function ScheduleSection({
             className="flex flex-1 items-center gap-3 text-left"
             title="Edit heartbeat"
           >
-            <Zap className={cn("h-3.5 w-3.5 shrink-0", persona.active ? "text-amber-500" : "text-muted-foreground/40")} />
-            <span className={cn("flex-1 text-[13px]", !persona.active && "text-muted-foreground/60")}>{t("agents:detail.heartbeat")}</span>
+            <Zap className={cn("h-3.5 w-3.5 shrink-0", heartbeatEffective ? "text-amber-500" : "text-muted-foreground/40")} />
+            <span className={cn("flex-1 text-[13px]", !heartbeatEffective && "text-muted-foreground/60")}>{t("agents:detail.heartbeat")}</span>
             <span className="text-[11px] text-muted-foreground tabular-nums">
               {cronToHuman(persona.heartbeat)}
             </span>
           </button>
           <Switch
-            checked={persona.active}
-            onCheckedChange={onToggleActive}
-            aria-label={persona.active ? "Pause heartbeat" : "Resume heartbeat"}
+            checked={heartbeatOn}
+            onCheckedChange={onToggleHeartbeat}
+            aria-label={heartbeatOn ? "Pause heartbeat" : "Resume heartbeat"}
           />
           <Button
             variant="ghost"
@@ -1459,13 +1458,15 @@ function ScheduleSection({
             className="h-7 w-7"
             onClick={onRunHeartbeat}
             title={t("agents:detail.runNow")}
-            disabled={!persona.active}
+            disabled={!heartbeatEffective}
           >
             <Play className="h-3 w-3" />
           </Button>
         </li>
         {/* Jobs */}
-        {jobs.map((job) => (
+        {jobs.map((job) => {
+          const jobEffective = persona.active && job.enabled;
+          return (
           <li
             key={job.id}
             className="flex items-center gap-3 px-2 py-2.5 -mx-2 rounded-md hover:bg-accent/30 transition-colors"
@@ -1476,8 +1477,8 @@ function ScheduleSection({
               className="flex flex-1 items-center gap-3 text-left"
               title={t("agents:detail.editRoutine")}
             >
-              <Briefcase className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-              <span className="flex-1 text-[13px] truncate">{job.name}</span>
+              <Briefcase className={cn("h-3.5 w-3.5 shrink-0", jobEffective ? "text-muted-foreground" : "text-muted-foreground/50")} />
+              <span className={cn("flex-1 text-[13px] truncate", !jobEffective && "text-muted-foreground/60")}>{job.name}</span>
               <span className="text-[11px] text-muted-foreground tabular-nums">
                 {cronToHuman(job.schedule)}
               </span>
@@ -1497,7 +1498,8 @@ function ScheduleSection({
               <Play className="h-3 w-3" />
             </Button>
           </li>
-        ))}
+          );
+        })}
         {/* Add */}
         <li>
           <button
@@ -2433,6 +2435,20 @@ export function AgentDetailV2({
     refresh();
   }, [slug, refresh, effectiveCabinetPath]);
 
+  const toggleHeartbeat = useCallback(async () => {
+    if (!persona) return;
+    const next = persona.heartbeatEnabled === false;
+    setPersona((prev) => (prev ? { ...prev, heartbeatEnabled: next } : prev));
+    const body: Record<string, unknown> = { heartbeatEnabled: next };
+    if (effectiveCabinetPath) body.cabinetPath = effectiveCabinetPath;
+    await fetch(`/api/agents/personas/${slug}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    refresh();
+  }, [persona, slug, refresh, effectiveCabinetPath]);
+
   const toggleCanDispatch = useCallback(async () => {
     if (!persona) return;
     const current =
@@ -2617,7 +2633,7 @@ export function AgentDetailV2({
                 }}
                 onEditHeartbeat={() => setHeartbeatDialogOpen(true)}
                 onRunHeartbeat={runHeartbeat}
-                onToggleActive={togglingActive ? () => {} : toggleActive}
+                onToggleHeartbeat={toggleHeartbeat}
                 onManage={() => setScheduleOpen(true)}
               />
               <DetailsSection
@@ -2666,10 +2682,10 @@ export function AgentDetailV2({
             cabinetPath: persona.cabinetPath || effectiveCabinetPath || "",
           }}
           initialHeartbeat={persona.heartbeat}
-          initialActive={persona.active}
+          initialEnabled={persona.heartbeatEnabled !== false}
           onSaved={() => void refresh()}
-          onToggledActive={(active) => {
-            setPersona((prev) => (prev ? { ...prev, active } : prev));
+          onToggledEnabled={(heartbeatEnabled) => {
+            setPersona((prev) => (prev ? { ...prev, heartbeatEnabled } : prev));
           }}
         />
 

--- a/src/components/agents/agent-row.tsx
+++ b/src/components/agents/agent-row.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState, type KeyboardEvent } from "react";
+import { Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { AgentAvatar } from "@/components/agents/agent-avatar";
+import { Switch } from "@/components/ui/switch";
+import { startCase } from "@/components/cabinets/cabinet-utils";
+import type { AgentListItem } from "@/types/agents";
+
+/**
+ * One row in the "Meet the team" list — same visual rhythm as the Routines
+ * rows. Click the row to open the agent. The Switch toggles `agent.active`
+ * (the master) without leaving the page.
+ */
+export function AgentRow({
+  agent,
+  onOpen,
+  onToggleActive,
+}: {
+  agent: AgentListItem;
+  onOpen: (slug: string) => void;
+  onToggleActive: (agent: AgentListItem) => void | Promise<void>;
+}) {
+  const [toggling, setToggling] = useState(false);
+
+  async function handleToggle() {
+    if (toggling) return;
+    setToggling(true);
+    try {
+      await onToggleActive(agent);
+    } finally {
+      setToggling(false);
+    }
+  }
+
+  function handleRowActivate() {
+    onOpen(agent.slug);
+  }
+
+  function handleKey(e: KeyboardEvent<HTMLDivElement>) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onOpen(agent.slug);
+    }
+  }
+
+  const isActive = agent.active;
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={handleRowActivate}
+      onKeyDown={handleKey}
+      className="group relative flex w-full items-center gap-3 px-4 py-2.5 text-left outline-none transition-colors hover:bg-muted/40 focus-visible:bg-muted/40"
+    >
+      <AgentAvatar
+        agent={agent}
+        shape="circle"
+        size="sm"
+        className={cn(!isActive && "saturate-50 opacity-60")}
+      />
+      <div className="flex min-w-0 flex-1 items-baseline gap-2 overflow-hidden">
+        <span
+          className={cn(
+            "truncate text-[12.5px] font-semibold",
+            isActive ? "text-foreground" : "text-muted-foreground/70"
+          )}
+        >
+          {agent.name}
+        </span>
+        {agent.role ? (
+          <span
+            className={cn(
+              "truncate text-[11.5px]",
+              isActive ? "text-muted-foreground" : "text-muted-foreground/60"
+            )}
+          >
+            · {agent.role}
+          </span>
+        ) : null}
+      </div>
+
+      <div className="flex shrink-0 items-center gap-2">
+        {agent.department ? (
+          <span
+            className={cn(
+              "hidden whitespace-nowrap rounded-full bg-muted/40 px-2 py-0.5 text-[10px] sm:inline-flex",
+              isActive ? "text-muted-foreground" : "text-muted-foreground/60"
+            )}
+          >
+            {startCase(agent.department)}
+          </span>
+        ) : null}
+        {agent.scope === "global" ? (
+          <span
+            className="hidden whitespace-nowrap rounded-full bg-violet-500/15 px-2 py-0.5 text-[10px] text-violet-300 sm:inline-flex"
+            title="Shared across all cabinets"
+          >
+            Global
+          </span>
+        ) : null}
+        <div
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+        >
+          <Switch
+            checked={isActive}
+            onCheckedChange={() => void handleToggle()}
+            disabled={toggling}
+            aria-label={isActive ? `Stop ${agent.name}` : `Start ${agent.name}`}
+          />
+        </div>
+        {toggling ? (
+          <Loader2 className="size-3.5 animate-spin text-muted-foreground/60" />
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/agents/agents-workspace.tsx
+++ b/src/components/agents/agents-workspace.tsx
@@ -51,6 +51,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { AgentAvatar } from "@/components/agents/agent-avatar";
 import { HeartbeatRow, RoutineRow } from "@/components/agents/schedule-row";
+import { AgentRow } from "@/components/agents/agent-row";
 import {
   appendConversationCabinetPath,
 } from "@/lib/agents/conversation-identity";
@@ -1473,6 +1474,21 @@ export function AgentsWorkspace({
     if (!res.ok) return;
     setAgents((prev) =>
       prev.map((a) => (a.slug === agent.slug ? { ...a, heartbeatEnabled: nextEnabled } : a))
+    );
+  }
+
+  async function listToggleAgentActive(agent: AgentListItem) {
+    const cabinetPath = agent.cabinetPath || effectiveCabinetPath;
+    const res = await fetch(`/api/agents/personas/${agent.slug}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "toggle", cabinetPath }),
+    });
+    if (!res.ok) return;
+    const data = (await res.json().catch(() => null)) as { active?: boolean } | null;
+    const nextActive = data?.active ?? !agent.active;
+    setAgents((prev) =>
+      prev.map((a) => (a.slug === agent.slug ? { ...a, active: nextActive } : a))
     );
   }
 
@@ -2932,16 +2948,16 @@ export function AgentsWorkspace({
                   </div>
                 )}
 
-                {/* Agents grid */}
+                {/* Agents list */}
                 <section className="space-y-4">
                   <div className="space-y-2">
                     <h2 className="text-[24px] font-semibold tracking-tight text-foreground sm:text-[28px]">
                       Meet the team
                     </h2>
                     <p className="max-w-3xl text-[14px] leading-6 text-muted-foreground">
-                      Each card is a specialist. Click one to open its profile
-                      and edit its name, role, and the instructions that shape
-                      how it thinks and works.
+                      Each row is a specialist. Click one to open its profile.
+                      Use the toggle on the right to start or stop an agent
+                      without leaving the page.
                     </p>
                     <p className="text-[12px] text-muted-foreground/80">
                       {orgAgentCount} on the team
@@ -2949,95 +2965,34 @@ export function AgentsWorkspace({
                   </div>
 
                   {!agentsLoaded ? (
-                    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                    <ul className="divide-y divide-border/60 overflow-hidden rounded-xl border border-border/70 bg-card">
                       {Array.from({ length: 3 }).map((_, i) => (
-                        <div
-                          key={i}
-                          className="flex flex-col gap-3 rounded-xl border border-border/40 bg-card/50 p-4 animate-pulse"
-                        >
-                          <div className="flex items-start gap-3">
-                            <div className="size-10 shrink-0 rounded-full bg-muted/60" />
-                            <div className="flex-1 space-y-2 pt-1">
-                              <div className="h-3 w-24 rounded bg-muted/60" />
-                              <div className="h-2.5 w-36 rounded bg-muted/40" />
-                            </div>
+                        <li key={i} className="flex items-center gap-3 px-4 py-3 animate-pulse">
+                          <div className="size-7 shrink-0 rounded-full bg-muted/60" />
+                          <div className="flex-1 space-y-2">
+                            <div className="h-3 w-32 rounded bg-muted/60" />
+                            <div className="h-2.5 w-48 rounded bg-muted/40" />
                           </div>
-                          <div className="flex gap-1.5">
-                            <div className="h-4 w-14 rounded-full bg-muted/40" />
-                            <div className="h-4 w-10 rounded-full bg-muted/40" />
-                          </div>
-                        </div>
+                          <div className="h-4 w-7 rounded-full bg-muted/40" />
+                        </li>
                       ))}
-                    </div>
+                    </ul>
                   ) : agents.length === 0 ? (
                     <p className="rounded-lg border border-dashed border-border/60 px-3 py-8 text-center text-[12px] text-muted-foreground">
                       No agents yet. Use <span className="font-medium text-foreground">{t("agents:workspace.newAgent")}</span> above to bring one in.
                     </p>
                   ) : (
-                    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-                      {agents.map((agent) => {
-                        const hbCount = agent.heartbeat ? 1 : 0;
-                        const jobCount = agent.jobCount || 0;
-                        return (
-                          <button
-                            key={agent.scopedId ?? (agent.cabinetPath ? `${agent.cabinetPath}::${agent.slug}` : agent.slug)}
-                            type="button"
-                            onClick={() => openAgentSettings(agent.slug)}
-                            className="flex flex-col gap-3 rounded-xl border border-border/70 bg-card p-4 text-left transition-colors hover:bg-muted/30"
-                          >
-                            <div className="flex items-start gap-3">
-                              <AgentAvatar agent={agent} shape="circle" size="lg" />
-                              <div className="min-w-0 flex-1">
-                                <h3 className="truncate text-[13px] font-semibold text-foreground">
-                                  {agent.name}
-                                </h3>
-                                {agent.role ? (
-                                  <p className="mt-0.5 line-clamp-2 text-[11px] leading-snug text-muted-foreground">
-                                    {agent.role}
-                                  </p>
-                                ) : null}
-                              </div>
-                              <span
-                                className={cn(
-                                  "mt-1.5 inline-flex size-2 shrink-0 rounded-full",
-                                  agent.active
-                                    ? "bg-emerald-500"
-                                    : "bg-muted-foreground/30"
-                                )}
-                                title={agent.active ? "Active" : "Paused"}
-                              />
-                            </div>
-                            <div className="flex flex-wrap items-center gap-1.5 text-[10px] text-muted-foreground">
-                              {agent.scope === "global" ? (
-                                <span
-                                  className="inline-flex items-center rounded-full bg-violet-500/15 px-2 py-0.5 text-violet-300"
-                                  title={t("agents:workspace.sharedAcrossCabinets")}
-                                >
-                                  Global
-                                </span>
-                              ) : null}
-                              {hbCount > 0 ? (
-                                <span className="inline-flex items-center gap-1 rounded-full bg-muted/40 px-2 py-0.5">
-                                  <HeartPulse className="size-2.5 text-pink-400" />
-                                  Heartbeat
-                                </span>
-                              ) : null}
-                              {jobCount > 0 ? (
-                                <span className="inline-flex items-center gap-1 rounded-full bg-muted/40 px-2 py-0.5">
-                                  <Clock3 className="size-2.5 text-emerald-400" />
-                                  {jobCount} {jobCount === 1 ? "job" : "jobs"}
-                                </span>
-                              ) : null}
-                              {agent.department ? (
-                                <span className="inline-flex rounded-full bg-muted/40 px-2 py-0.5">
-                                  {startCase(agent.department)}
-                                </span>
-                              ) : null}
-                            </div>
-                          </button>
-                        );
-                      })}
-                    </div>
+                    <ul className="divide-y divide-border/60 overflow-hidden rounded-xl border border-border/70 bg-card">
+                      {agents.map((agent) => (
+                        <li key={agent.scopedId ?? (agent.cabinetPath ? `${agent.cabinetPath}::${agent.slug}` : agent.slug)}>
+                          <AgentRow
+                            agent={agent}
+                            onOpen={openAgentSettings}
+                            onToggleActive={listToggleAgentActive}
+                          />
+                        </li>
+                      ))}
+                    </ul>
                   )}
                 </section>
 

--- a/src/components/agents/agents-workspace.tsx
+++ b/src/components/agents/agents-workspace.tsx
@@ -328,12 +328,13 @@ function blankJobDraft(
 // surrounding view conditionally renders.
 function ToggleAllHeartbeatsButton({
   heartbeatAgents,
-  anyActive,
+  anyEnabled,
   effectiveCabinetPath,
   refreshAgents,
 }: {
   heartbeatAgents: AgentListItem[];
-  anyActive: boolean;
+  /** At least one heartbeat is on (heartbeatEnabled !== false). */
+  anyEnabled: boolean;
   effectiveCabinetPath: string | undefined;
   refreshAgents: () => Promise<void>;
 }) {
@@ -347,7 +348,7 @@ function ToggleAllHeartbeatsButton({
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          action: anyActive ? "stop-all" : "start-all",
+          action: anyEnabled ? "pause-heartbeats" : "resume-heartbeats",
           cabinetPath: effectiveCabinetPath,
         }),
       });
@@ -362,10 +363,10 @@ function ToggleAllHeartbeatsButton({
       onClick={() => void toggleAll()}
       disabled={toggling}
       className="inline-flex h-9 items-center gap-2 rounded-lg border border-border/70 bg-background px-3 text-[12px] font-medium text-foreground transition-colors hover:bg-muted/50 disabled:pointer-events-none disabled:opacity-50"
-      title={anyActive ? "Pause all heartbeats in this cabinet" : "Resume all heartbeats in this cabinet"}
+      title={anyEnabled ? "Pause all heartbeats in this cabinet" : "Resume all heartbeats in this cabinet"}
     >
-      {anyActive ? <Pause className="size-3.5" /> : <Play className="size-3.5" />}
-      {anyActive ? "Pause all" : "Resume all"}
+      {anyEnabled ? <Pause className="size-3.5" /> : <Play className="size-3.5" />}
+      {anyEnabled ? "Pause all" : "Resume all"}
     </button>
   );
 }
@@ -493,7 +494,7 @@ export function AgentsWorkspace({
   const [heartbeatDialog, setHeartbeatDialog] = useState<{
     agent: NewRoutineDialogAgent;
     initialHeartbeat?: string;
-    initialActive?: boolean;
+    initialEnabled?: boolean;
   } | null>(null);
   const [cabinetJobs, setCabinetJobs] = useState<CabinetJobSummary[]>([]);
   const [cabinetChildren, setCabinetChildren] = useState<CabinetOverview["children"]>([]);
@@ -666,6 +667,7 @@ export function AgentsWorkspace({
           emoji: a.emoji || "🤖",
           role: a.role || "",
           active: a.active,
+          heartbeatEnabled: a.heartbeatEnabled,
           type: a.type,
           department: a.department,
           heartbeat: a.heartbeat || "",
@@ -1458,19 +1460,19 @@ export function AgentsWorkspace({
 
   async function listToggleHeartbeat(agent: AgentListItem) {
     const cabinetPath = agent.cabinetPath || effectiveCabinetPath;
-    const nextActive = !agent.active;
+    const nextEnabled = agent.heartbeatEnabled === false;
     const res = await fetch(`/api/agents/personas/${agent.slug}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         heartbeat: agent.heartbeat || "",
-        active: nextActive,
+        heartbeatEnabled: nextEnabled,
         cabinetPath,
       }),
     });
     if (!res.ok) return;
     setAgents((prev) =>
-      prev.map((a) => (a.slug === agent.slug ? { ...a, active: nextActive } : a))
+      prev.map((a) => (a.slug === agent.slug ? { ...a, heartbeatEnabled: nextEnabled } : a))
     );
   }
 
@@ -1845,6 +1847,7 @@ export function AgentsWorkspace({
         emoji: a.emoji,
         role: a.role,
         active: a.active,
+        heartbeatEnabled: a.heartbeatEnabled,
         department: a.department,
         type: a.type,
         heartbeat: a.heartbeat,
@@ -3166,7 +3169,7 @@ export function AgentsWorkspace({
                               cabinetPath: agent.cabinetPath || effectiveCabinetPath,
                             },
                             initialHeartbeat: agent.heartbeat || "0 9 * * 1-5",
-                            initialActive: agent.active,
+                            initialEnabled: agent.heartbeatEnabled !== false,
                           });
                         }}
                       />
@@ -3245,7 +3248,7 @@ export function AgentsWorkspace({
                       </div>
                       <ToggleAllHeartbeatsButton
                         heartbeatAgents={agents.filter((a) => !!a.heartbeat)}
-                        anyActive={agents.filter((a) => !!a.heartbeat).some((a) => a.active)}
+                        anyEnabled={agents.filter((a) => !!a.heartbeat).some((a) => a.heartbeatEnabled !== false)}
                         effectiveCabinetPath={effectiveCabinetPath}
                         refreshAgents={refreshAgents}
                       />
@@ -3312,7 +3315,7 @@ export function AgentsWorkspace({
                                         agent.cabinetPath || effectiveCabinetPath,
                                     },
                                     initialHeartbeat: agent.heartbeat!,
-                                    initialActive: agent.active,
+                                    initialEnabled: agent.heartbeatEnabled !== false,
                                   })
                                 }
                                 onRun={() => listRunHeartbeat(agent)}
@@ -3405,7 +3408,7 @@ export function AgentsWorkspace({
                     cabinetPath: agent.cabinetPath || effectiveCabinetPath,
                   },
                   initialHeartbeat: agent.heartbeat || "0 9 * * 1-5",
-                  initialActive: agent.active,
+                  initialEnabled: agent.heartbeatEnabled !== false,
                 });
               }}
             />
@@ -3800,17 +3803,17 @@ export function AgentsWorkspace({
         }}
         agent={heartbeatDialog?.agent ?? { slug: "", name: "" }}
         initialHeartbeat={heartbeatDialog?.initialHeartbeat}
-        initialActive={heartbeatDialog?.initialActive}
+        initialEnabled={heartbeatDialog?.initialEnabled}
         onSaved={() => {
           setHeartbeatDialog(null);
           void refreshAgents();
         }}
-        onToggledActive={(nextActive) => {
+        onToggledEnabled={(nextEnabled) => {
           const targetSlug = heartbeatDialog?.agent.slug;
           if (!targetSlug) return;
           setAgents((prev) =>
             prev.map((a) =>
-              a.slug === targetSlug ? { ...a, active: nextActive } : a
+              a.slug === targetSlug ? { ...a, heartbeatEnabled: nextEnabled } : a
             )
           );
         }}

--- a/src/components/agents/heartbeat-dialog.tsx
+++ b/src/components/agents/heartbeat-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { AlertTriangle, ExternalLink, HeartPulse, Loader2, Play, Power, Save } from "lucide-react";
+import { AlertTriangle, ExternalLink, HeartPulse, Loader2, Play, Save } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -10,6 +10,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 import { SchedulePicker } from "@/components/mission-control/schedule-picker";
 import { AgentAvatar } from "@/components/agents/agent-avatar";
@@ -184,28 +185,25 @@ export function HeartbeatDialog({
                 )}
                 Run now
               </Button>
-              <Button
-                variant="outline"
-                size="sm"
+              <label
                 className={cn(
-                  "h-9 gap-1.5 text-[12px]",
-                  !enabled && "text-emerald-600 dark:text-emerald-400"
+                  "inline-flex h-9 cursor-pointer select-none items-center gap-2 rounded-md border border-input px-3 text-[12px] font-medium transition-colors hover:bg-accent/40",
+                  toggling && "opacity-60"
                 )}
-                onClick={() => void toggleEnabled()}
-                disabled={toggling}
                 title={
                   enabled
                     ? "Disable the heartbeat — it won't fire on its schedule"
                     : "Enable the heartbeat so it fires on its schedule"
                 }
               >
-                {toggling ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                ) : (
-                  <Power className="h-3.5 w-3.5" />
-                )}
-                {enabled ? "Disable" : "Enable"}
-              </Button>
+                <Switch
+                  checked={enabled}
+                  onCheckedChange={() => void toggleEnabled()}
+                  disabled={toggling}
+                  aria-label={enabled ? "Disable heartbeat" : "Enable heartbeat"}
+                />
+                <span>{enabled ? "On" : "Off"}</span>
+              </label>
             </div>
           </div>
         </DialogHeader>

--- a/src/components/agents/heartbeat-dialog.tsx
+++ b/src/components/agents/heartbeat-dialog.tsx
@@ -30,27 +30,28 @@ export function HeartbeatDialog({
   onOpenChange,
   agent,
   initialHeartbeat,
-  initialActive,
+  initialEnabled,
   missedRun,
   onSaved,
   onRanNow,
-  onToggledActive,
+  onToggledEnabled,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   agent: NewRoutineDialogAgent;
   initialHeartbeat?: string;
-  initialActive?: boolean;
+  /** Heartbeat-specific enable. Independent from the agent's master `active`. */
+  initialEnabled?: boolean;
   missedRun?: { scheduledAt: string };
   onSaved?: () => void;
   onRanNow?: (sessionId: string | null) => void;
-  /** Fired when the user toggles active from inside the dialog without
-   *  saving/closing. Lets the parent update its list without tearing down
-   *  the open dialog. */
-  onToggledActive?: (active: boolean) => void;
+  /** Fired when the user toggles the heartbeat enable from inside the dialog
+   *  without saving/closing. Lets the parent update its list without tearing
+   *  down the open dialog. */
+  onToggledEnabled?: (enabled: boolean) => void;
 }) {
   const [heartbeat, setHeartbeat] = useState(initialHeartbeat || DEFAULT_HEARTBEAT);
-  const [active, setActive] = useState(initialActive ?? true);
+  const [enabled, setEnabled] = useState(initialEnabled ?? true);
   const [saving, setSaving] = useState(false);
   const [running, setRunning] = useState(false);
   const [toggling, setToggling] = useState(false);
@@ -59,8 +60,8 @@ export function HeartbeatDialog({
   useEffect(() => {
     if (!open) return;
     setHeartbeat(initialHeartbeat || DEFAULT_HEARTBEAT);
-    setActive(initialActive ?? true);
-  }, [open, initialHeartbeat, initialActive]);
+    setEnabled(initialEnabled ?? true);
+  }, [open, initialHeartbeat, initialEnabled]);
 
   const setSection = useAppStore((s) => s.setSection);
 
@@ -72,7 +73,7 @@ export function HeartbeatDialog({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           heartbeat,
-          active,
+          heartbeatEnabled: enabled,
           cabinetPath: agent.cabinetPath,
         }),
       });
@@ -100,22 +101,22 @@ export function HeartbeatDialog({
     }
   }
 
-  async function toggleActive() {
+  async function toggleEnabled() {
     setToggling(true);
     try {
-      const nextActive = !active;
+      const next = !enabled;
       const res = await fetch(`/api/agents/personas/${agent.slug}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           heartbeat,
-          active: nextActive,
+          heartbeatEnabled: next,
           cabinetPath: agent.cabinetPath,
         }),
       });
       if (!res.ok) return;
-      setActive(nextActive);
-      onToggledActive?.(nextActive);
+      setEnabled(next);
+      onToggledEnabled?.(next);
     } finally {
       setToggling(false);
     }
@@ -169,9 +170,9 @@ export function HeartbeatDialog({
                 size="sm"
                 className="h-9 gap-1.5 text-[12px]"
                 onClick={() => void runNow()}
-                disabled={running || !active}
+                disabled={running || !enabled}
                 title={
-                  active
+                  enabled
                     ? "Run heartbeat now (one-off, outside its schedule)"
                     : "Enable the heartbeat to run it"
                 }
@@ -188,12 +189,12 @@ export function HeartbeatDialog({
                 size="sm"
                 className={cn(
                   "h-9 gap-1.5 text-[12px]",
-                  !active && "text-emerald-600 dark:text-emerald-400"
+                  !enabled && "text-emerald-600 dark:text-emerald-400"
                 )}
-                onClick={() => void toggleActive()}
+                onClick={() => void toggleEnabled()}
                 disabled={toggling}
                 title={
-                  active
+                  enabled
                     ? "Disable the heartbeat — it won't fire on its schedule"
                     : "Enable the heartbeat so it fires on its schedule"
                 }
@@ -203,7 +204,7 @@ export function HeartbeatDialog({
                 ) : (
                   <Power className="h-3.5 w-3.5" />
                 )}
-                {active ? "Disable" : "Enable"}
+                {enabled ? "Disable" : "Enable"}
               </Button>
             </div>
           </div>

--- a/src/components/agents/new-routine-dialog.tsx
+++ b/src/components/agents/new-routine-dialog.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { AlertTriangle, Loader2, Play, Power, Save, Trash2 } from "lucide-react";
+import { AlertTriangle, Loader2, Play, Save, Trash2 } from "lucide-react";
+import { Switch } from "@/components/ui/switch";
 import {
   Dialog,
   DialogContent,
@@ -277,28 +278,25 @@ export function NewRoutineDialog({
                   )}
                   Run now
                 </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
+                <label
                   className={cn(
-                    "h-9 gap-1.5 text-[12px]",
-                    draft?.enabled === false && "text-emerald-600 dark:text-emerald-400"
+                    "inline-flex h-9 cursor-pointer select-none items-center gap-2 rounded-md border border-input px-3 text-[12px] font-medium transition-colors hover:bg-accent/40",
+                    toggling && "opacity-60"
                   )}
-                  onClick={() => void toggleEnabled()}
-                  disabled={toggling}
                   title={
                     draft?.enabled === false
                       ? "Enable this routine so it runs on its schedule"
                       : "Disable this routine — it stays saved but won't fire on its schedule"
                   }
                 >
-                  {toggling ? (
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                  ) : (
-                    <Power className="h-3.5 w-3.5" />
-                  )}
-                  {draft?.enabled === false ? "Enable" : "Disable"}
-                </Button>
+                  <Switch
+                    checked={draft?.enabled !== false}
+                    onCheckedChange={() => void toggleEnabled()}
+                    disabled={toggling}
+                    aria-label={draft?.enabled === false ? "Enable routine" : "Disable routine"}
+                  />
+                  <span>{draft?.enabled === false ? "Off" : "On"}</span>
+                </label>
                 <Button
                   variant="ghost"
                   size="sm"

--- a/src/components/agents/schedule-row.tsx
+++ b/src/components/agents/schedule-row.tsx
@@ -12,7 +12,13 @@ import { useLocale } from "@/i18n/use-locale";
 
 interface BaseRowProps {
   agent: AgentListItem;
+  /** Visual dim — the row reads as "effectively off". */
   disabled: boolean;
+  /** Switch position — defaults to !disabled so callers that don't split
+   *  effective vs. switch state still work. */
+  switchChecked?: boolean;
+  /** Disable the switch itself (e.g. master is off, can't toggle the child). */
+  switchDisabled?: boolean;
   title: string;
   subtitle: string;
   schedule: string;
@@ -26,6 +32,8 @@ interface BaseRowProps {
 function ScheduleRow({
   agent,
   disabled,
+  switchChecked,
+  switchDisabled = false,
   title,
   subtitle,
   schedule,
@@ -36,6 +44,7 @@ function ScheduleRow({
   onDelete,
 }: BaseRowProps) {
   const { t } = useLocale();
+  const isOn = switchChecked ?? !disabled;
   const [running, setRunning] = useState(false);
   const [toggling, setToggling] = useState(false);
   const [confirming, setConfirming] = useState(false);
@@ -88,9 +97,9 @@ function ScheduleRow({
   }
 
   const actionSlotWidth = onDelete ? "w-[64px]" : "w-[36px]";
-  const toggleLabel = disabled
-    ? toggleVerb === "pause" ? "Resume" : "Enable"
-    : toggleVerb === "pause" ? "Pause" : "Disable";
+  const toggleLabel = isOn
+    ? toggleVerb === "pause" ? "Pause" : "Disable"
+    : toggleVerb === "pause" ? "Resume" : "Enable";
 
   return (
     <div
@@ -198,9 +207,9 @@ function ScheduleRow({
           title={toggleLabel}
         >
           <Switch
-            checked={!disabled}
+            checked={isOn}
             onCheckedChange={() => void handleToggle()}
-            disabled={toggling}
+            disabled={toggling || switchDisabled}
             aria-label={toggleLabel}
           />
         </div>
@@ -225,10 +234,15 @@ export function RoutineRow({
   onDelete: () => void | Promise<void>;
 }) {
   const { t } = useLocale();
+  // Effective off when the agent is stopped or the job is disabled. The Switch
+  // still reflects only the per-job flag, so users can pre-configure routines
+  // even while the agent is stopped — they'll fire when the agent resumes.
+  const effectiveOn = agent.active && job.enabled;
   return (
     <ScheduleRow
       agent={agent}
-      disabled={!job.enabled}
+      disabled={!effectiveOn}
+      switchChecked={job.enabled}
       title={job.name}
       subtitle={agent.name}
       schedule={job.schedule}
@@ -249,12 +263,20 @@ export function HeartbeatRow({
   agent: AgentListItem;
   onEdit: () => void;
   onRun: () => void | Promise<void>;
+  /** Toggles `agent.heartbeatEnabled` only. The master `agent.active`
+   *  switch is gated separately on the agent header / detail page. */
   onToggle: () => void | Promise<void>;
 }) {
+  const heartbeatOn = agent.heartbeatEnabled !== false;
+  const effectiveOn = agent.active && heartbeatOn;
   return (
     <ScheduleRow
       agent={agent}
-      disabled={!agent.active}
+      // Visual dim when *effectively* off (master or per-heartbeat off);
+      // the Switch itself reflects only the per-heartbeat toggle so it stays
+      // editable even while the master is off.
+      disabled={!effectiveOn}
+      switchChecked={heartbeatOn}
       title={agent.name}
       subtitle="Heartbeat"
       schedule={agent.heartbeat || ""}

--- a/src/components/agents/schedule-row.tsx
+++ b/src/components/agents/schedule-row.tsx
@@ -4,11 +4,14 @@ import { useState, type KeyboardEvent, type MouseEvent } from "react";
 import { Check, Loader2, Play, Trash2, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { AgentAvatar } from "@/components/agents/agent-avatar";
-import { Switch } from "@/components/ui/switch";
+import { LockedSwitch } from "@/components/ui/locked-switch";
 import { cronToHuman } from "@/lib/agents/cron-utils";
 import type { AgentListItem } from "@/types/agents";
 import type { JobConfig } from "@/types/jobs";
 import { useLocale } from "@/i18n/use-locale";
+
+const LOCKED_TOOLTIP =
+  "This agent is stopped. Open the agent's page and start it to fire its routines.";
 
 interface BaseRowProps {
   agent: AgentListItem;
@@ -17,8 +20,9 @@ interface BaseRowProps {
   /** Switch position — defaults to !disabled so callers that don't split
    *  effective vs. switch state still work. */
   switchChecked?: boolean;
-  /** Disable the switch itself (e.g. master is off, can't toggle the child). */
-  switchDisabled?: boolean;
+  /** Lock the Switch (master is off — child can't be toggled until master
+   *  is back on). Renders gray + tooltip. */
+  switchLocked?: boolean;
   title: string;
   subtitle: string;
   schedule: string;
@@ -33,7 +37,7 @@ function ScheduleRow({
   agent,
   disabled,
   switchChecked,
-  switchDisabled = false,
+  switchLocked = false,
   title,
   subtitle,
   schedule,
@@ -111,21 +115,26 @@ function ScheduleRow({
         "group relative flex w-full items-center gap-3 px-4 py-2.5 text-left outline-none transition-colors",
         confirming
           ? "bg-red-500/10"
-          : "hover:bg-muted/40 focus-visible:bg-muted/40",
-        disabled && !confirming && "opacity-60"
+          : "hover:bg-muted/40 focus-visible:bg-muted/40"
       )}
     >
       <AgentAvatar
         agent={agent}
         shape="circle"
         size="sm"
-        className={cn(disabled && "saturate-50")}
+        className={cn(disabled && "saturate-50 opacity-60")}
       />
       <div className="flex min-w-0 flex-1 items-baseline gap-2 overflow-hidden">
-        <span className="truncate text-[12.5px] font-semibold text-foreground">
+        <span className={cn(
+          "truncate text-[12.5px] font-semibold",
+          disabled ? "text-muted-foreground/70" : "text-foreground"
+        )}>
           {title}
         </span>
-        <span className="truncate text-[11.5px] text-muted-foreground">
+        <span className={cn(
+          "truncate text-[11.5px]",
+          disabled ? "text-muted-foreground/60" : "text-muted-foreground"
+        )}>
           · {subtitle}
         </span>
       </div>
@@ -197,20 +206,22 @@ function ScheduleRow({
           </div>
         )}
 
-        <span className="whitespace-nowrap text-[11px] text-muted-foreground">
+        <span className={cn(
+          "whitespace-nowrap text-[11px]",
+          disabled ? "text-muted-foreground/60" : "text-muted-foreground"
+        )}>
           {schedule ? cronToHuman(schedule) : ""}
         </span>
         <div
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e) => e.stopPropagation()}
-          aria-label={toggleLabel}
-          title={toggleLabel}
         >
-          <Switch
+          <LockedSwitch
             checked={isOn}
             onCheckedChange={() => void handleToggle()}
-            disabled={toggling || switchDisabled}
-            aria-label={toggleLabel}
+            locked={switchLocked}
+            tooltip={LOCKED_TOOLTIP}
+            ariaLabel={toggleLabel}
           />
         </div>
       </div>
@@ -235,14 +246,15 @@ export function RoutineRow({
 }) {
   const { t } = useLocale();
   // Effective off when the agent is stopped or the job is disabled. The Switch
-  // still reflects only the per-job flag, so users can pre-configure routines
-  // even while the agent is stopped — they'll fire when the agent resumes.
+  // is locked while the agent is stopped — the user has to start the agent
+  // before they can toggle children, mirroring the parent/child relationship.
   const effectiveOn = agent.active && job.enabled;
   return (
     <ScheduleRow
       agent={agent}
       disabled={!effectiveOn}
       switchChecked={job.enabled}
+      switchLocked={!agent.active}
       title={job.name}
       subtitle={agent.name}
       schedule={job.schedule}
@@ -273,10 +285,11 @@ export function HeartbeatRow({
     <ScheduleRow
       agent={agent}
       // Visual dim when *effectively* off (master or per-heartbeat off);
-      // the Switch itself reflects only the per-heartbeat toggle so it stays
-      // editable even while the master is off.
+      // the Switch is locked while the agent is stopped (same parent/child
+      // gating used for routines).
       disabled={!effectiveOn}
       switchChecked={heartbeatOn}
+      switchLocked={!agent.active}
       title={agent.name}
       subtitle="Heartbeat"
       schedule={agent.heartbeat || ""}

--- a/src/components/agents/v2/agent-row.tsx
+++ b/src/components/agents/v2/agent-row.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useState, type KeyboardEvent } from "react";
+import { Calendar as CalendarIcon, HeartPulse, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Switch } from "@/components/ui/switch";
+import { AgentAvatar } from "@/components/agents/agent-avatar";
+import { startCase } from "@/components/cabinets/cabinet-utils";
+import { cronToHuman } from "@/lib/agents/cron-utils";
+import type { CabinetAgentSummary, CabinetJobSummary } from "@/types/cabinets";
+
+/** Compact row used in the Agents tab. */
+export function AgentRow({
+  agent,
+  routines,
+  onToggleActive,
+  onOpen,
+}: {
+  agent: CabinetAgentSummary;
+  routines: CabinetJobSummary[];
+  onToggleActive: () => void | Promise<void>;
+  onOpen: () => void;
+}) {
+  const [toggling, setToggling] = useState(false);
+  const heartbeatOn = agent.active && agent.heartbeatEnabled !== false;
+  const heartbeatLabel = agent.heartbeat ? cronToHuman(agent.heartbeat) : "off";
+  const routinesOff = routines.filter((r) => !r.enabled).length;
+
+  async function handleToggle() {
+    if (toggling) return;
+    setToggling(true);
+    try {
+      await onToggleActive();
+    } finally {
+      setToggling(false);
+    }
+  }
+
+  function handleActivate() {
+    onOpen();
+  }
+  function handleKey(e: KeyboardEvent<HTMLDivElement>) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onOpen();
+    }
+  }
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={handleActivate}
+      onKeyDown={handleKey}
+      className="group flex h-10 items-center gap-3 px-3 text-left outline-none transition-colors hover:bg-muted/40 focus-visible:bg-muted/40"
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
+        <Switch
+          checked={agent.active}
+          onCheckedChange={() => void handleToggle()}
+          disabled={toggling}
+          aria-label={agent.active ? `Stop ${agent.name}` : `Start ${agent.name}`}
+        />
+      </div>
+
+      <AgentAvatar
+        agent={agent}
+        shape="circle"
+        size="sm"
+        className={cn(!agent.active && "saturate-50 opacity-60")}
+      />
+
+      <div className="flex min-w-0 flex-1 items-baseline gap-2 overflow-hidden">
+        <span
+          className={cn(
+            "truncate text-[12.5px] font-semibold",
+            agent.active ? "text-foreground" : "text-muted-foreground/70"
+          )}
+        >
+          {agent.name}
+        </span>
+        {agent.role ? (
+          <span
+            className={cn(
+              "truncate text-[11.5px]",
+              agent.active ? "text-muted-foreground" : "text-muted-foreground/60"
+            )}
+          >
+            · {agent.role}
+          </span>
+        ) : null}
+      </div>
+
+      {agent.department ? (
+        <span
+          className={cn(
+            "hidden whitespace-nowrap rounded-full bg-muted/40 px-2 py-0.5 text-[10px] sm:inline-flex",
+            agent.active ? "text-muted-foreground" : "text-muted-foreground/60"
+          )}
+        >
+          {startCase(agent.department)}
+        </span>
+      ) : null}
+
+      <span
+        className={cn(
+          "hidden items-center gap-1 whitespace-nowrap rounded-full px-2 py-0.5 text-[10px] sm:inline-flex",
+          heartbeatOn
+            ? "bg-pink-500/10 text-pink-600 dark:text-pink-400"
+            : "bg-muted/40 text-muted-foreground/70"
+        )}
+        title={heartbeatOn ? `Heartbeat: ${heartbeatLabel}` : "Heartbeat off"}
+      >
+        <HeartPulse className="size-2.5" />
+        {agent.heartbeat ? heartbeatLabel : "off"}
+      </span>
+
+      <span
+        className={cn(
+          "hidden items-center gap-1 whitespace-nowrap rounded-full px-2 py-0.5 text-[10px] sm:inline-flex",
+          routines.length > 0
+            ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+            : "bg-muted/40 text-muted-foreground/70"
+        )}
+        title={
+          routines.length === 0
+            ? "No routines"
+            : routinesOff > 0
+              ? `${routines.length} routines · ${routinesOff} off`
+              : `${routines.length} routines`
+        }
+      >
+        <CalendarIcon className="size-2.5" />
+        {routines.length === 0
+          ? "0"
+          : routinesOff > 0
+            ? `${routines.length} · ${routinesOff} off`
+            : `${routines.length}`}
+      </span>
+
+      {toggling ? (
+        <Loader2 className="size-3.5 animate-spin text-muted-foreground/60" />
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/agents/v2/agent-row.tsx
+++ b/src/components/agents/v2/agent-row.tsx
@@ -54,18 +54,6 @@ export function AgentRow({
       onKeyDown={handleKey}
       className="group flex h-10 items-center gap-3 px-3 text-left outline-none transition-colors hover:bg-muted/40 focus-visible:bg-muted/40"
     >
-      <div
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
-        <Switch
-          checked={agent.active}
-          onCheckedChange={() => void handleToggle()}
-          disabled={toggling}
-          aria-label={agent.active ? `Stop ${agent.name}` : `Start ${agent.name}`}
-        />
-      </div>
-
       <AgentAvatar
         agent={agent}
         shape="circle"
@@ -144,6 +132,18 @@ export function AgentRow({
       {toggling ? (
         <Loader2 className="size-3.5 animate-spin text-muted-foreground/60" />
       ) : null}
+
+      <div
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
+        <Switch
+          checked={agent.active}
+          onCheckedChange={() => void handleToggle()}
+          disabled={toggling}
+          aria-label={agent.active ? `Stop ${agent.name}` : `Start ${agent.name}`}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/agents/v2/agents-context.tsx
+++ b/src/components/agents/v2/agents-context.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+/**
+ * Shared client context for the V2 /agents page. Owns:
+ *   - agents + jobs (fetched from cabinet overview)
+ *   - cabinet scope (visibility mode)
+ *   - dialog state (heartbeat, routine, new-agent, org-chart, agent-picker)
+ *   - toggle / bulk handlers wired to the production endpoints
+ *
+ * Single mount point for the whole tab tree.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { fetchCabinetOverviewClient } from "@/lib/cabinets/overview-client";
+import { ROOT_CABINET_PATH } from "@/lib/cabinets/paths";
+import { useAppStore } from "@/stores/app-store";
+import type {
+  CabinetAgentSummary,
+  CabinetJobSummary,
+  CabinetOverview,
+  CabinetVisibilityMode,
+} from "@/types/cabinets";
+import type { JobConfig } from "@/types/jobs";
+import type { NewRoutineDialogAgent } from "@/components/agents/new-routine-dialog";
+
+export interface HeartbeatDialogState {
+  agent: NewRoutineDialogAgent;
+  initialHeartbeat?: string;
+  initialEnabled?: boolean;
+}
+
+export interface RoutineDialogState {
+  agent: NewRoutineDialogAgent;
+  existingJob?: Partial<JobConfig>;
+  /** True when this is a fresh routine, not an edit. */
+  isNew?: boolean;
+}
+
+interface AgentsContextValue {
+  cabinetPath: string;
+  loading: boolean;
+  agents: CabinetAgentSummary[];
+  jobs: CabinetJobSummary[];
+
+  visibilityMode: CabinetVisibilityMode;
+  setVisibilityMode: (mode: CabinetVisibilityMode) => void;
+
+  refresh: () => Promise<void>;
+
+  // Per-row toggles — write-through to the API + optimistic update
+  toggleAgentActive: (agent: CabinetAgentSummary) => Promise<void>;
+  toggleHeartbeatEnabled: (agent: CabinetAgentSummary) => Promise<void>;
+  toggleJobEnabled: (job: CabinetJobSummary) => Promise<void>;
+
+  // Bulk
+  toggleAllHeartbeats: () => Promise<void>;
+
+  // Dialog openers
+  heartbeatDialog: HeartbeatDialogState | null;
+  setHeartbeatDialog: (s: HeartbeatDialogState | null) => void;
+  routineDialog: RoutineDialogState | null;
+  setRoutineDialog: (s: RoutineDialogState | null) => void;
+  newAgentOpen: boolean;
+  setNewAgentOpen: (open: boolean) => void;
+  orgChartOpen: boolean;
+  setOrgChartOpen: (open: boolean) => void;
+}
+
+const Ctx = createContext<AgentsContextValue | null>(null);
+
+export function AgentsContextProvider({
+  cabinetPath,
+  children,
+}: {
+  cabinetPath?: string;
+  children: React.ReactNode;
+}) {
+  const effectivePath = cabinetPath || ROOT_CABINET_PATH;
+
+  const visibilityMode = useAppStore(
+    (s) => s.cabinetVisibilityModes[effectivePath] ?? "own"
+  );
+  const setCabinetVisibilityMode = useAppStore(
+    (s) => s.setCabinetVisibilityMode
+  );
+  const setVisibilityMode = useCallback(
+    (mode: CabinetVisibilityMode) => {
+      setCabinetVisibilityMode(effectivePath, mode);
+    },
+    [effectivePath, setCabinetVisibilityMode]
+  );
+
+  const [agents, setAgents] = useState<CabinetAgentSummary[]>([]);
+  const [jobs, setJobs] = useState<CabinetJobSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const [heartbeatDialog, setHeartbeatDialog] =
+    useState<HeartbeatDialogState | null>(null);
+  const [routineDialog, setRoutineDialog] =
+    useState<RoutineDialogState | null>(null);
+  const [newAgentOpen, setNewAgentOpen] = useState(false);
+  const [orgChartOpen, setOrgChartOpen] = useState(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = (await fetchCabinetOverviewClient(
+        effectivePath,
+        visibilityMode
+      )) as CabinetOverview | null;
+      if (!data) {
+        setAgents([]);
+        setJobs([]);
+        return;
+      }
+      setAgents(data.agents || []);
+      setJobs(data.jobs || []);
+    } finally {
+      setLoading(false);
+    }
+  }, [effectivePath, visibilityMode]);
+
+  // Initial fetch + refetch whenever the scope changes
+  useEffect(() => {
+    setLoading(true);
+    void refresh();
+  }, [refresh]);
+
+  // Refetch when other parts of the app touch agents/jobs
+  useEffect(() => {
+    const onChange = () => void refresh();
+    window.addEventListener("cabinet:agents/agent_status", onChange);
+    window.addEventListener("cabinet:conversation-completed", onChange);
+    return () => {
+      window.removeEventListener("cabinet:agents/agent_status", onChange);
+      window.removeEventListener("cabinet:conversation-completed", onChange);
+    };
+  }, [refresh]);
+
+  const toggleAgentActive = useCallback(
+    async (agent: CabinetAgentSummary) => {
+      setAgents((prev) =>
+        prev.map((a) =>
+          a.slug === agent.slug ? { ...a, active: !a.active } : a
+        )
+      );
+      await fetch(`/api/agents/personas/${agent.slug}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "toggle",
+          cabinetPath: agent.cabinetPath || effectivePath,
+        }),
+      }).catch(() => {});
+    },
+    [effectivePath]
+  );
+
+  const toggleHeartbeatEnabled = useCallback(
+    async (agent: CabinetAgentSummary) => {
+      const next = agent.heartbeatEnabled === false;
+      setAgents((prev) =>
+        prev.map((a) =>
+          a.slug === agent.slug ? { ...a, heartbeatEnabled: next } : a
+        )
+      );
+      await fetch(`/api/agents/personas/${agent.slug}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          heartbeat: agent.heartbeat || "",
+          heartbeatEnabled: next,
+          cabinetPath: agent.cabinetPath || effectivePath,
+        }),
+      }).catch(() => {});
+    },
+    [effectivePath]
+  );
+
+  const toggleJobEnabled = useCallback(
+    async (job: CabinetJobSummary) => {
+      const next = !job.enabled;
+      setJobs((prev) =>
+        prev.map((j) =>
+          j.scopedId === job.scopedId ? { ...j, enabled: next } : j
+        )
+      );
+      const ownerSlug = job.ownerAgent || "";
+      if (!ownerSlug) return;
+      await fetch(`/api/agents/${ownerSlug}/jobs/${job.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "update",
+          cabinetPath: job.cabinetPath || effectivePath,
+          enabled: next,
+        }),
+      }).catch(() => {});
+    },
+    [effectivePath]
+  );
+
+  const toggleAllHeartbeats = useCallback(async () => {
+    const anyEnabled = agents.some(
+      (a) => !!a.heartbeat && a.heartbeatEnabled !== false
+    );
+    await fetch("/api/agents/scheduler", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        action: anyEnabled ? "pause-heartbeats" : "resume-heartbeats",
+        cabinetPath: effectivePath,
+      }),
+    }).catch(() => {});
+    await refresh();
+  }, [agents, effectivePath, refresh]);
+
+  const value = useMemo<AgentsContextValue>(
+    () => ({
+      cabinetPath: effectivePath,
+      loading,
+      agents,
+      jobs,
+      visibilityMode,
+      setVisibilityMode,
+      refresh,
+      toggleAgentActive,
+      toggleHeartbeatEnabled,
+      toggleJobEnabled,
+      toggleAllHeartbeats,
+      heartbeatDialog,
+      setHeartbeatDialog,
+      routineDialog,
+      setRoutineDialog,
+      newAgentOpen,
+      setNewAgentOpen,
+      orgChartOpen,
+      setOrgChartOpen,
+    }),
+    [
+      effectivePath,
+      loading,
+      agents,
+      jobs,
+      visibilityMode,
+      setVisibilityMode,
+      refresh,
+      toggleAgentActive,
+      toggleHeartbeatEnabled,
+      toggleJobEnabled,
+      toggleAllHeartbeats,
+      heartbeatDialog,
+      routineDialog,
+      newAgentOpen,
+      orgChartOpen,
+    ]
+  );
+
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+export function useAgentsContext(): AgentsContextValue {
+  const ctx = useContext(Ctx);
+  if (!ctx) {
+    throw new Error("useAgentsContext must be used inside AgentsContextProvider");
+  }
+  return ctx;
+}

--- a/src/components/agents/v2/agents-context.tsx
+++ b/src/components/agents/v2/agents-context.tsx
@@ -61,6 +61,11 @@ interface AgentsContextValue {
 
   // Bulk
   toggleAllHeartbeats: () => Promise<void>;
+  /** Flip every agent on/off via the scheduler `start-all` / `stop-all`
+   *  action. When any agent is currently active, this stops all of them
+   *  (which also gates their heartbeats and routines via PR #77). When
+   *  none are active, this starts all. */
+  toggleAllAgentsActive: () => Promise<void>;
 
   // Dialog openers
   heartbeatDialog: HeartbeatDialogState | null;
@@ -206,6 +211,19 @@ export function AgentsContextProvider({
     [effectivePath]
   );
 
+  const toggleAllAgentsActive = useCallback(async () => {
+    const anyActive = agents.some((a) => a.active);
+    await fetch("/api/agents/scheduler", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        action: anyActive ? "stop-all" : "start-all",
+        cabinetPath: effectivePath,
+      }),
+    }).catch(() => {});
+    await refresh();
+  }, [agents, effectivePath, refresh]);
+
   const toggleAllHeartbeats = useCallback(async () => {
     const anyEnabled = agents.some(
       (a) => !!a.heartbeat && a.heartbeatEnabled !== false
@@ -234,6 +252,7 @@ export function AgentsContextProvider({
       toggleHeartbeatEnabled,
       toggleJobEnabled,
       toggleAllHeartbeats,
+      toggleAllAgentsActive,
       heartbeatDialog,
       setHeartbeatDialog,
       routineDialog,
@@ -255,6 +274,7 @@ export function AgentsContextProvider({
       toggleHeartbeatEnabled,
       toggleJobEnabled,
       toggleAllHeartbeats,
+      toggleAllAgentsActive,
       heartbeatDialog,
       routineDialog,
       newAgentOpen,

--- a/src/components/agents/v2/agents-tab.tsx
+++ b/src/components/agents/v2/agents-tab.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Network } from "lucide-react";
+import { useAppStore } from "@/stores/app-store";
+import { startCase } from "@/components/cabinets/cabinet-utils";
+import type { CabinetJobSummary } from "@/types/cabinets";
+import { useAgentsContext } from "./agents-context";
+import { FilterChip, ListShell } from "./list-shell";
+import { TabExplainer } from "./tab-explainer";
+import { AgentRow } from "./agent-row";
+
+export function AgentsTab() {
+  const { loading, agents, jobs, toggleAgentActive, setOrgChartOpen } =
+    useAgentsContext();
+  const setSection = useAppStore((s) => s.setSection);
+
+  const [query, setQuery] = useState("");
+  const [deptFilter, setDeptFilter] = useState<string | "all">("all");
+  const [activeFilter, setActiveFilter] = useState<"all" | "active" | "stopped">(
+    "all"
+  );
+
+  const jobsByAgent = useMemo(() => {
+    const m = new Map<string, CabinetJobSummary[]>();
+    for (const job of jobs) {
+      const slug = job.ownerAgent || "";
+      if (!slug) continue;
+      const list = m.get(slug) || [];
+      list.push(job);
+      m.set(slug, list);
+    }
+    return m;
+  }, [jobs]);
+
+  const departments = useMemo(() => {
+    const set = new Set<string>();
+    for (const a of agents) if (a.department) set.add(a.department);
+    return ["all" as const, ...Array.from(set).sort()];
+  }, [agents]);
+
+  const activeCount = useMemo(
+    () => agents.filter((a) => a.active).length,
+    [agents]
+  );
+  const departmentCount = useMemo(
+    () => new Set(agents.map((a) => a.department).filter(Boolean)).size,
+    [agents]
+  );
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return agents.filter((a) => {
+      if (deptFilter !== "all" && a.department !== deptFilter) return false;
+      if (activeFilter === "active" && !a.active) return false;
+      if (activeFilter === "stopped" && a.active) return false;
+      if (q) {
+        const hay = [a.name, a.role, a.department]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    });
+  }, [agents, query, deptFilter, activeFilter]);
+
+  return (
+    <ListShell
+      explainer={
+        <TabExplainer
+          id="agents"
+          ariaLabel="About your agents"
+          body={
+            <>
+              <p>
+                Your AI teammates. Each one has a specialty — a writer, a
+                researcher, a planner. Click any agent to set them up or read
+                what they&apos;ve been doing.
+              </p>
+              <p>
+                The switch on each row is the agent&apos;s on / off button.
+                When it&apos;s on, the agent does its scheduled work on its
+                own. When it&apos;s off, nothing fires automatically — but
+                you can still chat with the agent any time.
+              </p>
+            </>
+          }
+        />
+      }
+      stats={
+        <>
+          <span className="tabular-nums text-foreground">{activeCount}</span>{" "}
+          active
+          {" · "}
+          <span className="tabular-nums text-foreground">{departmentCount}</span>{" "}
+          departments
+        </>
+      }
+      query={query}
+      setQuery={setQuery}
+      searchPlaceholder="Search by name, role, or department"
+      filters={
+        <>
+          <FilterChip
+            value={deptFilter}
+            onChange={(v) => setDeptFilter(v as string | "all")}
+            options={departments.map((d) => ({
+              value: d,
+              label: d === "all" ? "All departments" : startCase(d),
+            }))}
+          />
+          <FilterChip
+            value={activeFilter}
+            onChange={(v) => setActiveFilter(v as typeof activeFilter)}
+            options={[
+              { value: "all", label: "All" },
+              { value: "active", label: "Active only" },
+              { value: "stopped", label: "Stopped only" },
+            ]}
+          />
+        </>
+      }
+      trailingActions={
+        <button
+          type="button"
+          onClick={() => setOrgChartOpen(true)}
+          title="Open org chart"
+          className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border/70 bg-background px-2.5 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
+        >
+          <Network className="size-3.5" />
+          Org chart
+        </button>
+      }
+      loading={loading}
+      empty={{
+        title:
+          agents.length === 0
+            ? "No agents yet. Click + New Agent to add one."
+            : "No agents match your filters.",
+        hint:
+          agents.length > 0 && filtered.length === 0
+            ? "Try clearing a filter."
+            : undefined,
+      }}
+    >
+      {filtered.length === 0 ? (
+        []
+      ) : (
+        <ul className="divide-y divide-border/60">
+          {filtered.map((agent) => (
+            <li key={agent.scopedId}>
+              <AgentRow
+                agent={agent}
+                routines={jobsByAgent.get(agent.slug) || []}
+                onToggleActive={() => toggleAgentActive(agent)}
+                onOpen={() =>
+                  setSection({
+                    type: "agent",
+                    slug: agent.slug,
+                    cabinetPath: agent.cabinetPath,
+                    agentScopedId: agent.scopedId,
+                  })
+                }
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </ListShell>
+  );
+}

--- a/src/components/agents/v2/agents-tab.tsx
+++ b/src/components/agents/v2/agents-tab.tsx
@@ -7,13 +7,18 @@ import { startCase } from "@/components/cabinets/cabinet-utils";
 import type { CabinetJobSummary } from "@/types/cabinets";
 import { useAgentsContext } from "./agents-context";
 import { FilterChip, ListShell } from "./list-shell";
-import { TabExplainer } from "./tab-explainer";
+import {
+  ExplainerCard,
+  ExplainerIcon,
+  useExplainerState,
+} from "./tab-explainer";
 import { AgentRow } from "./agent-row";
 
 export function AgentsTab() {
   const { loading, agents, jobs, toggleAgentActive, setOrgChartOpen } =
     useAgentsContext();
   const setSection = useAppStore((s) => s.setSection);
+  const explainer = useExplainerState("agents");
 
   const [query, setQuery] = useState("");
   const [deptFilter, setDeptFilter] = useState<string | "all">("all");
@@ -68,25 +73,19 @@ export function AgentsTab() {
   return (
     <ListShell
       explainer={
-        <TabExplainer
-          id="agents"
-          ariaLabel="About your agents"
-          body={
-            <>
-              <p>
-                Your AI teammates. Each one has a specialty — a writer, a
-                researcher, a planner. Click any agent to set them up or read
-                what they&apos;ve been doing.
-              </p>
-              <p>
-                The switch on each row is the agent&apos;s on / off button.
-                When it&apos;s on, the agent does its scheduled work on its
-                own. When it&apos;s off, nothing fires automatically — but
-                you can still chat with the agent any time.
-              </p>
-            </>
-          }
-        />
+        <ExplainerCard state={explainer}>
+          <p>
+            Your AI teammates. Each one has a specialty, a writer, a
+            researcher, a planner. Click any agent to set them up or read
+            what they&apos;ve been doing.
+          </p>
+          <p>
+            The switch on each row is the agent&apos;s on / off button. When
+            it&apos;s on, the agent does its scheduled work on its own. When
+            it&apos;s off, nothing fires automatically, but you can still
+            chat with the agent any time.
+          </p>
+        </ExplainerCard>
       }
       stats={
         <>
@@ -95,6 +94,7 @@ export function AgentsTab() {
           {" · "}
           <span className="tabular-nums text-foreground">{departmentCount}</span>{" "}
           departments
+          <ExplainerIcon state={explainer} ariaLabel="About your agents" />
         </>
       }
       query={query}

--- a/src/components/agents/v2/agents-workspace-v2.tsx
+++ b/src/components/agents/v2/agents-workspace-v2.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { JobConfig } from "@/types/jobs";
+import { useAppStore } from "@/stores/app-store";
+import { NewRoutineDialog } from "@/components/agents/new-routine-dialog";
+import { HeartbeatDialog } from "@/components/agents/heartbeat-dialog";
+import { OrgChartModal } from "@/components/cabinets/org-chart-modal";
+import { AgentsContextProvider, useAgentsContext } from "./agents-context";
+import { TabsLayout, type AgentsTabKey } from "./tabs-layout";
+import { NewAgentDialog } from "./new-agent-dialog";
+
+const ALL_TABS: readonly AgentsTabKey[] = [
+  "agents",
+  "routines",
+  "heartbeats",
+  "schedule",
+];
+
+function isTab(value: string | undefined): value is AgentsTabKey {
+  return !!value && (ALL_TABS as readonly string[]).includes(value);
+}
+
+/**
+ * V2 entry point for /agents. Mounts the shared context + all dialogs and
+ * renders the tabbed layout. The `tab` prop is parsed by app-shell from the
+ * hash route (e.g. `#/agents/routines`).
+ */
+export function AgentsWorkspaceV2({
+  cabinetPath,
+  tab,
+  onTabChange,
+}: {
+  cabinetPath?: string;
+  tab?: string;
+  onTabChange: (next: AgentsTabKey) => void;
+}) {
+  const activeTab: AgentsTabKey = isTab(tab) ? tab : "agents";
+
+  return (
+    <AgentsContextProvider cabinetPath={cabinetPath}>
+      <TabsLayout tab={activeTab} onTabChange={onTabChange} />
+      <Dialogs />
+    </AgentsContextProvider>
+  );
+}
+
+/**
+ * Mount point for all V2 dialogs. Reads state from the context and reuses
+ * the same dialog components the rest of the app uses, so behavior is
+ * identical to the cabinet view, tasks board, etc.
+ */
+function Dialogs() {
+  const {
+    cabinetPath,
+    agents,
+    jobs,
+    refresh,
+    heartbeatDialog,
+    setHeartbeatDialog,
+    routineDialog,
+    setRoutineDialog,
+    newAgentOpen,
+    setNewAgentOpen,
+    orgChartOpen,
+    setOrgChartOpen,
+  } = useAgentsContext();
+
+  const setSection = useAppStore((s) => s.setSection);
+
+  // The org chart modal needs the cabinet's children too. For V2 we don't
+  // expose child cabinets through the agents context, so refetch via the
+  // overview here when the modal opens. Keeps the context lean.
+  const [orgChartChildren, setOrgChartChildren] = useState<
+    Parameters<typeof OrgChartModal>[0]["childCabinets"]
+  >([]);
+  useEffect(() => {
+    if (!orgChartOpen) return;
+    let cancel = false;
+    (async () => {
+      try {
+        const res = await fetch(
+          `/api/cabinets/overview?path=${encodeURIComponent(cabinetPath)}&visibility=own`
+        );
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!cancel) setOrgChartChildren(data.children || []);
+      } catch {
+        /* ignore */
+      }
+    })();
+    return () => {
+      cancel = true;
+    };
+  }, [orgChartOpen, cabinetPath]);
+
+  return (
+    <>
+      <HeartbeatDialog
+        open={heartbeatDialog !== null}
+        onOpenChange={(next) => {
+          if (!next) setHeartbeatDialog(null);
+        }}
+        agent={heartbeatDialog?.agent ?? { slug: "", name: "" }}
+        initialHeartbeat={heartbeatDialog?.initialHeartbeat}
+        initialEnabled={heartbeatDialog?.initialEnabled}
+        onSaved={() => {
+          setHeartbeatDialog(null);
+          void refresh();
+        }}
+        onToggledEnabled={() => void refresh()}
+      />
+
+      <NewRoutineDialog
+        open={routineDialog !== null}
+        onOpenChange={(next) => {
+          if (!next) setRoutineDialog(null);
+        }}
+        agent={routineDialog?.agent ?? { slug: "", name: "" }}
+        existingJob={routineDialog?.existingJob as JobConfig | undefined}
+        onSaved={() => {
+          setRoutineDialog(null);
+          void refresh();
+        }}
+        onDeleted={() => {
+          setRoutineDialog(null);
+          void refresh();
+        }}
+      />
+
+      <NewAgentDialog
+        open={newAgentOpen}
+        onOpenChange={setNewAgentOpen}
+        cabinetPath={cabinetPath}
+        onAdded={refresh}
+      />
+
+      <OrgChartModal
+        open={orgChartOpen}
+        onOpenChange={setOrgChartOpen}
+        cabinetName={cabinetPath === "." ? "Cabinet" : cabinetPath}
+        agents={agents}
+        jobs={jobs}
+        childCabinets={orgChartChildren}
+        onAgentClick={(agent) =>
+          setSection({
+            type: "agent",
+            slug: agent.slug,
+            cabinetPath: agent.cabinetPath,
+            agentScopedId: agent.scopedId,
+          })
+        }
+        onAgentSend={(agent) =>
+          setSection({
+            type: "agent",
+            slug: agent.slug,
+            cabinetPath: agent.cabinetPath,
+            agentScopedId: agent.scopedId,
+          })
+        }
+        onChildCabinetClick={(child) =>
+          setSection({
+            type: "cabinet",
+            cabinetPath: child.path,
+          })
+        }
+      />
+    </>
+  );
+}

--- a/src/components/agents/v2/heartbeats-tab.tsx
+++ b/src/components/agents/v2/heartbeats-tab.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { HeartPulse, Pause } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { LockedSwitch } from "@/components/ui/locked-switch";
+import { AgentAvatar } from "@/components/agents/agent-avatar";
+import { cronToHuman } from "@/lib/agents/cron-utils";
+import type { CabinetAgentSummary } from "@/types/cabinets";
+import { useAgentsContext } from "./agents-context";
+import { FilterChip, ListShell } from "./list-shell";
+import { TabExplainer } from "./tab-explainer";
+
+export function HeartbeatsTab() {
+  const {
+    loading,
+    agents,
+    toggleHeartbeatEnabled,
+    toggleAllHeartbeats,
+    setHeartbeatDialog,
+  } = useAgentsContext();
+
+  const [query, setQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState<
+    "all" | "firing" | "off" | "locked"
+  >("all");
+
+  const heartbeats = useMemo(
+    () => agents.filter((a) => !!a.heartbeat),
+    [agents]
+  );
+
+  const stats = useMemo(() => {
+    let firing = 0;
+    let off = 0;
+    let locked = 0;
+    for (const a of heartbeats) {
+      const enabled = a.heartbeatEnabled !== false;
+      if (!a.active) locked++;
+      else if (enabled) firing++;
+      else off++;
+    }
+    return { firing, off, locked };
+  }, [heartbeats]);
+
+  const anyEnabled = heartbeats.some((a) => a.heartbeatEnabled !== false);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return heartbeats.filter((a) => {
+      const enabled = a.heartbeatEnabled !== false;
+      const firing = a.active && enabled;
+      const locked = !a.active;
+      if (statusFilter === "firing" && !firing) return false;
+      if (statusFilter === "off" && (locked || enabled)) return false;
+      if (statusFilter === "locked" && !locked) return false;
+      if (q) {
+        const hay = [a.name, a.role, a.department]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    });
+  }, [heartbeats, query, statusFilter]);
+
+  return (
+    <ListShell
+      explainer={
+        <TabExplainer
+          id="heartbeats"
+          ariaLabel="About heartbeats"
+          body={
+            <>
+              <p>
+                A heartbeat is what makes your agent feel alive. Every time
+                it ticks, the agent wakes up, looks around, and decides what
+                to do next — no instructions needed. It&apos;s the
+                difference between an agent that waits to be told and one
+                that takes initiative.
+              </p>
+              <p>
+                Pick a rhythm that fits the work — every few minutes for
+                fast-moving things, once a day for quieter ones. Switch it
+                off any time to give the agent a break without stopping it
+                completely.
+              </p>
+            </>
+          }
+        />
+      }
+      stats={
+        <>
+          <span className="tabular-nums text-foreground">{stats.firing}</span>{" "}
+          firing
+          {" · "}
+          <span className="tabular-nums text-foreground">{stats.off}</span> off
+          {" · "}
+          <span className="tabular-nums text-foreground">{stats.locked}</span>{" "}
+          locked
+        </>
+      }
+      query={query}
+      setQuery={setQuery}
+      searchPlaceholder="Search by agent name or role"
+      filters={
+        <FilterChip
+          value={statusFilter}
+          onChange={(v) => setStatusFilter(v as typeof statusFilter)}
+          options={[
+            { value: "all", label: "All states" },
+            { value: "firing", label: "Firing" },
+            { value: "off", label: "Off" },
+            { value: "locked", label: "Locked (agent stopped)" },
+          ]}
+        />
+      }
+      trailingActions={
+        heartbeats.length > 0 ? (
+          <button
+            type="button"
+            onClick={() => void toggleAllHeartbeats()}
+            title={anyEnabled ? "Pause every heartbeat" : "Resume every heartbeat"}
+            className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border/70 bg-background px-2.5 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
+          >
+            <Pause className="size-3.5" />
+            {anyEnabled ? "Pause all" : "Resume all"}
+          </button>
+        ) : null
+      }
+      loading={loading}
+      empty={{
+        title:
+          heartbeats.length === 0
+            ? "No heartbeats configured yet."
+            : "No heartbeats match your filters.",
+        hint:
+          heartbeats.length === 0
+            ? "Open any agent and set a heartbeat schedule to see it here."
+            : "Try clearing a filter.",
+      }}
+    >
+      {filtered.length === 0 ? (
+        []
+      ) : (
+        <ul className="divide-y divide-border/60">
+          {filtered.map((agent) => (
+            <li key={agent.scopedId}>
+              <HeartbeatRow
+                agent={agent}
+                onToggle={() => toggleHeartbeatEnabled(agent)}
+                onOpen={() =>
+                  setHeartbeatDialog({
+                    agent: {
+                      slug: agent.slug,
+                      name: agent.name,
+                      role: agent.role,
+                      cabinetPath: agent.cabinetPath,
+                    },
+                    initialHeartbeat: agent.heartbeat,
+                    initialEnabled: agent.heartbeatEnabled !== false,
+                  })
+                }
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </ListShell>
+  );
+}
+
+function HeartbeatRow({
+  agent,
+  onToggle,
+  onOpen,
+}: {
+  agent: CabinetAgentSummary;
+  onToggle: () => void;
+  onOpen: () => void;
+}) {
+  const enabled = agent.heartbeatEnabled !== false;
+  const firing = agent.active && enabled;
+  const locked = !agent.active;
+  const schedule = agent.heartbeat ? cronToHuman(agent.heartbeat) : "";
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onOpen}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+      className="group flex h-10 items-center gap-3 px-3 outline-none transition-colors hover:bg-muted/40 focus-visible:bg-muted/40"
+    >
+      <HeartPulse
+        className={cn(
+          "size-3.5 shrink-0",
+          firing ? "text-pink-500" : "text-muted-foreground/40"
+        )}
+      />
+      <AgentAvatar
+        agent={agent}
+        shape="circle"
+        size="sm"
+        className={cn(!firing && "saturate-50 opacity-60")}
+      />
+      <div className="flex min-w-0 flex-1 items-baseline gap-2 overflow-hidden">
+        <span
+          className={cn(
+            "truncate text-[12.5px] font-semibold",
+            firing ? "text-foreground" : "text-muted-foreground/70"
+          )}
+        >
+          {agent.name}
+        </span>
+        <span
+          className={cn(
+            "truncate text-[11.5px]",
+            firing ? "text-muted-foreground" : "text-muted-foreground/60"
+          )}
+        >
+          · Heartbeat
+        </span>
+      </div>
+      <span
+        className={cn(
+          "whitespace-nowrap text-[11px] tabular-nums",
+          firing ? "text-muted-foreground" : "text-muted-foreground/60"
+        )}
+      >
+        {schedule}
+      </span>
+      <div
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
+        <LockedSwitch
+          checked={enabled}
+          onCheckedChange={onToggle}
+          locked={locked}
+          tooltip="This agent is stopped. Start it on the Agents tab to enable the heartbeat."
+          ariaLabel={
+            enabled ? `Pause ${agent.name} heartbeat` : `Resume ${agent.name} heartbeat`
+          }
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/agents/v2/heartbeats-tab.tsx
+++ b/src/components/agents/v2/heartbeats-tab.tsx
@@ -9,7 +9,11 @@ import { cronToHuman } from "@/lib/agents/cron-utils";
 import type { CabinetAgentSummary } from "@/types/cabinets";
 import { useAgentsContext } from "./agents-context";
 import { FilterChip, ListShell } from "./list-shell";
-import { TabExplainer } from "./tab-explainer";
+import {
+  ExplainerCard,
+  ExplainerIcon,
+  useExplainerState,
+} from "./tab-explainer";
 
 export function HeartbeatsTab() {
   const {
@@ -19,6 +23,7 @@ export function HeartbeatsTab() {
     toggleAllHeartbeats,
     setHeartbeatDialog,
   } = useAgentsContext();
+  const explainer = useExplainerState("heartbeats");
 
   const [query, setQuery] = useState("");
   const [statusFilter, setStatusFilter] = useState<
@@ -68,27 +73,20 @@ export function HeartbeatsTab() {
   return (
     <ListShell
       explainer={
-        <TabExplainer
-          id="heartbeats"
-          ariaLabel="About heartbeats"
-          body={
-            <>
-              <p>
-                A heartbeat is what makes your agent feel alive. Every time
-                it ticks, the agent wakes up, looks around, and decides what
-                to do next — no instructions needed. It&apos;s the
-                difference between an agent that waits to be told and one
-                that takes initiative.
-              </p>
-              <p>
-                Pick a rhythm that fits the work — every few minutes for
-                fast-moving things, once a day for quieter ones. Switch it
-                off any time to give the agent a break without stopping it
-                completely.
-              </p>
-            </>
-          }
-        />
+        <ExplainerCard state={explainer}>
+          <p>
+            A heartbeat is what makes your agent feel alive. Every time it
+            ticks, the agent wakes up, looks around, and decides what to do
+            next, no instructions needed. It&apos;s the difference between
+            an agent that waits to be told and one that takes initiative.
+          </p>
+          <p>
+            Pick a rhythm that fits the work, every few minutes for
+            fast-moving things, once a day for quieter ones. Switch it off
+            any time to give the agent a break without stopping it
+            completely.
+          </p>
+        </ExplainerCard>
       }
       stats={
         <>
@@ -99,6 +97,7 @@ export function HeartbeatsTab() {
           {" · "}
           <span className="tabular-nums text-foreground">{stats.locked}</span>{" "}
           locked
+          <ExplainerIcon state={explainer} ariaLabel="About heartbeats" />
         </>
       }
       query={query}

--- a/src/components/agents/v2/list-shell.tsx
+++ b/src/components/agents/v2/list-shell.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { ChevronDown, ListFilter, Search } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/** Search input + N filter chips + list pane shell, shared across all tabs. */
+export function ListShell({
+  explainer,
+  stats,
+  query,
+  setQuery,
+  searchPlaceholder = "Search",
+  filters,
+  trailingActions,
+  loading,
+  empty,
+  children,
+}: {
+  /** Either a plain string (rendered as a one-line muted paragraph) or a
+   *  ReactNode (e.g. a `<TabExplainer>`) that the tab fully owns. */
+  explainer: ReactNode;
+  /** Optional sub-header line above the filter row, e.g. mini-stats
+   *  ("12 firing · 4 off · 3 locked") or facets ("50 active · 36 depts"). */
+  stats?: ReactNode;
+  query: string;
+  setQuery: (q: string) => void;
+  searchPlaceholder?: string;
+  filters?: ReactNode;
+  /** Action(s) anchored to the right of the filter row (e.g. "Pause all
+   *  heartbeats" on the Heartbeats tab, "Org chart" on the Agents tab). */
+  trailingActions?: ReactNode;
+  loading: boolean;
+  /** Shown when not loading and the list has no items. */
+  empty: { title: string; hint?: string };
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-3">
+      {typeof explainer === "string" ? (
+        <p className="text-[12px] text-muted-foreground">{explainer}</p>
+      ) : (
+        explainer
+      )}
+
+      {stats ? (
+        <p className="text-[11.5px] text-muted-foreground/80">{stats}</p>
+      ) : null}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="relative min-w-[200px] flex-1">
+          <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+          <input
+            type="text"
+            placeholder={searchPlaceholder}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="h-8 w-full rounded-md border border-border/70 bg-background pl-8 pr-3 text-[12.5px] outline-none placeholder:text-muted-foreground focus:border-ring"
+          />
+        </div>
+        {filters}
+        {trailingActions ? (
+          <div className="ml-auto flex items-center gap-1.5">{trailingActions}</div>
+        ) : null}
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto rounded-xl border border-border/70 bg-card">
+        {loading ? (
+          <div className="divide-y divide-border/60">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div
+                key={i}
+                className="flex h-9 animate-pulse items-center gap-3 px-3"
+              >
+                <div className="size-4 rounded-full bg-muted/60" />
+                <div className="size-5 shrink-0 rounded-full bg-muted/60" />
+                <div className="h-2.5 w-32 rounded bg-muted/60" />
+                <div className="ml-auto h-2.5 w-20 rounded bg-muted/40" />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <EmptyOrChildren empty={empty}>{children}</EmptyOrChildren>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EmptyOrChildren({
+  empty,
+  children,
+}: {
+  empty: { title: string; hint?: string };
+  children: ReactNode;
+}) {
+  // Children may be a list — if it's a non-array (e.g. a single <ul/>), let
+  // the parent decide. If it's an empty array we paint the empty state.
+  const isEmpty = Array.isArray(children) && children.length === 0;
+  if (isEmpty) {
+    return (
+      <div className="flex h-full min-h-[160px] flex-col items-center justify-center gap-2 text-center">
+        <ListFilter className="size-5 text-muted-foreground/60" />
+        <p className="text-[13px] text-muted-foreground">{empty.title}</p>
+        {empty.hint ? (
+          <p className="text-[11.5px] text-muted-foreground/70">{empty.hint}</p>
+        ) : null}
+      </div>
+    );
+  }
+  return <>{children}</>;
+}
+
+export function FilterChip<V extends string>({
+  options,
+  value,
+  onChange,
+}: {
+  options: { value: V; label: string }[];
+  value: V;
+  onChange: (v: V) => void;
+}) {
+  return (
+    <div className="relative">
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value as V)}
+        className={cn(
+          "h-8 cursor-pointer appearance-none rounded-md border border-border/70 bg-background pl-3 pr-7 text-[12.5px] outline-none focus:border-ring"
+        )}
+      >
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+      <ChevronDown className="pointer-events-none absolute right-2 top-1/2 size-3 -translate-y-1/2 text-muted-foreground" />
+    </div>
+  );
+}

--- a/src/components/agents/v2/list-shell.tsx
+++ b/src/components/agents/v2/list-shell.tsx
@@ -64,7 +64,7 @@ export function ListShell({
         ) : null}
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto rounded-xl border border-border/70 bg-card">
+      <div className="min-h-0 max-h-full overflow-y-auto rounded-xl border border-border/70 bg-card">
         {loading ? (
           <div className="divide-y divide-border/60">
             {Array.from({ length: 8 }).map((_, i) => (

--- a/src/components/agents/v2/new-agent-dialog.tsx
+++ b/src/components/agents/v2/new-agent-dialog.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Loader2, Plus, Search } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { useAppStore } from "@/stores/app-store";
+
+interface AgentTemplate {
+  slug: string;
+  name: string;
+  role?: string;
+  emoji?: string;
+  department?: string;
+  description?: string;
+}
+
+/**
+ * Pick-an-agent-from-the-library dialog used by V2's `+ New Agent` button.
+ * Self-contained (no panel coupling) so it can mount anywhere. Once a
+ * template is added, navigates to the new agent's detail page so the user
+ * lands inside the agent's profile, ready to edit.
+ */
+export function NewAgentDialog({
+  open,
+  onOpenChange,
+  cabinetPath,
+  onAdded,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  cabinetPath: string;
+  onAdded: () => void | Promise<void>;
+}) {
+  const setSection = useAppStore((s) => s.setSection);
+  const [templates, setTemplates] = useState<AgentTemplate[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [addingSlug, setAddingSlug] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    if (!open) return;
+    let cancel = false;
+    setLoading(true);
+    setError(null);
+    (async () => {
+      try {
+        const res = await fetch("/api/agents/library");
+        if (!res.ok) {
+          setError("Couldn't load the agent library.");
+          return;
+        }
+        const data = await res.json();
+        if (cancel) return;
+        setTemplates((data.templates || []) as AgentTemplate[]);
+      } catch {
+        if (!cancel) setError("Couldn't load the agent library.");
+      } finally {
+        if (!cancel) setLoading(false);
+      }
+    })();
+    return () => {
+      cancel = true;
+    };
+  }, [open]);
+
+  async function add(template: AgentTemplate) {
+    setAddingSlug(template.slug);
+    setError(null);
+    try {
+      const res = await fetch(`/api/agents/library/${template.slug}/add`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ cabinetPath }),
+      });
+      // 409 = already exists — just navigate to it.
+      if (!res.ok && res.status !== 409) {
+        setError("Couldn't add this agent.");
+        return;
+      }
+      await onAdded();
+      onOpenChange(false);
+      setSection({
+        type: "agent",
+        slug: template.slug,
+        cabinetPath,
+      });
+    } finally {
+      setAddingSlug(null);
+    }
+  }
+
+  const filtered = templates.filter((t) => {
+    if (!query.trim()) return true;
+    const q = query.toLowerCase();
+    return (
+      t.name.toLowerCase().includes(q) ||
+      (t.role || "").toLowerCase().includes(q) ||
+      (t.department || "").toLowerCase().includes(q)
+    );
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[80vh] sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Add an agent to your team</DialogTitle>
+          <DialogDescription>
+            Pick a specialist from the library. You can edit its name, role,
+            and instructions after it&apos;s added.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+            <input
+              type="text"
+              placeholder="Search the library"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="h-8 w-full rounded-md border border-border/70 bg-background pl-8 pr-3 text-[12.5px] outline-none placeholder:text-muted-foreground focus:border-ring"
+            />
+          </div>
+
+          {error ? (
+            <p className="rounded-md bg-destructive/10 px-3 py-2 text-[12px] text-destructive">
+              {error}
+            </p>
+          ) : null}
+
+          <div className="max-h-[55vh] overflow-y-auto rounded-md border border-border/60">
+            {loading ? (
+              <div className="flex items-center justify-center gap-2 py-12 text-[12px] text-muted-foreground">
+                <Loader2 className="size-3.5 animate-spin" />
+                Loading the library…
+              </div>
+            ) : filtered.length === 0 ? (
+              <div className="py-10 text-center text-[12px] text-muted-foreground">
+                {templates.length === 0
+                  ? "No templates available."
+                  : "No matches."}
+              </div>
+            ) : (
+              <ul className="divide-y divide-border/60">
+                {filtered.map((t) => (
+                  <li key={t.slug}>
+                    <button
+                      type="button"
+                      onClick={() => void add(t)}
+                      disabled={addingSlug !== null}
+                      className="flex w-full items-center gap-3 px-3 py-2 text-left transition-colors hover:bg-muted/40 disabled:opacity-60"
+                    >
+                      <span className="text-lg leading-none">
+                        {t.emoji || "🤖"}
+                      </span>
+                      <div className="flex min-w-0 flex-1 flex-col">
+                        <span className="truncate text-[12.5px] font-semibold text-foreground">
+                          {t.name}
+                        </span>
+                        {t.role ? (
+                          <span className="truncate text-[11px] text-muted-foreground">
+                            {t.role}
+                          </span>
+                        ) : null}
+                      </div>
+                      {addingSlug === t.slug ? (
+                        <Loader2 className="size-3.5 animate-spin text-muted-foreground" />
+                      ) : (
+                        <Plus className="size-3.5 text-muted-foreground" />
+                      )}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/agents/v2/routines-tab.tsx
+++ b/src/components/agents/v2/routines-tab.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Clock3 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { LockedSwitch } from "@/components/ui/locked-switch";
+import { AgentAvatar } from "@/components/agents/agent-avatar";
+import { cronToHuman } from "@/lib/agents/cron-utils";
+import type { CabinetAgentSummary, CabinetJobSummary } from "@/types/cabinets";
+import type { JobConfig } from "@/types/jobs";
+import { useAgentsContext } from "./agents-context";
+import { FilterChip, ListShell } from "./list-shell";
+import { TabExplainer } from "./tab-explainer";
+
+export function RoutinesTab() {
+  const {
+    loading,
+    agents,
+    jobs,
+    toggleJobEnabled,
+    setRoutineDialog,
+  } = useAgentsContext();
+
+  const [query, setQuery] = useState("");
+  const [agentFilter, setAgentFilter] = useState<string | "all">("all");
+  const [statusFilter, setStatusFilter] = useState<
+    "all" | "firing" | "off" | "locked"
+  >("all");
+
+  const agentBySlug = useMemo(() => {
+    const m = new Map<string, CabinetAgentSummary>();
+    for (const a of agents) m.set(a.slug, a);
+    return m;
+  }, [agents]);
+
+  const stats = useMemo(() => {
+    let firing = 0;
+    let off = 0;
+    let locked = 0;
+    for (const job of jobs) {
+      const masterOn = agentBySlug.get(job.ownerAgent || "")?.active ?? false;
+      if (!masterOn) locked++;
+      else if (job.enabled) firing++;
+      else off++;
+    }
+    return { firing, off, locked };
+  }, [jobs, agentBySlug]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return jobs.filter((job) => {
+      const owner = agentBySlug.get(job.ownerAgent || "");
+      const masterOn = owner?.active ?? false;
+      const firing = masterOn && job.enabled;
+      const locked = !masterOn;
+
+      if (agentFilter !== "all" && job.ownerAgent !== agentFilter) return false;
+      if (statusFilter === "firing" && !firing) return false;
+      if (statusFilter === "off" && (locked || job.enabled)) return false;
+      if (statusFilter === "locked" && !locked) return false;
+      if (q) {
+        const hay = [job.name, owner?.name, owner?.role]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    });
+  }, [jobs, agentBySlug, query, agentFilter, statusFilter]);
+
+  const agentOptions = useMemo(
+    () => [
+      { value: "all" as const, label: "All agents" },
+      ...agents
+        .filter((a) => jobs.some((j) => j.ownerAgent === a.slug))
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map((a) => ({ value: a.slug, label: a.name })),
+    ],
+    [agents, jobs]
+  );
+
+  return (
+    <ListShell
+      explainer={
+        <TabExplainer
+          id="routines"
+          ariaLabel="About routines"
+          body={
+            <>
+              <p>
+                A routine is a recurring task you give an agent. Write it
+                once, pick when it should run, and your agent handles it on
+                schedule — like <em>&ldquo;every weekday at 9am, summarize
+                yesterday&rsquo;s work.&rdquo;</em>
+              </p>
+              <p>
+                Switch a routine off to pause it without losing the prompt.
+                If the agent itself is stopped, its routines wait until you
+                start it again.
+              </p>
+            </>
+          }
+        />
+      }
+      stats={
+        <>
+          <span className="tabular-nums text-foreground">{stats.firing}</span>{" "}
+          firing
+          {" · "}
+          <span className="tabular-nums text-foreground">{stats.off}</span> off
+          {" · "}
+          <span className="tabular-nums text-foreground">{stats.locked}</span>{" "}
+          locked
+        </>
+      }
+      query={query}
+      setQuery={setQuery}
+      searchPlaceholder="Search by routine name or agent"
+      filters={
+        <>
+          <FilterChip
+            value={agentFilter}
+            onChange={(v) => setAgentFilter(v as string | "all")}
+            options={agentOptions}
+          />
+          <FilterChip
+            value={statusFilter}
+            onChange={(v) => setStatusFilter(v as typeof statusFilter)}
+            options={[
+              { value: "all", label: "All states" },
+              { value: "firing", label: "Firing" },
+              { value: "off", label: "Off" },
+              { value: "locked", label: "Locked (agent stopped)" },
+            ]}
+          />
+        </>
+      }
+      loading={loading}
+      empty={{
+        title:
+          jobs.length === 0
+            ? "No routines yet. Click + New Routine to add one."
+            : "No routines match your filters.",
+        hint:
+          jobs.length > 0 && filtered.length === 0
+            ? "Try clearing a filter."
+            : undefined,
+      }}
+    >
+      {filtered.length === 0 ? (
+        []
+      ) : (
+        <ul className="divide-y divide-border/60">
+          {filtered.map((job) => {
+            const owner = agentBySlug.get(job.ownerAgent || "");
+            return (
+              <li key={job.scopedId}>
+                <RoutineRow
+                  job={job}
+                  owner={owner}
+                  onToggle={() => toggleJobEnabled(job)}
+                  onOpen={() => {
+                    if (!owner) return;
+                    setRoutineDialog({
+                      agent: {
+                        slug: owner.slug,
+                        name: owner.name,
+                        role: owner.role,
+                        cabinetPath: owner.cabinetPath,
+                      },
+                      existingJob: {
+                        id: job.id,
+                        name: job.name,
+                        schedule: job.schedule,
+                        enabled: job.enabled,
+                      } as Partial<JobConfig>,
+                    });
+                  }}
+                />
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </ListShell>
+  );
+}
+
+function RoutineRow({
+  job,
+  owner,
+  onToggle,
+  onOpen,
+}: {
+  job: CabinetJobSummary;
+  owner: CabinetAgentSummary | undefined;
+  onToggle: () => void;
+  onOpen: () => void;
+}) {
+  const masterOn = owner?.active ?? false;
+  const firing = masterOn && job.enabled;
+  const locked = !masterOn;
+  const schedule = job.schedule ? cronToHuman(job.schedule) : "";
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onOpen}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+      className="group flex h-10 items-center gap-3 px-3 outline-none transition-colors hover:bg-muted/40 focus-visible:bg-muted/40"
+    >
+      <Clock3
+        className={cn(
+          "size-3.5 shrink-0",
+          firing ? "text-emerald-500" : "text-muted-foreground/40"
+        )}
+      />
+      {owner ? (
+        <AgentAvatar
+          agent={owner}
+          shape="circle"
+          size="sm"
+          className={cn(!firing && "saturate-50 opacity-60")}
+        />
+      ) : (
+        <div className="size-5 shrink-0 rounded-full bg-muted/40" />
+      )}
+      <div className="flex min-w-0 flex-1 items-baseline gap-2 overflow-hidden">
+        <span
+          className={cn(
+            "truncate text-[12.5px] font-semibold",
+            firing ? "text-foreground" : "text-muted-foreground/70"
+          )}
+        >
+          {job.name || "(untitled routine)"}
+        </span>
+        {owner ? (
+          <span
+            className={cn(
+              "truncate text-[11.5px]",
+              firing ? "text-muted-foreground" : "text-muted-foreground/60"
+            )}
+          >
+            · {owner.name}
+          </span>
+        ) : null}
+      </div>
+      <span
+        className={cn(
+          "whitespace-nowrap text-[11px] tabular-nums",
+          firing ? "text-muted-foreground" : "text-muted-foreground/60"
+        )}
+      >
+        {schedule}
+      </span>
+      <div
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
+        <LockedSwitch
+          checked={job.enabled}
+          onCheckedChange={onToggle}
+          locked={locked}
+          tooltip="This agent is stopped. Start it on the Agents tab to enable its routines."
+          ariaLabel={
+            job.enabled
+              ? `Disable routine ${job.name}`
+              : `Enable routine ${job.name}`
+          }
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/agents/v2/routines-tab.tsx
+++ b/src/components/agents/v2/routines-tab.tsx
@@ -10,7 +10,11 @@ import type { CabinetAgentSummary, CabinetJobSummary } from "@/types/cabinets";
 import type { JobConfig } from "@/types/jobs";
 import { useAgentsContext } from "./agents-context";
 import { FilterChip, ListShell } from "./list-shell";
-import { TabExplainer } from "./tab-explainer";
+import {
+  ExplainerCard,
+  ExplainerIcon,
+  useExplainerState,
+} from "./tab-explainer";
 
 export function RoutinesTab() {
   const {
@@ -20,6 +24,7 @@ export function RoutinesTab() {
     toggleJobEnabled,
     setRoutineDialog,
   } = useAgentsContext();
+  const explainer = useExplainerState("routines");
 
   const [query, setQuery] = useState("");
   const [agentFilter, setAgentFilter] = useState<string | "all">("all");
@@ -83,25 +88,19 @@ export function RoutinesTab() {
   return (
     <ListShell
       explainer={
-        <TabExplainer
-          id="routines"
-          ariaLabel="About routines"
-          body={
-            <>
-              <p>
-                A routine is a recurring task you give an agent. Write it
-                once, pick when it should run, and your agent handles it on
-                schedule — like <em>&ldquo;every weekday at 9am, summarize
-                yesterday&rsquo;s work.&rdquo;</em>
-              </p>
-              <p>
-                Switch a routine off to pause it without losing the prompt.
-                If the agent itself is stopped, its routines wait until you
-                start it again.
-              </p>
-            </>
-          }
-        />
+        <ExplainerCard state={explainer}>
+          <p>
+            A routine is a recurring task you give an agent. Write it once,
+            pick when it should run, and your agent handles it on schedule,
+            like <em>&ldquo;every weekday at 9am, summarize yesterday&rsquo;s
+            work.&rdquo;</em>
+          </p>
+          <p>
+            Switch a routine off to pause it without losing the prompt. If
+            the agent itself is stopped, its routines wait until you start
+            it again.
+          </p>
+        </ExplainerCard>
       }
       stats={
         <>
@@ -112,6 +111,7 @@ export function RoutinesTab() {
           {" · "}
           <span className="tabular-nums text-foreground">{stats.locked}</span>{" "}
           locked
+          <ExplainerIcon state={explainer} ariaLabel="About routines" />
         </>
       }
       query={query}

--- a/src/components/agents/v2/schedule-tab.tsx
+++ b/src/components/agents/v2/schedule-tab.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useState } from "react";
+import { ScheduleCalendar } from "@/components/cabinets/schedule-calendar";
+import type { ScheduleEvent } from "@/lib/agents/cron-compute";
+import type { JobConfig } from "@/types/jobs";
+import { useAgentsContext } from "./agents-context";
+import { TabExplainer } from "./tab-explainer";
+
+type Mode = "day" | "week" | "month";
+
+export function ScheduleTab() {
+  const { agents, jobs, setRoutineDialog, setHeartbeatDialog } =
+    useAgentsContext();
+  const [mode, setMode] = useState<Mode>("week");
+  const [anchor] = useState(() => new Date());
+
+  function handleEventClick(event: ScheduleEvent) {
+    if (event.sourceType === "heartbeat" && event.agentRef) {
+      setHeartbeatDialog({
+        agent: {
+          slug: event.agentRef.slug,
+          name: event.agentRef.name,
+          role: event.agentRef.role,
+          cabinetPath: event.agentRef.cabinetPath,
+        },
+        initialHeartbeat: event.agentRef.heartbeat,
+        initialEnabled: event.agentRef.heartbeatEnabled !== false,
+      });
+    } else if (event.sourceType === "job" && event.jobRef && event.agentRef) {
+      const job = event.jobRef;
+      setRoutineDialog({
+        agent: {
+          slug: event.agentRef.slug,
+          name: event.agentRef.name,
+          role: event.agentRef.role,
+          cabinetPath: event.agentRef.cabinetPath,
+        },
+        existingJob: {
+          id: job.id,
+          name: job.name,
+          schedule: job.schedule,
+          enabled: job.enabled,
+        } as Partial<JobConfig>,
+      });
+    }
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <TabExplainer
+            id="schedule"
+            ariaLabel="About the schedule"
+            body={
+              <>
+                <p>
+                  Everything your team is doing this week, on one calendar.
+                  Pink is a heartbeat, green is a routine. Click any pill to
+                  edit it.
+                </p>
+                <p>
+                  Use this tab to spot conflicts, find quiet stretches, or
+                  just see at a glance how busy the team is.
+                </p>
+              </>
+            }
+          />
+        </div>
+        <div className="inline-flex shrink-0 items-center rounded-md border border-border/70 bg-background p-0.5">
+          {(["day", "week", "month"] as const).map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => setMode(m)}
+              className={
+                mode === m
+                  ? "rounded px-2.5 py-1 text-[11.5px] font-medium bg-foreground text-background"
+                  : "rounded px-2.5 py-1 text-[11.5px] font-medium text-muted-foreground hover:text-foreground"
+              }
+            >
+              {m[0].toUpperCase() + m.slice(1)}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="min-h-0 flex-1 overflow-hidden rounded-xl border border-border/70 bg-card">
+        <ScheduleCalendar
+          mode={mode}
+          anchor={anchor}
+          agents={agents}
+          jobs={jobs}
+          fullscreen
+          onEventClick={handleEventClick}
+          onDayClick={() => {
+            /* day-click no-op for now */
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/agents/v2/schedule-tab.tsx
+++ b/src/components/agents/v2/schedule-tab.tsx
@@ -5,13 +5,18 @@ import { ScheduleCalendar } from "@/components/cabinets/schedule-calendar";
 import type { ScheduleEvent } from "@/lib/agents/cron-compute";
 import type { JobConfig } from "@/types/jobs";
 import { useAgentsContext } from "./agents-context";
-import { TabExplainer } from "./tab-explainer";
+import {
+  ExplainerCard,
+  ExplainerIcon,
+  useExplainerState,
+} from "./tab-explainer";
 
 type Mode = "day" | "week" | "month";
 
 export function ScheduleTab() {
   const { agents, jobs, setRoutineDialog, setHeartbeatDialog } =
     useAgentsContext();
+  const explainer = useExplainerState("schedule");
   const [mode, setMode] = useState<Mode>("week");
   const [anchor] = useState(() => new Date());
 
@@ -48,26 +53,20 @@ export function ScheduleTab() {
 
   return (
     <div className="flex h-full min-h-0 flex-col gap-3">
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0 flex-1">
-          <TabExplainer
-            id="schedule"
-            ariaLabel="About the schedule"
-            body={
-              <>
-                <p>
-                  Everything your team is doing this week, on one calendar.
-                  Pink is a heartbeat, green is a routine. Click any pill to
-                  edit it.
-                </p>
-                <p>
-                  Use this tab to spot conflicts, find quiet stretches, or
-                  just see at a glance how busy the team is.
-                </p>
-              </>
-            }
-          />
-        </div>
+      <ExplainerCard state={explainer}>
+        <p>
+          Everything your team is doing this week, on one calendar. Pink is
+          a heartbeat, green is a routine. Click any pill to edit it.
+        </p>
+        <p>
+          Use this tab to spot conflicts, find quiet stretches, or just see
+          at a glance how busy the team is.
+        </p>
+      </ExplainerCard>
+      <div className="flex items-center justify-between gap-3">
+        <span className="inline-flex items-center text-[11.5px] text-muted-foreground/80">
+          <ExplainerIcon state={explainer} ariaLabel="About the schedule" />
+        </span>
         <div className="inline-flex shrink-0 items-center rounded-md border border-border/70 bg-background p-0.5">
           {(["day", "week", "month"] as const).map((m) => (
             <button

--- a/src/components/agents/v2/tab-explainer.tsx
+++ b/src/components/agents/v2/tab-explainer.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useState, type ReactNode } from "react";
+import { Info, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const STORAGE_PREFIX = "cabinet.agents.explainer.";
+
+/**
+ * Per-tab onboarding card. Visible by default on first visit, dismissible.
+ * After dismissal a small `ⓘ` button stays inline next to the page heading
+ * and re-opens the card on click. Dismissal is persisted per-tab via
+ * localStorage so each tab onboards independently.
+ *
+ * No heading inside the card — the prose carries it. Soft styling (subtle
+ * border, no background tint) so it feels like product chrome, not a
+ * warning banner.
+ */
+export function TabExplainer({
+  id,
+  body,
+  ariaLabel,
+}: {
+  /** Stable ID per tab; used as the localStorage key suffix. */
+  id: string;
+  /** The conversational copy. Use short paragraphs, plain language. */
+  body: ReactNode;
+  /** Used on the toggle button for screen readers. */
+  ariaLabel: string;
+}) {
+  const storageKey = STORAGE_PREFIX + id;
+  // `null` = haven't checked localStorage yet (SSR-safe initial render).
+  const [open, setOpen] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let dismissed = false;
+    try {
+      dismissed = window.localStorage.getItem(storageKey) === "1";
+    } catch {
+      dismissed = false;
+    }
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setOpen(!dismissed);
+  }, [storageKey]);
+
+  function dismiss() {
+    setOpen(false);
+    try {
+      window.localStorage.setItem(storageKey, "1");
+    } catch {
+      // Quota / private mode — non-fatal.
+    }
+  }
+
+  function reopen() {
+    setOpen(true);
+  }
+
+  const isOpen = open === true;
+
+  if (!isOpen) {
+    return (
+      <button
+        type="button"
+        onClick={reopen}
+        aria-label={ariaLabel}
+        title={ariaLabel}
+        className="inline-flex size-5 shrink-0 items-center justify-center rounded-full text-muted-foreground/60 transition-colors hover:bg-muted/40 hover:text-foreground focus-visible:bg-muted/40 focus-visible:text-foreground focus-visible:outline-none"
+      >
+        <Info className="size-3.5" />
+      </button>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "relative rounded-lg border border-border/50 bg-muted/20 px-4 py-3",
+        "animate-in fade-in slide-in-from-top-1 duration-200"
+      )}
+    >
+      <button
+        type="button"
+        onClick={dismiss}
+        aria-label="Dismiss"
+        title="Dismiss"
+        className="absolute right-1.5 top-1.5 inline-flex size-6 items-center justify-center rounded-md text-muted-foreground/60 transition-colors hover:bg-muted/40 hover:text-foreground"
+      >
+        <X className="size-3.5" />
+      </button>
+      <div className="space-y-1.5 pr-6 text-[12.5px] leading-relaxed text-foreground/80">
+        {body}
+      </div>
+    </div>
+  );
+}

--- a/src/components/agents/v2/tab-explainer.tsx
+++ b/src/components/agents/v2/tab-explainer.tsx
@@ -7,29 +7,15 @@ import { cn } from "@/lib/utils";
 const STORAGE_PREFIX = "cabinet.agents.explainer.";
 
 /**
- * Per-tab onboarding card. Visible by default on first visit, dismissible.
- * After dismissal a small `ⓘ` button stays inline next to the page heading
- * and re-opens the card on click. Dismissal is persisted per-tab via
- * localStorage so each tab onboards independently.
- *
- * No heading inside the card — the prose carries it. Soft styling (subtle
- * border, no background tint) so it feels like product chrome, not a
- * warning banner.
+ * Onboarding-card state for a tab. Split into a hook + two pieces (Card,
+ * Icon) so the card can live in a prominent row at the top of the tab
+ * while the dismissed-state `ⓘ` re-opener sits inline with the stats line
+ * (no dedicated row, no empty space when collapsed). Dismissal persists
+ * per tab via localStorage.
  */
-export function TabExplainer({
-  id,
-  body,
-  ariaLabel,
-}: {
-  /** Stable ID per tab; used as the localStorage key suffix. */
-  id: string;
-  /** The conversational copy. Use short paragraphs, plain language. */
-  body: ReactNode;
-  /** Used on the toggle button for screen readers. */
-  ariaLabel: string;
-}) {
+export function useExplainerState(id: string) {
   const storageKey = STORAGE_PREFIX + id;
-  // `null` = haven't checked localStorage yet (SSR-safe initial render).
+  // `null` = haven't checked localStorage yet (avoids SSR/hydration flicker).
   const [open, setOpen] = useState<boolean | null>(null);
 
   useEffect(() => {
@@ -43,35 +29,32 @@ export function TabExplainer({
     setOpen(!dismissed);
   }, [storageKey]);
 
-  function dismiss() {
-    setOpen(false);
-    try {
-      window.localStorage.setItem(storageKey, "1");
-    } catch {
-      // Quota / private mode — non-fatal.
-    }
-  }
+  return {
+    open,
+    dismiss: () => {
+      setOpen(false);
+      try {
+        window.localStorage.setItem(storageKey, "1");
+      } catch {
+        /* quota / private mode is non-fatal */
+      }
+    },
+    reopen: () => setOpen(true),
+  };
+}
 
-  function reopen() {
-    setOpen(true);
-  }
+export type ExplainerState = ReturnType<typeof useExplainerState>;
 
-  const isOpen = open === true;
-
-  if (!isOpen) {
-    return (
-      <button
-        type="button"
-        onClick={reopen}
-        aria-label={ariaLabel}
-        title={ariaLabel}
-        className="inline-flex size-5 shrink-0 items-center justify-center rounded-full text-muted-foreground/60 transition-colors hover:bg-muted/40 hover:text-foreground focus-visible:bg-muted/40 focus-visible:text-foreground focus-visible:outline-none"
-      >
-        <Info className="size-3.5" />
-      </button>
-    );
-  }
-
+/** The prominent card with the body copy + dismiss `×`. Renders nothing
+ *  when dismissed or while storage is being read. */
+export function ExplainerCard({
+  state,
+  children,
+}: {
+  state: ExplainerState;
+  children: ReactNode;
+}) {
+  if (state.open !== true) return null;
   return (
     <div
       className={cn(
@@ -81,7 +64,7 @@ export function TabExplainer({
     >
       <button
         type="button"
-        onClick={dismiss}
+        onClick={state.dismiss}
         aria-label="Dismiss"
         title="Dismiss"
         className="absolute right-1.5 top-1.5 inline-flex size-6 items-center justify-center rounded-md text-muted-foreground/60 transition-colors hover:bg-muted/40 hover:text-foreground"
@@ -89,8 +72,32 @@ export function TabExplainer({
         <X className="size-3.5" />
       </button>
       <div className="space-y-1.5 pr-6 text-[12.5px] leading-relaxed text-foreground/80">
-        {body}
+        {children}
       </div>
     </div>
+  );
+}
+
+/** The small `ⓘ` re-opener. Renders nothing while the card is visible (or
+ *  state is still loading) so it can sit inline with the stats line without
+ *  pushing layout when present/absent. */
+export function ExplainerIcon({
+  state,
+  ariaLabel,
+}: {
+  state: ExplainerState;
+  ariaLabel: string;
+}) {
+  if (state.open !== false) return null;
+  return (
+    <button
+      type="button"
+      onClick={state.reopen}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+      className="ml-1 inline-flex size-4 items-center justify-center rounded-full text-muted-foreground/60 transition-colors hover:bg-muted/40 hover:text-foreground"
+    >
+      <Info className="size-3" />
+    </button>
   );
 }

--- a/src/components/agents/v2/tabs-layout.tsx
+++ b/src/components/agents/v2/tabs-layout.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import {
+  Calendar as CalendarIcon,
+  Clock3,
+  HeartPulse,
+  Loader2,
+  Plus,
+  RefreshCw,
+  Users,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { DepthDropdown } from "@/components/cabinets/depth-dropdown";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { AgentAvatar } from "@/components/agents/agent-avatar";
+import type { CabinetAgentSummary } from "@/types/cabinets";
+import { useAgentsContext } from "./agents-context";
+import { AgentsTab } from "./agents-tab";
+import { RoutinesTab } from "./routines-tab";
+import { HeartbeatsTab } from "./heartbeats-tab";
+import { ScheduleTab } from "./schedule-tab";
+
+export type AgentsTabKey = "agents" | "routines" | "heartbeats" | "schedule";
+
+const TABS: { key: AgentsTabKey; label: string; icon: typeof Users }[] = [
+  { key: "agents", label: "Agents", icon: Users },
+  { key: "routines", label: "Routines", icon: Clock3 },
+  { key: "heartbeats", label: "Heartbeats", icon: HeartPulse },
+  { key: "schedule", label: "Schedule", icon: CalendarIcon },
+];
+
+export function TabsLayout({
+  tab,
+  onTabChange,
+}: {
+  tab: AgentsTabKey;
+  onTabChange: (next: AgentsTabKey) => void;
+}) {
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <TopBar tab={tab} onTabChange={onTabChange} />
+      <div className="mx-auto min-h-0 w-full max-w-6xl flex-1 overflow-hidden px-6 pb-8 pt-4">
+        {tab === "agents" && <AgentsTab />}
+        {tab === "routines" && <RoutinesTab />}
+        {tab === "heartbeats" && <HeartbeatsTab />}
+        {tab === "schedule" && <ScheduleTab />}
+      </div>
+    </div>
+  );
+}
+
+function TopBar({
+  tab,
+  onTabChange,
+}: {
+  tab: AgentsTabKey;
+  onTabChange: (next: AgentsTabKey) => void;
+}) {
+  const { loading, refresh, visibilityMode, setVisibilityMode } =
+    useAgentsContext();
+  return (
+    <header className="flex h-12 shrink-0 items-center gap-3 border-b border-border/70 bg-background px-4">
+      <h1 className="text-[14px] font-semibold tracking-tight">Team</h1>
+      {loading && (
+        <Loader2 className="size-3.5 animate-spin text-muted-foreground" />
+      )}
+      <div className="ml-2 flex items-center gap-2">
+        <TabStrip tab={tab} onTabChange={onTabChange} />
+      </div>
+      <div className="ml-auto flex items-center gap-2">
+        <DepthDropdown mode={visibilityMode} onChange={setVisibilityMode} />
+        <Divider />
+        <button
+          type="button"
+          onClick={() => void refresh()}
+          title="Refresh"
+          aria-label="Refresh"
+          className="inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+        >
+          <RefreshCw className="size-3.5" />
+        </button>
+        <NewButton tab={tab} />
+      </div>
+    </header>
+  );
+}
+
+function Divider() {
+  return <div className="h-3.5 w-px bg-border/60" aria-hidden />;
+}
+
+function TabStrip({
+  tab,
+  onTabChange,
+}: {
+  tab: AgentsTabKey;
+  onTabChange: (next: AgentsTabKey) => void;
+}) {
+  const { agents, jobs } = useAgentsContext();
+  const counts: Record<AgentsTabKey, number | undefined> = {
+    agents: agents.length,
+    routines: jobs.length,
+    heartbeats: agents.filter((a) => !!a.heartbeat).length,
+    schedule: undefined,
+  };
+  return (
+    <nav
+      className="flex h-7 items-center rounded-lg border border-border/60 p-0.5"
+      role="tablist"
+    >
+      {TABS.map((t) => {
+        const active = tab === t.key;
+        const Icon = t.icon;
+        const count = counts[t.key];
+        return (
+          <button
+            key={t.key}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => onTabChange(t.key)}
+            className={cn(
+              "flex items-center gap-1.5 rounded-md px-2.5 py-1 text-[11px] font-medium transition-colors",
+              active
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:text-foreground"
+            )}
+          >
+            <Icon className="size-3.5" />
+            {t.label}
+            {typeof count === "number" ? (
+              <span
+                className={cn(
+                  "rounded-full px-1.5 py-px text-[9.5px] font-semibold tabular-nums",
+                  active
+                    ? "bg-primary-foreground/20 text-primary-foreground"
+                    : "bg-muted/60 text-muted-foreground/80"
+                )}
+              >
+                {count}
+              </span>
+            ) : null}
+          </button>
+        );
+      })}
+    </nav>
+  );
+}
+
+function NewButton({ tab }: { tab: AgentsTabKey }) {
+  const {
+    agents,
+    setNewAgentOpen,
+    setRoutineDialog,
+    setHeartbeatDialog,
+    cabinetPath,
+  } = useAgentsContext();
+
+  if (tab === "agents") {
+    return (
+      <button
+        type="button"
+        onClick={() => setNewAgentOpen(true)}
+        className="inline-flex h-7 items-center gap-1.5 rounded-md bg-primary px-2.5 text-[11.5px] font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
+      >
+        <Plus className="size-3.5" />
+        New Agent
+      </button>
+    );
+  }
+
+  if (tab === "routines") {
+    return (
+      <AgentPickerDropdown
+        label="New Routine"
+        agents={agents}
+        onSelect={(agent) =>
+          setRoutineDialog({
+            agent: {
+              slug: agent.slug,
+              name: agent.name,
+              role: agent.role,
+              cabinetPath: agent.cabinetPath || cabinetPath,
+            },
+            isNew: true,
+          })
+        }
+      />
+    );
+  }
+
+  if (tab === "heartbeats") {
+    return (
+      <AgentPickerDropdown
+        label="Configure heartbeat"
+        agents={agents}
+        onSelect={(agent) =>
+          setHeartbeatDialog({
+            agent: {
+              slug: agent.slug,
+              name: agent.name,
+              role: agent.role,
+              cabinetPath: agent.cabinetPath || cabinetPath,
+            },
+            initialHeartbeat: agent.heartbeat || undefined,
+            initialEnabled: agent.heartbeatEnabled !== false,
+          })
+        }
+      />
+    );
+  }
+
+  return null;
+}
+
+function AgentPickerDropdown({
+  label,
+  agents,
+  onSelect,
+}: {
+  label: string;
+  agents: CabinetAgentSummary[];
+  onSelect: (agent: CabinetAgentSummary) => void;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        className="inline-flex h-7 items-center gap-1.5 rounded-md bg-primary px-2.5 text-[11.5px] font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
+        disabled={agents.length === 0}
+      >
+        <Plus className="size-3.5" />
+        {label}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="max-h-[360px] overflow-y-auto p-1">
+        <div className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Pick an agent
+        </div>
+        {agents
+          .slice()
+          .sort((a, b) => a.name.localeCompare(b.name))
+          .map((agent) => (
+            <DropdownMenuItem
+              key={agent.scopedId}
+              onClick={() => onSelect(agent)}
+              className="flex items-center gap-2 rounded-md px-2 py-1.5 text-[12px]"
+            >
+              <AgentAvatar agent={agent} shape="circle" size="md" />
+              <span className="flex min-w-0 flex-col leading-tight">
+                <span className="truncate text-[12px] font-medium text-foreground">
+                  {agent.name}
+                </span>
+                {agent.role ? (
+                  <span className="truncate text-[10px] text-muted-foreground">
+                    {agent.role}
+                  </span>
+                ) : null}
+              </span>
+            </DropdownMenuItem>
+          ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/agents/v2/tabs-layout.tsx
+++ b/src/components/agents/v2/tabs-layout.tsx
@@ -18,12 +18,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { AgentAvatar } from "@/components/agents/agent-avatar";
 import type { CabinetAgentSummary } from "@/types/cabinets";
 import { useAgentsContext } from "./agents-context";
@@ -49,17 +43,15 @@ export function TabsLayout({
   onTabChange: (next: AgentsTabKey) => void;
 }) {
   return (
-    <TooltipProvider>
-      <div className="flex h-full min-h-0 flex-col">
-        <TopBar tab={tab} onTabChange={onTabChange} />
-        <div className="mx-auto min-h-0 w-full max-w-6xl flex-1 overflow-hidden px-6 pb-8 pt-4">
-          {tab === "agents" && <AgentsTab />}
-          {tab === "routines" && <RoutinesTab />}
-          {tab === "heartbeats" && <HeartbeatsTab />}
-          {tab === "schedule" && <ScheduleTab />}
-        </div>
+    <div className="flex h-full min-h-0 flex-col">
+      <TopBar tab={tab} onTabChange={onTabChange} />
+      <div className="mx-auto min-h-0 w-full max-w-6xl flex-1 overflow-hidden px-6 pb-8 pt-4">
+        {tab === "agents" && <AgentsTab />}
+        {tab === "routines" && <RoutinesTab />}
+        {tab === "heartbeats" && <HeartbeatsTab />}
+        {tab === "schedule" && <ScheduleTab />}
       </div>
-    </TooltipProvider>
+    </div>
   );
 }
 
@@ -108,12 +100,13 @@ function Divider() {
 /**
  * Master Switch in the top nav. Reflects "is any agent running?". Toggling
  * flips every agent on/off (which also gates their heartbeats and routines
- * via the V2 data model). Always visible on the Team section so users can
- * pause everything regardless of which tab they're on.
+ * via the V2 data model). Always visible on the Team section.
  *
- * Renders a larger-than-default switch inline (not the shared `<Switch>`
- * primitive) so the prominent on/off control reads at a glance from
- * across the room. Wrapped in a Tooltip for the long-form explanation.
+ * Built without base-ui's Tooltip primitive on purpose: the TooltipTrigger
+ * render-prop pattern swallowed the Switch's onCheckedChange (base-ui
+ * merges its own props onto the rendered element, clobbering the Switch's
+ * controlled-value handlers). Hover popover is CSS-only via `peer-hover`
+ * — no JS handlers competing for the same element.
  */
 function MasterToggle() {
   const { agents, toggleAllAgentsActive } = useAgentsContext();
@@ -126,73 +119,72 @@ function MasterToggle() {
       ? "No agents in this team"
       : "Every agent is stopped";
   const actionLine = anyActive
-    ? "Click to stop the whole team — all heartbeats and routines pause."
-    : "Click to start the whole team — heartbeats and routines fire on their schedule.";
+    ? "Click to stop the whole team. All heartbeats and routines will be paused."
+    : "Click to start the whole team. Heartbeats and routines fire on their schedule.";
   return (
-    <Tooltip>
-      <TooltipTrigger
-        render={
-          /* Span wrapper carries the tooltip's hover/focus listeners; the
-             Switch.Root inside owns click handling. Rendering Switch.Root
-             directly as the trigger caused base-ui to overwrite its
-             onCheckedChange handler with its own merged props. */
-          <span className="inline-flex">
-            <SwitchPrimitive.Root
-              checked={anyActive}
-              onCheckedChange={() => void toggleAllAgentsActive()}
-              disabled={totalCount === 0}
-              aria-label={anyActive ? "Stop every agent" : "Start every agent"}
-              className={cn(
-                "group/master peer relative inline-flex h-7 w-[5.5rem] shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors outline-none",
-                "focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-1 focus-visible:ring-offset-background",
-                "disabled:cursor-not-allowed disabled:opacity-50",
-                "data-[checked]:bg-emerald-500 data-[unchecked]:bg-muted-foreground/30"
-              )}
-            >
-              <span
-                aria-hidden
-                className={cn(
-                  "pointer-events-none absolute inset-y-0 left-2 flex items-center text-[10.5px] font-bold uppercase tracking-wider text-white transition-opacity",
-                  "opacity-0 group-data-[checked]/master:opacity-100"
-                )}
-              >
-                Team on
-              </span>
-              <span
-                aria-hidden
-                className={cn(
-                  "pointer-events-none absolute inset-y-0 right-2 flex items-center text-[10.5px] font-bold uppercase tracking-wider text-muted-foreground/80 transition-opacity",
-                  "opacity-100 group-data-[checked]/master:opacity-0"
-                )}
-              >
-                Team off
-              </span>
-              <SwitchPrimitive.Thumb
-                className={cn(
-                  "pointer-events-none relative z-10 block size-5 rounded-full bg-background shadow-sm ring-0 transition-transform",
-                  "data-[checked]:translate-x-16 data-[unchecked]:translate-x-1"
-                )}
-              />
-            </SwitchPrimitive.Root>
-          </span>
-        }
-      />
-      <TooltipContent
-        side="bottom"
-        variant="themed"
-        className="flex max-w-[280px] flex-col items-start gap-1 p-3 text-left"
+    <div className="relative inline-flex">
+      <SwitchPrimitive.Root
+        checked={anyActive}
+        onCheckedChange={() => void toggleAllAgentsActive()}
+        disabled={totalCount === 0}
+        aria-label={anyActive ? "Stop every agent" : "Start every agent"}
+        className={cn(
+          "peer group/master relative inline-flex h-7 w-[5.5rem] shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors outline-none",
+          "focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-1 focus-visible:ring-offset-background",
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          "data-[checked]:bg-emerald-500 data-[unchecked]:bg-muted-foreground/30"
+        )}
+      >
+        <span
+          aria-hidden
+          className={cn(
+            "pointer-events-none absolute inset-y-0 left-2 flex items-center text-[10.5px] font-bold uppercase tracking-wider text-white transition-opacity",
+            "opacity-0 group-data-[checked]/master:opacity-100"
+          )}
+        >
+          Team on
+        </span>
+        <span
+          aria-hidden
+          className={cn(
+            "pointer-events-none absolute inset-y-0 right-2 flex items-center text-[10.5px] font-bold uppercase tracking-wider text-muted-foreground/80 transition-opacity",
+            "opacity-100 group-data-[checked]/master:opacity-0"
+          )}
+        >
+          Team off
+        </span>
+        <SwitchPrimitive.Thumb
+          className={cn(
+            "pointer-events-none relative z-10 block size-5 rounded-full bg-background shadow-sm ring-0 transition-transform",
+            "data-[checked]:translate-x-16 data-[unchecked]:translate-x-1"
+          )}
+        />
+      </SwitchPrimitive.Root>
+
+      {/* Pure-CSS hover/focus popover. Shows when the Switch (the peer)
+          is hovered or focused. `pointer-events-none` lets the cursor
+          slide off the popover without re-triggering the Switch behind
+          it; we don't need the popover to be interactive. */}
+      <div
+        role="tooltip"
+        className={cn(
+          "pointer-events-none invisible absolute left-1/2 top-full z-50 mt-2 w-[280px] -translate-x-1/2 rounded-md border border-border bg-popover p-3 text-left text-popover-foreground opacity-0 shadow-md transition-opacity",
+          "peer-hover:visible peer-hover:opacity-100 peer-focus-visible:visible peer-focus-visible:opacity-100"
+        )}
       >
         <p className="text-[12px] font-semibold">
           {anyActive ? "Team is running" : "Team is stopped"}
         </p>
-        <p className="text-[11px] text-muted-foreground">{summaryLine}.</p>
-        <p className="text-[11px] text-muted-foreground">{actionLine}</p>
-        <p className="text-[11px] italic text-muted-foreground/80">
-          Tasks already running won&apos;t be interrupted — only future
-          fires are affected.
+        <p className="mt-1 text-[11px] text-muted-foreground">
+          {summaryLine}.
         </p>
-      </TooltipContent>
-    </Tooltip>
+        <p className="mt-1 text-[11px] text-muted-foreground">{actionLine}</p>
+        <p className="mt-2 text-[11px] italic text-muted-foreground/80">
+          Tasks already running won&apos;t stop, only future scheduled
+          runs are affected.
+        </p>
+      </div>
+    </div>
   );
 }
 

--- a/src/components/agents/v2/tabs-layout.tsx
+++ b/src/components/agents/v2/tabs-layout.tsx
@@ -9,6 +9,7 @@ import {
   RefreshCw,
   Users,
 } from "lucide-react";
+import { Switch as SwitchPrimitive } from "@base-ui/react/switch";
 import { cn } from "@/lib/utils";
 import { DepthDropdown } from "@/components/cabinets/depth-dropdown";
 import {
@@ -17,7 +18,12 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Switch } from "@/components/ui/switch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { AgentAvatar } from "@/components/agents/agent-avatar";
 import type { CabinetAgentSummary } from "@/types/cabinets";
 import { useAgentsContext } from "./agents-context";
@@ -43,15 +49,17 @@ export function TabsLayout({
   onTabChange: (next: AgentsTabKey) => void;
 }) {
   return (
-    <div className="flex h-full min-h-0 flex-col">
-      <TopBar tab={tab} onTabChange={onTabChange} />
-      <div className="mx-auto min-h-0 w-full max-w-6xl flex-1 overflow-hidden px-6 pb-8 pt-4">
-        {tab === "agents" && <AgentsTab />}
-        {tab === "routines" && <RoutinesTab />}
-        {tab === "heartbeats" && <HeartbeatsTab />}
-        {tab === "schedule" && <ScheduleTab />}
+    <TooltipProvider>
+      <div className="flex h-full min-h-0 flex-col">
+        <TopBar tab={tab} onTabChange={onTabChange} />
+        <div className="mx-auto min-h-0 w-full max-w-6xl flex-1 overflow-hidden px-6 pb-8 pt-4">
+          {tab === "agents" && <AgentsTab />}
+          {tab === "routines" && <RoutinesTab />}
+          {tab === "heartbeats" && <HeartbeatsTab />}
+          {tab === "schedule" && <ScheduleTab />}
+        </div>
       </div>
-    </div>
+    </TooltipProvider>
   );
 }
 
@@ -102,25 +110,72 @@ function Divider() {
  * flips every agent on/off (which also gates their heartbeats and routines
  * via the V2 data model). Always visible on the Team section so users can
  * pause everything regardless of which tab they're on.
+ *
+ * Renders a larger-than-default switch inline (not the shared `<Switch>`
+ * primitive) so the prominent on/off control reads at a glance from
+ * across the room. Wrapped in a Tooltip for the long-form explanation.
  */
 function MasterToggle() {
   const { agents, toggleAllAgentsActive } = useAgentsContext();
   const anyActive = agents.some((a) => a.active);
-  const label = anyActive
-    ? "Stop every agent (and pause their heartbeats and routines)"
-    : "Start every agent";
+  const activeCount = agents.filter((a) => a.active).length;
+  const totalCount = agents.length;
+  const summaryLine = anyActive
+    ? `${activeCount} of ${totalCount} ${totalCount === 1 ? "agent" : "agents"} running`
+    : totalCount === 0
+      ? "No agents in this team"
+      : "Every agent is stopped";
+  const actionLine = anyActive
+    ? "Click to stop the whole team — all heartbeats and routines pause."
+    : "Click to start the whole team — heartbeats and routines fire on their schedule.";
   return (
-    <label
-      title={label}
-      className="inline-flex h-7 cursor-pointer select-none items-center gap-1.5 rounded-md px-2 text-[11.5px] font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
-    >
-      <Switch
-        checked={anyActive}
-        onCheckedChange={() => void toggleAllAgentsActive()}
-        aria-label={label}
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <label
+            className={cn(
+              "inline-flex cursor-pointer select-none items-center gap-2 rounded-lg px-2 py-1 transition-colors hover:bg-muted/40",
+              totalCount === 0 && "pointer-events-none opacity-50"
+            )}
+          >
+            <SwitchPrimitive.Root
+              checked={anyActive}
+              onCheckedChange={() => void toggleAllAgentsActive()}
+              disabled={totalCount === 0}
+              aria-label={anyActive ? "Stop every agent" : "Start every agent"}
+              className={cn(
+                "peer relative inline-flex h-7 w-12 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors outline-none",
+                "focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-1 focus-visible:ring-offset-background",
+                "disabled:cursor-not-allowed disabled:opacity-50",
+                "data-[checked]:bg-emerald-500 data-[unchecked]:bg-muted-foreground/30"
+              )}
+            >
+              <SwitchPrimitive.Thumb
+                className={cn(
+                  "pointer-events-none block size-5 rounded-full bg-background shadow-sm ring-0 transition-transform",
+                  "data-[checked]:translate-x-6 data-[unchecked]:translate-x-1"
+                )}
+              />
+            </SwitchPrimitive.Root>
+            <span
+              className={cn(
+                "text-[12px] font-semibold tabular-nums",
+                anyActive ? "text-foreground" : "text-muted-foreground"
+              )}
+            >
+              {anyActive ? "Team on" : "Team off"}
+            </span>
+          </label>
+        }
       />
-      <span>{anyActive ? "Team on" : "Team off"}</span>
-    </label>
+      <TooltipContent side="bottom" className="max-w-[260px] text-left">
+        <p className="font-medium">
+          {anyActive ? "Team is running" : "Team is stopped"}
+        </p>
+        <p className="mt-1 text-[11px] opacity-80">{summaryLine}.</p>
+        <p className="mt-2 text-[11px] opacity-80">{actionLine}</p>
+      </TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/src/components/agents/v2/tabs-layout.tsx
+++ b/src/components/agents/v2/tabs-layout.tsx
@@ -132,58 +132,65 @@ function MasterToggle() {
     <Tooltip>
       <TooltipTrigger
         render={
-          <SwitchPrimitive.Root
-            checked={anyActive}
-            onCheckedChange={() => void toggleAllAgentsActive()}
-            disabled={totalCount === 0}
-            aria-label={anyActive ? "Stop every agent" : "Start every agent"}
-            className={cn(
-              "group/master peer relative inline-flex h-7 w-[5.5rem] shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors outline-none",
-              "focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-1 focus-visible:ring-offset-background",
-              "disabled:cursor-not-allowed disabled:opacity-50",
-              "data-[checked]:bg-emerald-500 data-[unchecked]:bg-muted-foreground/30"
-            )}
-          >
-            {/* Track label — sits opposite the thumb. "Team on" hugs the
-                left when checked (thumb on right); "Team off" hugs the
-                right when unchecked (thumb on left). */}
-            <span
-              aria-hidden
+          /* Span wrapper carries the tooltip's hover/focus listeners; the
+             Switch.Root inside owns click handling. Rendering Switch.Root
+             directly as the trigger caused base-ui to overwrite its
+             onCheckedChange handler with its own merged props. */
+          <span className="inline-flex">
+            <SwitchPrimitive.Root
+              checked={anyActive}
+              onCheckedChange={() => void toggleAllAgentsActive()}
+              disabled={totalCount === 0}
+              aria-label={anyActive ? "Stop every agent" : "Start every agent"}
               className={cn(
-                "pointer-events-none absolute inset-y-0 left-2 flex items-center text-[10.5px] font-bold uppercase tracking-wider text-white transition-opacity",
-                "opacity-0 group-data-[checked]/master:opacity-100"
+                "group/master peer relative inline-flex h-7 w-[5.5rem] shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors outline-none",
+                "focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-1 focus-visible:ring-offset-background",
+                "disabled:cursor-not-allowed disabled:opacity-50",
+                "data-[checked]:bg-emerald-500 data-[unchecked]:bg-muted-foreground/30"
               )}
             >
-              Team on
-            </span>
-            <span
-              aria-hidden
-              className={cn(
-                "pointer-events-none absolute inset-y-0 right-2 flex items-center text-[10.5px] font-bold uppercase tracking-wider text-muted-foreground/80 transition-opacity",
-                "opacity-100 group-data-[checked]/master:opacity-0"
-              )}
-            >
-              Team off
-            </span>
-            <SwitchPrimitive.Thumb
-              className={cn(
-                "pointer-events-none relative z-10 block size-5 rounded-full bg-background shadow-sm ring-0 transition-transform",
-                "data-[checked]:translate-x-16 data-[unchecked]:translate-x-1"
-              )}
-            />
-          </SwitchPrimitive.Root>
+              <span
+                aria-hidden
+                className={cn(
+                  "pointer-events-none absolute inset-y-0 left-2 flex items-center text-[10.5px] font-bold uppercase tracking-wider text-white transition-opacity",
+                  "opacity-0 group-data-[checked]/master:opacity-100"
+                )}
+              >
+                Team on
+              </span>
+              <span
+                aria-hidden
+                className={cn(
+                  "pointer-events-none absolute inset-y-0 right-2 flex items-center text-[10.5px] font-bold uppercase tracking-wider text-muted-foreground/80 transition-opacity",
+                  "opacity-100 group-data-[checked]/master:opacity-0"
+                )}
+              >
+                Team off
+              </span>
+              <SwitchPrimitive.Thumb
+                className={cn(
+                  "pointer-events-none relative z-10 block size-5 rounded-full bg-background shadow-sm ring-0 transition-transform",
+                  "data-[checked]:translate-x-16 data-[unchecked]:translate-x-1"
+                )}
+              />
+            </SwitchPrimitive.Root>
+          </span>
         }
       />
       <TooltipContent
         side="bottom"
         variant="themed"
-        className="flex max-w-[260px] flex-col items-start gap-1 p-3 text-left"
+        className="flex max-w-[280px] flex-col items-start gap-1 p-3 text-left"
       >
         <p className="text-[12px] font-semibold">
           {anyActive ? "Team is running" : "Team is stopped"}
         </p>
         <p className="text-[11px] text-muted-foreground">{summaryLine}.</p>
         <p className="text-[11px] text-muted-foreground">{actionLine}</p>
+        <p className="text-[11px] italic text-muted-foreground/80">
+          Tasks already running won&apos;t be interrupted — only future
+          fires are affected.
+        </p>
       </TooltipContent>
     </Tooltip>
   );

--- a/src/components/agents/v2/tabs-layout.tsx
+++ b/src/components/agents/v2/tabs-layout.tsx
@@ -132,48 +132,57 @@ function MasterToggle() {
     <Tooltip>
       <TooltipTrigger
         render={
-          <label
+          <SwitchPrimitive.Root
+            checked={anyActive}
+            onCheckedChange={() => void toggleAllAgentsActive()}
+            disabled={totalCount === 0}
+            aria-label={anyActive ? "Stop every agent" : "Start every agent"}
             className={cn(
-              "inline-flex cursor-pointer select-none items-center gap-2 rounded-lg px-2 py-1 transition-colors hover:bg-muted/40",
-              totalCount === 0 && "pointer-events-none opacity-50"
+              "group/master peer relative inline-flex h-7 w-[5.5rem] shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors outline-none",
+              "focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-1 focus-visible:ring-offset-background",
+              "disabled:cursor-not-allowed disabled:opacity-50",
+              "data-[checked]:bg-emerald-500 data-[unchecked]:bg-muted-foreground/30"
             )}
           >
-            <SwitchPrimitive.Root
-              checked={anyActive}
-              onCheckedChange={() => void toggleAllAgentsActive()}
-              disabled={totalCount === 0}
-              aria-label={anyActive ? "Stop every agent" : "Start every agent"}
-              className={cn(
-                "peer relative inline-flex h-7 w-12 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors outline-none",
-                "focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-1 focus-visible:ring-offset-background",
-                "disabled:cursor-not-allowed disabled:opacity-50",
-                "data-[checked]:bg-emerald-500 data-[unchecked]:bg-muted-foreground/30"
-              )}
-            >
-              <SwitchPrimitive.Thumb
-                className={cn(
-                  "pointer-events-none block size-5 rounded-full bg-background shadow-sm ring-0 transition-transform",
-                  "data-[checked]:translate-x-6 data-[unchecked]:translate-x-1"
-                )}
-              />
-            </SwitchPrimitive.Root>
+            {/* Track label — sits opposite the thumb. "Team on" hugs the
+                left when checked (thumb on right); "Team off" hugs the
+                right when unchecked (thumb on left). */}
             <span
+              aria-hidden
               className={cn(
-                "text-[12px] font-semibold tabular-nums",
-                anyActive ? "text-foreground" : "text-muted-foreground"
+                "pointer-events-none absolute inset-y-0 left-2 flex items-center text-[10.5px] font-bold uppercase tracking-wider text-white transition-opacity",
+                "opacity-0 group-data-[checked]/master:opacity-100"
               )}
             >
-              {anyActive ? "Team on" : "Team off"}
+              Team on
             </span>
-          </label>
+            <span
+              aria-hidden
+              className={cn(
+                "pointer-events-none absolute inset-y-0 right-2 flex items-center text-[10.5px] font-bold uppercase tracking-wider text-muted-foreground/80 transition-opacity",
+                "opacity-100 group-data-[checked]/master:opacity-0"
+              )}
+            >
+              Team off
+            </span>
+            <SwitchPrimitive.Thumb
+              className={cn(
+                "pointer-events-none relative z-10 block size-5 rounded-full bg-background shadow-sm ring-0 transition-transform",
+                "data-[checked]:translate-x-16 data-[unchecked]:translate-x-1"
+              )}
+            />
+          </SwitchPrimitive.Root>
         }
       />
-      <TooltipContent side="bottom" className="max-w-[260px] text-left">
+      <TooltipContent
+        side="bottom"
+        className="flex max-w-[260px] flex-col items-start gap-1 text-left"
+      >
         <p className="font-medium">
           {anyActive ? "Team is running" : "Team is stopped"}
         </p>
-        <p className="mt-1 text-[11px] opacity-80">{summaryLine}.</p>
-        <p className="mt-2 text-[11px] opacity-80">{actionLine}</p>
+        <p className="text-[11px] opacity-80">{summaryLine}.</p>
+        <p className="text-[11px] opacity-80">{actionLine}</p>
       </TooltipContent>
     </Tooltip>
   );

--- a/src/components/agents/v2/tabs-layout.tsx
+++ b/src/components/agents/v2/tabs-layout.tsx
@@ -176,13 +176,14 @@ function MasterToggle() {
       />
       <TooltipContent
         side="bottom"
-        className="flex max-w-[260px] flex-col items-start gap-1 text-left"
+        variant="themed"
+        className="flex max-w-[260px] flex-col items-start gap-1 p-3 text-left"
       >
-        <p className="font-medium">
+        <p className="text-[12px] font-semibold">
           {anyActive ? "Team is running" : "Team is stopped"}
         </p>
-        <p className="text-[11px] opacity-80">{summaryLine}.</p>
-        <p className="text-[11px] opacity-80">{actionLine}</p>
+        <p className="text-[11px] text-muted-foreground">{summaryLine}.</p>
+        <p className="text-[11px] text-muted-foreground">{actionLine}</p>
       </TooltipContent>
     </Tooltip>
   );

--- a/src/components/agents/v2/tabs-layout.tsx
+++ b/src/components/agents/v2/tabs-layout.tsx
@@ -17,6 +17,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Switch } from "@/components/ui/switch";
 import { AgentAvatar } from "@/components/agents/agent-avatar";
 import type { CabinetAgentSummary } from "@/types/cabinets";
 import { useAgentsContext } from "./agents-context";
@@ -84,6 +85,8 @@ function TopBar({
         >
           <RefreshCw className="size-3.5" />
         </button>
+        <Divider />
+        <MasterToggle />
         <NewButton tab={tab} />
       </div>
     </header>
@@ -92,6 +95,33 @@ function TopBar({
 
 function Divider() {
   return <div className="h-3.5 w-px bg-border/60" aria-hidden />;
+}
+
+/**
+ * Master Switch in the top nav. Reflects "is any agent running?". Toggling
+ * flips every agent on/off (which also gates their heartbeats and routines
+ * via the V2 data model). Always visible on the Team section so users can
+ * pause everything regardless of which tab they're on.
+ */
+function MasterToggle() {
+  const { agents, toggleAllAgentsActive } = useAgentsContext();
+  const anyActive = agents.some((a) => a.active);
+  const label = anyActive
+    ? "Stop every agent (and pause their heartbeats and routines)"
+    : "Start every agent";
+  return (
+    <label
+      title={label}
+      className="inline-flex h-7 cursor-pointer select-none items-center gap-1.5 rounded-md px-2 text-[11.5px] font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+    >
+      <Switch
+        checked={anyActive}
+        onCheckedChange={() => void toggleAllAgentsActive()}
+        aria-label={label}
+      />
+      <span>{anyActive ? "Team on" : "Team off"}</span>
+    </label>
+  );
 }
 
 function TabStrip({

--- a/src/components/cabinets/cabinet-view.tsx
+++ b/src/components/cabinets/cabinet-view.tsx
@@ -51,7 +51,7 @@ export function CabinetView({ cabinetPath }: { cabinetPath: string }) {
   const [heartbeatDialog, setHeartbeatDialog] = useState<{
     agent: NewRoutineDialogAgent;
     initialHeartbeat?: string;
-    initialActive?: boolean;
+    initialEnabled?: boolean;
     missedRun?: { scheduledAt: string };
   } | null>(null);
 
@@ -199,7 +199,7 @@ export function CabinetView({ cabinetPath }: { cabinetPath: string }) {
           cabinetPath: event.agentRef.cabinetPath || cabinetPath,
         },
         initialHeartbeat: event.agentRef.heartbeat || "0 9 * * 1-5",
-        initialActive: event.agentRef.active,
+        initialEnabled: event.agentRef.heartbeatEnabled !== false,
       });
     }
   }
@@ -370,7 +370,7 @@ export function CabinetView({ cabinetPath }: { cabinetPath: string }) {
         }}
         agent={heartbeatDialog?.agent ?? { slug: "", name: "" }}
         initialHeartbeat={heartbeatDialog?.initialHeartbeat}
-        initialActive={heartbeatDialog?.initialActive}
+        initialEnabled={heartbeatDialog?.initialEnabled}
         missedRun={heartbeatDialog?.missedRun}
         onSaved={() => {
           setHeartbeatDialog(null);

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -61,6 +61,15 @@ import { SystemToasts } from "@/components/layout/system-toasts";
 // load them on demand to keep the first-paint bundle small. Previously all of
 // these (together ~15k lines of code including AgentsWorkspace and
 // OnboardingWizard) shipped in the home-page chunk.
+const AgentsWorkspaceV2 = dynamic(
+  () =>
+    import("@/components/agents/v2/agents-workspace-v2").then(
+      (m) => m.AgentsWorkspaceV2
+    ),
+  { ssr: false }
+);
+// Legacy V1 — used for the "agent settings" sub-screen (which still lives in
+// the V1 workspace component). Phased out once that path lands in V2.
 const AgentsWorkspace = dynamic(
   () => import("@/components/agents/agents-workspace").then((m) => m.AgentsWorkspace),
   { ssr: false }
@@ -616,10 +625,16 @@ export function AppShell() {
     }
     if (section.type === "agents") {
       return (
-        <AgentsWorkspace
-          selectedScope="all"
-          selectedAgentSlug={null}
+        <AgentsWorkspaceV2
           cabinetPath={section.cabinetPath}
+          tab={section.agentsTab}
+          onTabChange={(next) =>
+            setSection({
+              type: "agents",
+              cabinetPath: section.cabinetPath,
+              agentsTab: next,
+            })
+          }
         />
       );
     }

--- a/src/components/tasks/board/schedule-dialogs.tsx
+++ b/src/components/tasks/board/schedule-dialogs.tsx
@@ -22,7 +22,8 @@ export interface HeartbeatDialogState {
   agentName: string;
   cabinetPath: string;
   heartbeat: string;
-  active: boolean;
+  /** Whether the heartbeat itself is enabled (independent from agent.active). */
+  enabled: boolean;
 }
 
 /**
@@ -96,7 +97,7 @@ export function ScheduleHeartbeatDialog({
         cabinetPath: state.cabinetPath,
       }}
       initialHeartbeat={state.heartbeat}
-      initialActive={state.active}
+      initialEnabled={state.enabled}
       onSaved={() => {
         onClose();
         void onRefresh();

--- a/src/components/tasks/board/tasks-board.tsx
+++ b/src/components/tasks/board/tasks-board.tsx
@@ -566,7 +566,7 @@ export function TasksBoard({
                     agentName: agent.name,
                     cabinetPath: agent.cabinetPath || cabinetPath,
                     heartbeat: agent.heartbeat || "0 9 * * 1-5",
-                    active: agent.active,
+                    enabled: agent.heartbeatEnabled !== false,
                   });
                 }}
               />

--- a/src/components/ui/locked-switch.tsx
+++ b/src/components/ui/locked-switch.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Switch } from "@/components/ui/switch";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
+/**
+ * A Switch that shows its configured state but cannot be toggled. Used when
+ * the parent that gates the Switch's effect is itself off — the user needs
+ * to fix the parent first.
+ *
+ * In unlocked mode, behaves exactly like a regular `<Switch>`. In locked
+ * mode, the Switch renders gray and disabled but still captures clicks via
+ * a wrapping span (the inner Switch is `pointer-events-none` so clicks fall
+ * through to the span). A Tooltip explains the state. `onLockedClick` is an
+ * optional callback fired on click — useful for nudging the user toward the
+ * parent control with a visual pulse.
+ */
+export function LockedSwitch({
+  checked,
+  locked,
+  onCheckedChange,
+  onLockedClick,
+  tooltip,
+  ariaLabel,
+}: {
+  checked: boolean;
+  locked: boolean;
+  onCheckedChange: (next: boolean) => void;
+  onLockedClick?: () => void;
+  tooltip: string;
+  ariaLabel: string;
+}) {
+  if (!locked) {
+    return (
+      <Switch
+        checked={checked}
+        onCheckedChange={onCheckedChange}
+        aria-label={ariaLabel}
+      />
+    );
+  }
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span
+            className="inline-flex cursor-not-allowed"
+            onClick={() => onLockedClick?.()}
+            role="presentation"
+          >
+            <Switch
+              checked={checked}
+              disabled
+              aria-label={ariaLabel}
+              className="pointer-events-none"
+            />
+          </span>
+        }
+      />
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -31,13 +31,23 @@ function TooltipContent({
   sideOffset = 4,
   align = "center",
   alignOffset = 0,
+  variant = "default",
   children,
   ...props
 }: TooltipPrimitive.Popup.Props &
   Pick<
     TooltipPrimitive.Positioner.Props,
     "align" | "alignOffset" | "side" | "sideOffset"
-  >) {
+  > & {
+    /** `default` = high-contrast dark bubble (inverts with theme).
+     *  `themed` = popover-style — uses --popover / --popover-foreground
+     *  with a border + shadow, matching surfaces like the System Status
+     *  popover. Use for tooltips that carry richer content (multi-line
+     *  state explanations) where the high-contrast variant feels
+     *  out of place. */
+    variant?: "default" | "themed";
+  }) {
+  const themed = variant === "themed";
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Positioner
@@ -50,13 +60,23 @@ function TooltipContent({
         <TooltipPrimitive.Popup
           data-slot="tooltip-content"
           className={cn(
-            "z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            "z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md px-3 py-1.5 text-xs has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            themed
+              ? "border border-border bg-popover text-popover-foreground shadow-md"
+              : "bg-foreground text-background",
             className
           )}
           {...props}
         >
           {children}
-          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+          <TooltipPrimitive.Arrow
+            className={cn(
+              "z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5",
+              themed
+                ? "border border-border bg-popover fill-popover"
+                : "bg-foreground fill-foreground"
+            )}
+          />
         </TooltipPrimitive.Popup>
       </TooltipPrimitive.Positioner>
     </TooltipPrimitive.Portal>

--- a/src/hooks/use-hash-route.ts
+++ b/src/hooks/use-hash-route.ts
@@ -70,6 +70,13 @@ function decodePathSegment(value?: string): string {
   }
 }
 
+const AGENTS_SUB_TABS = ["agents", "routines", "heartbeats", "schedule"] as const;
+type AgentsSubTab = (typeof AGENTS_SUB_TABS)[number];
+
+function isAgentsSubTab(value: string | undefined): value is AgentsSubTab {
+  return !!value && (AGENTS_SUB_TABS as readonly string[]).includes(value);
+}
+
 function buildHash(section: SectionState, pagePath: string | null): string {
   const cabinetPath = section.cabinetPath || ROOT_CABINET_PATH;
   const isRoot = cabinetPath === ROOT_CABINET_PATH;
@@ -93,8 +100,12 @@ function buildHash(section: SectionState, pagePath: string | null): string {
     return `#/cabinet/${encodePathSegment(cabinetPath)}/agents/${encodePathSegment(section.slug)}`;
   }
   if (section.type === "agents") {
-    if (isRoot) return "#/agents";
-    return `#/cabinet/${encodePathSegment(cabinetPath)}/agents`;
+    const tabSuffix =
+      section.agentsTab && section.agentsTab !== "agents"
+        ? `/${section.agentsTab}`
+        : "";
+    if (isRoot) return `#/agents${tabSuffix}`;
+    return `#/cabinet/${encodePathSegment(cabinetPath)}/agents${tabSuffix}`;
   }
   if (section.type === "task" && section.taskId) {
     return buildTaskHash(section.taskId, cabinetPath);
@@ -162,6 +173,13 @@ function parseHash(hash: string): RouteState {
     if (!leaf) {
       return {
         section: { type: "cabinet", cabinetPath },
+        pagePath: null,
+      };
+    }
+
+    if (leaf === "agents" && parts[3] && isAgentsSubTab(parts[3])) {
+      return {
+        section: { type: "agents", cabinetPath, agentsTab: parts[3] },
         pagePath: null,
       };
     }
@@ -241,6 +259,18 @@ function parseHash(hash: string): RouteState {
   // the form `/#/tasks`, `/#/agents` land on the correct view without having
   // to know about the internal `/#/cabinet/./tasks` shape. Audit #11, #12.
   if (parts[0] === "agents") {
+    // `#/agents/{sub-tab}` for the new V2 layout — sub-tab takes priority
+    // over the legacy `#/agents/{slug}` form (which is now under `#/a/`).
+    if (parts[1] && isAgentsSubTab(parts[1])) {
+      return {
+        section: {
+          type: "agents",
+          cabinetPath: ROOT_CABINET_PATH,
+          agentsTab: parts[1],
+        },
+        pagePath: null,
+      };
+    }
     if (parts[1]) {
       const slug = decodePathSegment(parts[1]);
       return {
@@ -399,7 +429,8 @@ export function useHashRoute() {
       if (
         state.section.type !== prev.section.type ||
         state.section.slug !== prev.section.slug ||
-        state.section.cabinetPath !== prev.section.cabinetPath
+        state.section.cabinetPath !== prev.section.cabinetPath ||
+        state.section.agentsTab !== prev.section.agentsTab
       ) {
         const selectedPath = useTreeStore.getState().selectedPath;
         const hash = buildHash(state.section, selectedPath);

--- a/src/lib/agents/cron-compute.ts
+++ b/src/lib/agents/cron-compute.ts
@@ -165,7 +165,9 @@ export function getScheduleEvents(
             agentEmoji: owner?.emoji || "🤖",
             agentName: owner?.name || job.ownerAgent || "Unknown",
             agentSlug: slug,
-            enabled: job.enabled,
+            // Effective enable: agent must be active too. Stopping the agent
+            // dims every routine even though `job.enabled` stays true on disk.
+            enabled: job.enabled && (owner?.active !== false),
             cronExpr: job.schedule,
             time: next,
             jobRef: job,
@@ -209,7 +211,8 @@ export function getScheduleEvents(
             agentEmoji: agent.emoji || "🤖",
             agentName: agent.name,
             agentSlug: agent.slug,
-            enabled: agent.active,
+            // Effective enable: master switch AND per-heartbeat toggle.
+            enabled: agent.active && agent.heartbeatEnabled !== false,
             cronExpr: agent.heartbeat,
             time: next,
             agentRef: agent,

--- a/src/lib/agents/library-manager.ts
+++ b/src/lib/agents/library-manager.ts
@@ -168,6 +168,7 @@ export async function readLibraryPersona(
     heartbeat: (data.heartbeat as string) || "0 8 * * *",
     budget: (data.budget as number) || 100,
     active: data.active !== false,
+    heartbeatEnabled: data.heartbeatEnabled !== false,
     workdir: (data.workdir as string) || "/data",
     focus: (data.focus as string[]) || [],
     tags: (data.tags as string[]) || [],

--- a/src/lib/agents/persona-manager.ts
+++ b/src/lib/agents/persona-manager.ts
@@ -175,6 +175,13 @@ export interface AgentPersona {
   heartbeat: string; // cron expression
   budget: number; // max heartbeats per month
   active: boolean;
+  /**
+   * Whether the heartbeat is enabled. Independent from `active` so users can
+   * silence the heartbeat without disabling the agent's other routines.
+   * Effective scheduling = `active && heartbeatEnabled`. Defaults to true
+   * for personas missing the field (backward compat).
+   */
+  heartbeatEnabled: boolean;
   workdir: string;
   focus: string[];
   tags: string[];
@@ -367,6 +374,7 @@ export async function readPersona(slug: string, cabinetPath?: string): Promise<A
     heartbeat: (data.heartbeat as string) || "0 8 * * *",
     budget: (data.budget as number) || 100,
     active: data.active !== false,
+    heartbeatEnabled: data.heartbeatEnabled !== false,
     workdir: (data.workdir as string) || "/data",
     focus: (data.focus as string[]) || [],
     tags: (data.tags as string[]) || [],
@@ -429,7 +437,7 @@ export async function readPersona(slug: string, cabinetPath?: string): Promise<A
   }
 
   // Compute nextHeartbeat from cron expression + lastHeartbeat
-  if (persona.active && persona.heartbeat && persona.lastHeartbeat) {
+  if (persona.active && persona.heartbeatEnabled && persona.heartbeat && persona.lastHeartbeat) {
     try {
       const nextRun = computeNextCronRun(persona.heartbeat, new Date(persona.lastHeartbeat));
       if (nextRun) persona.nextHeartbeat = nextRun.toISOString();
@@ -473,6 +481,7 @@ export async function writePersona(slug: string, persona: Partial<AgentPersona> 
     heartbeat: merged.heartbeat,
     budget: merged.budget,
     active: merged.active,
+    heartbeatEnabled: merged.heartbeatEnabled !== false,
     workdir: merged.workdir,
     focus: merged.focus,
     tags: merged.tags,
@@ -687,7 +696,7 @@ export function unregisterHeartbeat(slug: string): void {
 export async function registerAllHeartbeats(): Promise<void> {
   const personas = await listPersonas();
   for (const persona of personas) {
-    if (persona.active && persona.heartbeatsUsed !== undefined && persona.heartbeatsUsed < persona.budget) {
+    if (persona.active && persona.heartbeatEnabled && persona.heartbeatsUsed !== undefined && persona.heartbeatsUsed < persona.budget) {
       registerHeartbeat(persona.slug, persona.heartbeat);
     }
   }

--- a/src/lib/cabinets/overview.ts
+++ b/src/lib/cabinets/overview.ts
@@ -281,6 +281,7 @@ async function readAgentPersona(
       emoji: trimString(data.emoji) || "🤖",
       role,
       active: data.active !== false,
+      heartbeatEnabled: data.heartbeatEnabled !== false,
       department: trimString(data.department) || "general",
       type: trimString(data.type) || "specialist",
       heartbeat: trimString(data.heartbeat),

--- a/src/lib/data-locations/client-registry.ts
+++ b/src/lib/data-locations/client-registry.ts
@@ -30,6 +30,17 @@ export const CLIENT_DATA_LOCATIONS: DataLocation[] = [
     onboarding: true,
   },
   {
+    id: "ls-agents-explainer",
+    label: "Team page tab explainers",
+    pathOrKey: "cabinet.agents.explainer.",
+    prefix: true,
+    contains:
+      "Per-tab dismissal flag for the Team page explainer cards (Agents / Routines / Heartbeats / Schedule).",
+    leavesDevice: false,
+    scope: "localStorage",
+    onboarding: true,
+  },
+  {
     id: "ls-feedback-prompted",
     label: "Feedback popup state",
     pathOrKey: "cabinet.feedback.",

--- a/src/stores/app-store.ts
+++ b/src/stores/app-store.ts
@@ -64,6 +64,8 @@ export interface SelectedSection {
   agentScopedId?: string;
   conversationId?: string; // auto-select this conversation on mount
   taskId?: string; // task id when type === "task"
+  /** Sub-tab key when type === "agents" (e.g. "routines", "heartbeats"). */
+  agentsTab?: "agents" | "routines" | "heartbeats" | "schedule";
 }
 
 interface TerminalTab {

--- a/src/types/agents.ts
+++ b/src/types/agents.ts
@@ -72,6 +72,8 @@ export interface AgentListItem {
   provider?: string;
   adapterType?: string;
   active: boolean;
+  /** Optional — undefined falls back to true for legacy personas. */
+  heartbeatEnabled?: boolean;
   type?: AgentType | string;
   department?: string;
   heartbeat?: string;

--- a/src/types/cabinets.ts
+++ b/src/types/cabinets.ts
@@ -34,6 +34,8 @@ export interface CabinetAgentSummary {
   emoji: string;
   role: string;
   active: boolean;
+  /** Optional — undefined falls back to true for legacy personas. */
+  heartbeatEnabled?: boolean;
   department?: string;
   type?: AgentType | string;
   heartbeat?: string;


### PR DESCRIPTION
**Stacked on PR #77.** Set the base to `feat/agent-master-switch-and-heartbeat-toggle` to see only this PR's diff.

## Why

The production `/agents` page stacked three lists ("Meet the team", "Routines", "Heartbeats") plus a calendar plus multi-paragraph intros. With 70 agents on a real account, that scroll is brutal and the redundancy (each agent appears in up to three lists) creates cognitive load. The Discord report from frozar was the surface symptom — the deeper issue was page architecture.

## What ships

`/agents` is now a four-tab Team page. Each tab is a focused list with its own filters and bulk actions; the calendar gets its own tab so it stops competing for screen real estate.

```
┌────────────────────────────────────────────────────────────────────────┐
│ Team  [Agents 70] [Routines 38] [Heartbeats 50] [Schedule]   Own ▾ ↻ + New │
└────────────────────────────────────────────────────────────────────────┘
```

### Per tab

| Tab | Stats | Filters | Trailing action | Row click |
|---|---|---|---|---|
| Agents | `N active · M departments` | search + dept + status | Org chart | → agent detail |
| Routines | `N firing · M off · K locked` | search + agent + status | — | → NewRoutineDialog |
| Heartbeats | `N firing · M off · K locked` | search + status | Pause/Resume all | → HeartbeatDialog |
| Schedule | — | — | Day/Week/Month | → matching dialog |

### Top bar

- Page title `Team` + loading spinner
- Pill-style tabs (paper-theme `bg-primary` active), grouped in a bordered container — matches the Tasks page
- Cabinet scope picker (real `DepthDropdown` from production, bound to app store)
- Refresh icon
- Context-aware `+ New ___` button — opens an agent-picker dropdown on Routines + Heartbeats tabs

### Onboarding

Per-tab `TabExplainer` cards with plain-language copy (the heartbeat tab uses a metaphor instead of jargon: "what makes your agent feel alive — every tick, the agent wakes up, looks around, and decides what to do next"). Dismissed per tab via localStorage; small `ⓘ` re-opens this session.

## Routing

New canonical URLs:
- `#/agents` (default Agents tab)
- `#/agents/routines`
- `#/agents/heartbeats`
- `#/agents/schedule`
- Cabinet-scoped: `#/cabinet/<path>/agents/<tab>`

`SelectedSection.agentsTab` carries the active tab. Browser back/forward replays the tab change. Legacy `#/agents/<slug>` still routes to agent detail (canonical form is `#/a/<slug>`).

## Architecture

```
src/components/agents/v2/
├── agents-workspace-v2.tsx   # entry: provider + dialogs + layout
├── agents-context.tsx        # shared state, fetch, toggle handlers
├── tabs-layout.tsx           # top bar + tab strip + outlet
├── agents-tab.tsx
├── routines-tab.tsx
├── heartbeats-tab.tsx
├── schedule-tab.tsx
├── agent-row.tsx
├── list-shell.tsx            # search + filters + list pane shell
├── tab-explainer.tsx         # onboarding card
└── new-agent-dialog.tsx      # self-contained library picker
```

The provider:
- Fetches via `fetchCabinetOverviewClient` (same as V1)
- Owns dialog state (heartbeat, routine, new-agent, org-chart)
- Exposes toggle handlers hitting the same endpoints V1 uses
- Refetches on `cabinet:agents/agent_status` and `cabinet:conversation-completed` window events from the global SSE subscription

## Preserved from V1

- Cabinet scope picker
- Org chart modal
- Pause-all / Resume-all heartbeats (uses scheduler actions from PR #77)
- All dialogs (HeartbeatDialog, NewRoutineDialog, OrgChartModal)
- Refresh
- Live data refetch on global SSE events
- Master switch + per-heartbeat + per-routine toggles with locked-child semantics (PR #74 / #77)

## Dropped from V1

- Multi-paragraph "This is your AI team" intro → per-tab plain-language explainer cards
- "Routines & heartbeats" combined section → split into dedicated tabs
- Inline grid of agent cards → list view (already in PR #77)

V1 (`AgentsWorkspace`) remains imported as a legacy fallback (no route renders it). Slated for full removal one PR cycle after this ships. The `/agents-demo` route also stays for that cycle as a side-by-side fallback.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` on changed files clean (pre-existing warnings only)
- [ ] In a browser: navigate `#/agents`, `#/agents/routines`, `#/agents/heartbeats`, `#/agents/schedule` — each tab loads, count chips populate
- [ ] Click a tab — URL updates, browser back/forward replays
- [ ] Toggle an agent's master switch — persists across reload, daemon scheduling reflects it
- [ ] Toggle a heartbeat — persists, daemon scheduling reflects it
- [ ] Toggle a routine — persists, daemon scheduling reflects it
- [ ] Click an agent row → agent detail page opens
- [ ] Click a heartbeat row → HeartbeatDialog opens with prefilled cron + enabled state
- [ ] Click a routine row → NewRoutineDialog opens in edit mode
- [ ] Click a calendar pill → matching dialog opens
- [ ] `+ New Agent` → library dialog opens, picking a template adds + navigates to it
- [ ] `+ New Routine` → agent picker → NewRoutineDialog opens in create mode
- [ ] `+ Configure heartbeat` → agent picker → HeartbeatDialog opens
- [ ] `Org chart` → modal opens with current team
- [ ] `Pause all` heartbeats → all heartbeats flip off; button label flips to `Resume all`
- [ ] Cabinet scope picker → list updates to the new scope
- [ ] Refresh → re-fetches without page reload
- [ ] Per-tab explainer dismisses + reopens via `ⓘ`
- [ ] Empty states render correctly (no agents / no routines / no heartbeats / no scheduled events)

## Out of scope (follow-ups)

- Multi-select bulk Start/Stop on Agents tab — deferred
- Delete `/agents-demo` and old `AgentsWorkspace` — one PR cycle later
- Migrate the "agent settings" panel (inline drawer in V1) — agent detail page already does this