### PR TITLE
Mobile responsive: bottom-tab nav, AI overlay, tour fit, trigger dropdown

### DIFF
--- a/MOBILE_RESPONSIVE_PRD.md
+++ b/MOBILE_RESPONSIVE_PRD.md
@@ -1,0 +1,138 @@
+# PRD — Cabinet Mobile Responsive
+
+**Author.** hilash · **Date.** 2026-05-15 · **Status.** Draft · **Related.** PR #21 (micahbrich, stalled)
+
+## Goal
+
+Make the entire Cabinet app usable and look intentional on mobile viewports (375×667 → 430×932). Desktop behavior must not regress. Output is one PR onto `main`, plus a `before/after` audit folder under `data/cabinet-data/audits/audit-2026-05-15-mobile-responsive/` with side-by-side screenshots and a written summary in the existing audit format.
+
+## Non-goals
+
+- Tablet-specific layouts (640–1023). They follow desktop by default — fix only if something actively breaks.
+- New features. No new screens, no new components.
+- Touch-gesture upgrades (swipe drawers, pull-to-refresh). Tap-only.
+- Native iOS/Android packaging.
+
+## Target viewports
+
+- **Phone S** — 375×667 (iPhone SE, smallest in regular rotation)
+- **Phone M** — 390×844 (iPhone 14)
+- **Phone L** — 430×932 (iPhone 14 Pro Max)
+- **Desktop baseline** — 1440×900 (no regression)
+- **Breakpoint.** Tailwind `md` (768px) is the desktop/mobile line. Use `max-md:` for mobile-only.
+
+## Reference patterns (from PR #21, kept)
+
+- `useIsMobile()` hook — single source of truth for runtime checks.
+- **Sidebar.** Off-canvas drawer on mobile; toggle moves inline into header (not floating).
+- **AI panel.** Full-screen overlay with scrim on mobile.
+- **Agents workspace.** Master-detail — list collapses to detail on row tap, back button to return.
+
+Codebase has moved on a lot since #21 (i18n, RTL, Team tabs, heartbeats, mission-control, skills hub). We **reimplement the patterns**, not cherry-pick the commits.
+
+## Screens to audit (the checklist — every one gets before+after screenshots at 375 and 1440)
+
+### Shell / chrome
+1. `app-shell` — viewport, scroll containers, safe-area insets
+2. `header` — title, breadcrumb, nav-arrows, user avatar, theme picker, header-actions
+3. `sidebar` — drawer behavior, file tree, cabinet switcher
+4. `status-bar` — server status, sync, uncommitted, terminal toggle, popovers
+5. `ai-panel` — overlay, scrim, close affordance, composer inside it
+6. `terminal` panel — opens, resizes, doesn't trap viewport
+7. `notification-toasts` — placement, stacking, dismiss target
+8. `system-toasts` — same
+9. `theme-picker` — popover/dialog fits, scrolls
+10. `update-dialog`, `breaking-changes-warning`, `daemon-health-banner`, `narrow-viewport-hint` (kill or improve)
+
+### Home / onboarding
+11. `home-screen` — greeting, prompt, templates carousel, recents
+12. `onboarding-wizard` — steps, inputs, CTAs
+13. `onboarding/tour` — tooltips don't overflow viewport
+14. `data-dir-prompt`, `feedback-popup`
+
+### Editor & viewers
+15. `editor` — toolbar, bubble menu, table menu, slash commands, mention picker, emoji picker
+16. `editor-toolbar` — overflow / scroll on narrow
+17. `bubble-menu`, `link-popover`, `media-popover`, `embed-popover`
+18. `color-palette`, `emoji-picker` — sizing
+19. `folder-index`
+20. Viewers: `image-viewer`, `pdf-viewer`, `csv-viewer`, `mermaid-viewer`, `notebook-viewer`, `source-viewer`, `google-doc-viewer`, `website-viewer`, `media-viewer`, `file-fallback-viewer`
+21. `office` editors (docx/xlsx/pptx)
+22. `version-history`
+
+### Agents
+23. `agents-workspace` (list + detail master-detail on mobile)
+24. `agents/v2` flow
+25. `agent-preview` page
+26. Conversations: `agents/conversations/[id]`
+27. Schedule, routines, heartbeats tabs (`agents-demo/*`)
+
+### Tasks
+28. `tasks` board (kanban → stacked or scroll-x on mobile?)
+29. `tasks/[id]` task detail
+30. `tasks/conversation`
+31. Task creation flow
+
+### Search / palette / composer
+32. `search` palette — full-height sheet on mobile
+33. `composer` — input, file attachments, slash commands, mentions
+
+### Settings
+34. `settings-page` — sections list, scroll
+35. `api-keys-section`
+36. `cli-mcp-section`
+37. `connected-integrations-card`
+38. `data-locations-section`
+39. `storage-backend-section`
+40. `uninstall-section`
+41. `edit-user-avatar-dialog`
+
+### Other
+42. `cabinets` — cabinet switcher, create flow
+43. `integrations`
+44. `skills` hub
+45. `mission-control`
+46. `registry`
+47. `help` — demos, keyboard cheatsheet
+48. `login` page
+49. RTL (Hebrew) — every above screen at 375 needs an RTL spot-check on at least 5 representative screens
+
+## Definition of done
+
+- [ ] No horizontal scroll at 375 on any screen above.
+- [ ] All tap targets ≥ 44×44 (iOS HIG) — focus-rings still visible.
+- [ ] No content trapped behind keyboard / virtual viewport.
+- [ ] Sidebar opens/closes on mobile with header toggle; doesn't overlap content when desktop expands.
+- [ ] AI panel is full-screen with a backdrop on mobile, dismissable; composer keyboard-friendly.
+- [ ] Agents workspace master-detail works both directions (list→detail, back).
+- [ ] Tasks board readable (either single-column stack or horizontal-scroll columns with snap).
+- [ ] Editor toolbar doesn't overflow — wrap, scroll-x, or overflow menu.
+- [ ] Every popover/dialog (theme picker, mention picker, emoji picker, link/media popover) fits in 375 viewport.
+- [ ] RTL spot-check passes on Home, Editor, Agents, Settings, Sidebar.
+- [ ] Lighthouse mobile a11y ≥ 90 on Home, Editor, Agents, Settings.
+- [ ] Desktop (1440) screenshots show **no diff** beyond intended changes.
+- [ ] Audit folder `audit-2026-05-15-mobile-responsive/` populated with:
+  - `index.md` — walkthrough with paired before/after screenshots and summary
+  - `screenshots/` — `NN-screen-name-mobile-before.png`, `NN-screen-name-mobile-after.png`, `NN-screen-name-desktop.png`
+  - `progress.md` — issue tracker
+  - `issues/` — per-issue files
+
+## Approach
+
+1. Worktree off `main` at `../cabinet-mobile/`, branch `feat/mobile-responsive`.
+2. Run dev server, capture **all before screenshots at 375 + 1440** for every screen above.
+3. Implement in phases:
+   - **Phase 1 — Shell.** `useIsMobile`, `app-shell`, `header`, `sidebar`, `status-bar`, `ai-panel`. (Foundation; unlocks everything.)
+   - **Phase 2 — Agents + Tasks + Home.** The primary surfaces.
+   - **Phase 3 — Editor + viewers.** The content surface.
+   - **Phase 4 — Settings + dialogs + popovers.** The long tail.
+   - **Phase 5 — RTL + a11y + tap-target sweep.**
+4. After each phase, re-screenshot the touched screens and update the audit.
+5. Final pass: walk every screen in the checklist, fix what's left, write the audit summary.
+
+## Risks
+
+- **Scope balloon.** 49 surfaces. Hard cap: any single surface that needs >1 hour gets its own follow-up issue rather than blocking the PR.
+- **i18n branch interference.** Branch from `main`, not from `feat/i18n-chinese` (which has uncommitted work).
+- **RTL × mobile interaction.** Drawer slides from `start`, not `left`. Test in Hebrew explicitly.
+- **Test coverage.** No mobile Playwright suite exists; we rely on manual + Chrome DevTools MCP screenshots. Acceptable for v1.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1110,3 +1110,10 @@ html[data-custom-theme="cyber"] :where(button:not([data-no-bevel])):hover {
     background-image: none;
   }
 }
+
+/* Tour data slide — 3-column grid at md+ (sidebar / viewer / copy). */
+@media (min-width: 768px) {
+  .cabinet-tour-data-grid {
+    grid-template-columns: 280px 340px 1fr;
+  }
+}

--- a/src/components/agents/v2/tabs-layout.tsx
+++ b/src/components/agents/v2/tabs-layout.tsx
@@ -46,7 +46,7 @@ export function TabsLayout({
   return (
     <div className="flex h-full min-h-0 flex-col">
       <TopBar tab={tab} onTabChange={onTabChange} />
-      <div className="mx-auto min-h-0 w-full max-w-6xl flex-1 overflow-hidden px-6 pb-8 pt-4">
+      <div className="mx-auto min-h-0 w-full max-w-6xl flex-1 overflow-x-hidden overflow-y-auto px-4 pb-8 pt-4 sm:px-6">
         {tab === "agents" && <AgentsTab />}
         {tab === "routines" && <RoutinesTab />}
         {tab === "heartbeats" && <HeartbeatsTab />}
@@ -67,27 +67,29 @@ function TopBar({
   const { loading, refresh, visibilityMode, setVisibilityMode } =
     useAgentsContext();
   return (
-    <header className="flex h-12 shrink-0 items-center gap-3 border-b border-border/70 bg-background px-4">
-      <h1 className="text-[14px] font-semibold tracking-tight">Team</h1>
-      {loading && (
-        <Loader2 className="size-3.5 animate-spin text-muted-foreground" />
-      )}
-      <div className="ml-2 flex items-center gap-2">
+    <header className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-2 border-b border-border/70 bg-background px-4 py-2 md:h-12 md:flex-nowrap md:py-0">
+      <div className="flex items-center gap-2">
+        <h1 className="text-[14px] font-semibold tracking-tight">Team</h1>
+        {loading && (
+          <Loader2 className="size-3.5 animate-spin text-muted-foreground" />
+        )}
+      </div>
+      <div className="order-3 w-full overflow-x-auto md:order-2 md:ml-2 md:w-auto md:overflow-visible">
         <TabStrip tab={tab} onTabChange={onTabChange} />
       </div>
-      <div className="ml-auto flex items-center gap-2">
+      <div className="order-2 ml-auto flex items-center gap-2 md:order-3">
         <DepthDropdown mode={visibilityMode} onChange={setVisibilityMode} />
-        <Divider />
+        <Divider className="hidden md:block" />
         <button
           type="button"
           onClick={() => void refresh()}
           title={t("agents:workspace.refresh")}
           aria-label={t("agents:workspace.refresh")}
-          className="inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+          className="hidden md:inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
         >
           <RefreshCw className="size-3.5" />
         </button>
-        <Divider />
+        <Divider className="hidden md:block" />
         <MasterToggle />
         <NewButton tab={tab} />
       </div>
@@ -95,8 +97,8 @@ function TopBar({
   );
 }
 
-function Divider() {
-  return <div className="h-3.5 w-px bg-border/60" aria-hidden />;
+function Divider({ className }: { className?: string }) {
+  return <div className={cn("h-3.5 w-px bg-border/60", className)} aria-hidden />;
 }
 
 /**

--- a/src/components/ai-panel/ai-panel.tsx
+++ b/src/components/ai-panel/ai-panel.tsx
@@ -498,7 +498,23 @@ export function AIPanel() {
   };
 
   return (
-    <div className="w-[480px] min-w-[420px] border-l border-border bg-background flex flex-col">
+    <>
+      {/* Mobile scrim — full-screen overlay backdrop */}
+      <div
+        className="md:hidden fixed inset-0 z-40 bg-black/40"
+        onClick={close}
+        aria-hidden="true"
+      />
+      <div
+        className={cn(
+          "bg-background flex flex-col",
+          // Desktop: fixed-width side panel docked to the right
+          "md:w-[480px] md:min-w-[420px] md:border-l md:border-border md:relative md:inset-auto",
+          // Mobile: full-screen overlay
+          "max-md:fixed max-md:inset-0 max-md:z-50",
+          "max-md:pb-[max(env(safe-area-inset-bottom),0px)]"
+        )}
+      >
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
         <div className="flex items-center gap-2">
@@ -843,6 +859,7 @@ export function AIPanel() {
           }
         />
       </div>
-    </div>
+      </div>
+    </>
   );
 }

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -56,6 +56,8 @@ import type { CabinetAgentSummary } from "@/types/cabinets";
 import { UpdateDialog } from "@/components/layout/update-dialog";
 import { NotificationToasts } from "@/components/layout/notification-toasts";
 import { SystemToasts } from "@/components/layout/system-toasts";
+import { MobileBottomNav } from "@/components/layout/mobile-bottom-nav";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 
 // Section components are only rendered when the user navigates to them —
 // load them on demand to keep the first-paint bundle small. Previously all of
@@ -144,6 +146,7 @@ const useIsoLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : use
 
 export function AppShell() {
   useGlobalHotkeys();
+  const isMobile = useIsMobile();
   const loadTree = useTreeStore((s) => s.loadTree);
   const nodes = useTreeStore((s) => s.nodes);
   const selectedPath = useTreeStore((s) => s.selectedPath);
@@ -839,17 +842,18 @@ export function AppShell() {
       />
       <Sidebar />
       <div
-        className="flex-1 flex flex-col overflow-hidden"
+        className="flex-1 flex flex-col overflow-hidden max-md:pb-[calc(56px+env(safe-area-inset-bottom))]"
         style={{ '--sidebar-toggle-offset': sidebarCollapsed ? '2.25rem' : '0px' } as React.CSSProperties}
       >
         <DaemonHealthBanner />
-        <NarrowViewportHint />
+        {!isMobile && <NarrowViewportHint />}
         <main className="flex-1 flex flex-col overflow-hidden">
           {renderContent()}
         </main>
         {terminalOpen && terminalPosition === "bottom" && <TerminalTabs />}
-        <StatusBar />
+        {!isMobile && <StatusBar />}
       </div>
+      <MobileBottomNav />
       {terminalOpen && terminalPosition === "right" && <TerminalTabs />}
       {taskPanelConversation && <TaskDetailPanel />}
       {!aiPanelCollapsed && <AIPanel />}

--- a/src/components/layout/mobile-bottom-nav.tsx
+++ b/src/components/layout/mobile-bottom-nav.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { Home, Users, ListChecks, Sparkles, Menu } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useAppStore } from "@/stores/app-store";
+import { useAIPanelStore } from "@/stores/ai-panel-store";
+import { ROOT_CABINET_PATH } from "@/lib/cabinets/paths";
+
+type TabId = "home" | "agents" | "tasks" | "ai" | "menu";
+
+interface TabSpec {
+  id: TabId;
+  label: string;
+  icon: typeof Home;
+}
+
+const TABS: TabSpec[] = [
+  { id: "home", label: "Home", icon: Home },
+  { id: "agents", label: "Agents", icon: Users },
+  { id: "tasks", label: "Tasks", icon: ListChecks },
+  { id: "ai", label: "AI", icon: Sparkles },
+  { id: "menu", label: "Menu", icon: Menu },
+];
+
+export function MobileBottomNav() {
+  const section = useAppStore((s) => s.section);
+  const setSection = useAppStore((s) => s.setSection);
+  const setSidebarCollapsed = useAppStore((s) => s.setSidebarCollapsed);
+  const aiOpen = useAIPanelStore((s) => s.isOpen);
+  const openAI = useAIPanelStore((s) => s.open);
+  const closeAI = useAIPanelStore((s) => s.close);
+  const setAiPanelCollapsed = useAppStore((s) => s.setAiPanelCollapsed);
+
+  const activeTab: TabId = aiOpen
+    ? "ai"
+    : section.type === "agents" || section.type === "agent"
+      ? "agents"
+      : section.type === "tasks" || section.type === "task"
+        ? "tasks"
+        : section.type === "home"
+          ? "home"
+          : "home";
+
+  const onSelect = (id: TabId) => {
+    if (id === "ai") {
+      if (aiOpen) {
+        closeAI();
+      } else {
+        setAiPanelCollapsed(false);
+        openAI();
+      }
+      return;
+    }
+    // Always close AI when navigating away
+    if (aiOpen) closeAI();
+    if (id === "menu") {
+      setSidebarCollapsed(false);
+      return;
+    }
+    if (id === "home") {
+      setSection({ type: "home" });
+      return;
+    }
+    if (id === "agents") {
+      setSection({ type: "agents", cabinetPath: ROOT_CABINET_PATH });
+      return;
+    }
+    if (id === "tasks") {
+      setSection({ type: "tasks", cabinetPath: ROOT_CABINET_PATH });
+      return;
+    }
+  };
+
+  return (
+    <nav
+      aria-label="Primary"
+      className={cn(
+        "md:hidden fixed bottom-0 inset-x-0 z-30",
+        "bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80",
+        "border-t border-border",
+        "pb-[max(env(safe-area-inset-bottom),0.25rem)]"
+      )}
+    >
+      <ul className="flex items-stretch justify-around">
+        {TABS.map((tab) => {
+          const Icon = tab.icon;
+          const isActive = activeTab === tab.id;
+          return (
+            <li key={tab.id} className="flex-1">
+              <button
+                type="button"
+                onClick={() => onSelect(tab.id)}
+                aria-label={tab.label}
+                aria-current={isActive ? "page" : undefined}
+                className={cn(
+                  "w-full min-h-[56px] flex flex-col items-center justify-center gap-0.5",
+                  "text-[10px] font-medium tracking-wide",
+                  "transition-colors cursor-pointer",
+                  isActive
+                    ? "text-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                <Icon
+                  className={cn(
+                    "h-5 w-5 shrink-0",
+                    isActive && "text-primary"
+                  )}
+                />
+                <span>{tab.label}</span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/src/components/layout/viewer-toolbar.tsx
+++ b/src/components/layout/viewer-toolbar.tsx
@@ -39,12 +39,12 @@ export function ViewerToolbar({
   return (
     <div
       className={cn(
-        "flex shrink-0 items-center justify-between gap-3 border-b border-border/70 bg-background/95 px-4 py-2.5 transition-[padding] duration-200 sm:px-6",
+        "flex shrink-0 items-center justify-between gap-2 border-b border-border/70 bg-background/95 px-3 py-2 transition-[padding] duration-200 sm:gap-3 sm:px-4 sm:py-2.5 md:px-6",
         className
       )}
-      style={{ paddingLeft: `calc(1rem + var(--sidebar-toggle-offset, 0px))` }}
+      style={{ paddingLeft: `calc(0.75rem + var(--sidebar-toggle-offset, 0px))` }}
     >
-      <div className="flex min-w-0 flex-1 items-center gap-2">
+      <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
         <ReturnToChip />
         {leading}
         {showBreadcrumb && path ? <ViewerBreadcrumb path={path} /> : null}
@@ -54,7 +54,9 @@ export function ViewerToolbar({
           </span>
         )}
         {sublabel && (
-          <span className="shrink-0 text-xs text-muted-foreground/40">{sublabel}</span>
+          <span className="hidden shrink-0 text-xs text-muted-foreground/40 sm:inline">
+            {sublabel}
+          </span>
         )}
       </div>
       <div className="flex shrink-0 items-center gap-1">

--- a/src/components/onboarding/tour/slide-agents.tsx
+++ b/src/components/onboarding/tour/slide-agents.tsx
@@ -13,8 +13,8 @@ export function SlideAgents() {
     { name: t("slideAgents:otherOrganizer"), icon: FolderTree, tone: "#9678BA" },
   ];
   return (
-    <div className="grid h-full grid-cols-[minmax(260px,320px)_1fr] gap-10 lg:gap-14 items-center">
-      <div className="h-[440px] w-full">
+    <div className="flex h-full flex-col items-center gap-6 md:grid md:grid-cols-[minmax(260px,320px)_1fr] md:gap-10 md:items-center lg:gap-14">
+      <div className="order-2 h-[420px] w-full max-w-[300px] md:order-1 md:h-[440px] md:max-w-none">
         <MockupSidebar activeTab="agents" viewTransitionName="cabinet-card">
           <div className="relative flex h-full flex-col gap-2 px-2.5 py-2">
             {/* Other agents fade in then fade out */}
@@ -140,7 +140,7 @@ export function SlideAgents() {
       </div>
 
       {/* Copy */}
-      <div className="flex flex-col gap-5 max-w-lg">
+      <div className="order-1 flex flex-col items-center gap-3 max-w-lg text-center md:order-2 md:items-start md:gap-5 md:text-start">
         <span
           className="inline-block w-fit rounded-full px-3 py-1 text-[10px] font-semibold tracking-[0.18em] opacity-0"
           style={{
@@ -154,7 +154,7 @@ export function SlideAgents() {
           {t("slideAgents:slideNum")}
         </span>
         <h2
-          className="font-logo text-4xl italic tracking-tight opacity-0 lg:text-5xl"
+          className="font-logo text-3xl italic tracking-tight opacity-0 md:text-4xl lg:text-5xl"
           style={{
             color: P.text,
             animation: "cabinet-tour-fade-up 0.5s ease-out forwards",

--- a/src/components/onboarding/tour/slide-data.tsx
+++ b/src/components/onboarding/tour/slide-data.tsx
@@ -407,11 +407,10 @@ export function SlideData({ sceneIdx, viewerRevealed }: SlideDataProps) {
 
   return (
     <div
-      className="grid h-full items-center gap-8 lg:gap-10"
-      style={{ gridTemplateColumns: "280px 340px 1fr" }}
+      className="cabinet-tour-data-grid flex h-full flex-col items-center gap-6 md:grid md:items-center md:gap-8 lg:gap-10"
     >
       {/* ── Column 1: Sidebar + caption ─── */}
-      <div className="flex h-[500px] w-full flex-col gap-3">
+      <div className="order-2 flex h-[440px] w-full max-w-[260px] flex-col gap-3 md:order-1 md:h-[500px] md:max-w-none">
         <div
           className="h-[440px] w-full opacity-0"
           style={{ animation: "cabinet-tour-fade-up 0.4s ease-out forwards", animationDelay: "0ms" }}
@@ -525,7 +524,7 @@ export function SlideData({ sceneIdx, viewerRevealed }: SlideDataProps) {
       </div>
 
       {/* ── Column 2: File viewer panel — appears last ─── */}
-      <div className="h-[440px] w-full">
+      <div className="order-3 hidden h-[440px] w-full md:order-2 md:block">
         <div
           key={scene.id + "-viewer"}
           className="h-full w-full opacity-0"
@@ -546,7 +545,7 @@ export function SlideData({ sceneIdx, viewerRevealed }: SlideDataProps) {
       </div>
 
       {/* ── Column 3: Copy — appears first ─── */}
-      <div className="flex flex-col gap-5 max-w-md">
+      <div className="order-1 flex flex-col items-center gap-3 max-w-md text-center md:order-3 md:items-start md:gap-5 md:text-start">
         <span
           className="inline-block w-fit rounded-full px-3 py-1 text-[10px] font-semibold tracking-[0.18em] opacity-0"
           style={{
@@ -560,7 +559,7 @@ export function SlideData({ sceneIdx, viewerRevealed }: SlideDataProps) {
           {t("slideDataCopy:slideNum")}
         </span>
         <h2
-          className="font-logo text-4xl italic tracking-tight opacity-0 lg:text-5xl"
+          className="font-logo text-3xl italic tracking-tight opacity-0 md:text-4xl lg:text-5xl"
           style={{
             color: P.text,
             animation: "cabinet-tour-fade-up 0.35s ease-out forwards",

--- a/src/components/onboarding/tour/slide-tasks.tsx
+++ b/src/components/onboarding/tour/slide-tasks.tsx
@@ -26,8 +26,8 @@ export function SlideTasks() {
   const { t } = useLocale();
   const TYPED_COMMAND = t("slideTasks:typedCommand");
   return (
-    <div className="grid h-full grid-cols-[minmax(360px,420px)_1fr] gap-10 lg:gap-14 items-center">
-      <div className="h-[440px] w-full">
+    <div className="flex h-full flex-col items-center gap-6 md:grid md:grid-cols-[minmax(360px,420px)_1fr] md:gap-10 md:items-center lg:gap-14">
+      <div className="order-2 h-[420px] w-full max-w-[320px] md:order-1 md:h-[440px] md:max-w-none">
         <MockupSidebar activeTab="tasks" viewTransitionName="cabinet-card">
           <div className="flex h-full flex-col gap-2 px-2 py-2">
             {/* Composer */}
@@ -174,7 +174,7 @@ export function SlideTasks() {
       </div>
 
       {/* Copy */}
-      <div className="flex flex-col gap-5 max-w-lg">
+      <div className="order-1 flex flex-col items-center gap-3 max-w-lg text-center md:order-2 md:items-start md:gap-5 md:text-start">
         <span
           className="inline-block w-fit rounded-full px-3 py-1 text-[10px] font-semibold tracking-[0.18em] opacity-0"
           style={{
@@ -188,7 +188,7 @@ export function SlideTasks() {
           {t("slideTasks:slideNum")}
         </span>
         <h2
-          className="font-logo text-4xl italic tracking-tight opacity-0 lg:text-5xl"
+          className="font-logo text-3xl italic tracking-tight opacity-0 md:text-4xl lg:text-5xl"
           style={{
             color: P.text,
             animation: "cabinet-tour-fade-up 0.5s ease-out forwards",

--- a/src/components/onboarding/tour/tour-modal.tsx
+++ b/src/components/onboarding/tour/tour-modal.tsx
@@ -128,7 +128,7 @@ function TourBody({
 
   return (
     <div
-      className="fixed inset-0 z-[200] flex items-center justify-center backdrop-blur-md"
+      className="fixed inset-0 z-[200] flex flex-col backdrop-blur-md"
       role="dialog"
       aria-modal="true"
       aria-label={t("tour:ariaLabel")}
@@ -143,11 +143,11 @@ function TourBody({
         }}
       />
 
-      {/* Skip / close */}
+      {/* Skip / close — tighter offset on mobile so it doesn't crowd the slide */}
       <button
         onClick={onClose}
         aria-label={t("tour:skipAriaLabel")}
-        className="absolute right-6 top-6 flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[12px] transition-colors"
+        className="absolute end-4 top-4 z-10 flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[12px] transition-colors sm:end-6 sm:top-6"
         style={{
           color: P.textSecondary,
           background: P.bgCard,
@@ -158,24 +158,29 @@ function TourBody({
         <X className="h-3.5 w-3.5" />
       </button>
 
-      {/* Slide stage */}
-      <div className="relative flex h-full w-full max-w-6xl flex-col px-10 py-16 lg:px-14">
+      {/* Slide stage — scrolls vertically on mobile; centered/static on desktop */}
+      <div className="relative mx-auto flex w-full max-w-6xl flex-1 min-h-0 flex-col overflow-y-auto px-4 pb-4 pt-16 sm:px-10 sm:pt-16 lg:px-14">
         <div
           key={current.stageKey}
-          className="cabinet-tour-animated flex-1"
+          className="cabinet-tour-animated flex flex-1 min-h-0 items-center justify-center"
         >
           {current.id === "data-0"
             ? <SlideData sceneIdx={0} viewerRevealed={viewerRevealed} />
             : current.render()}
         </div>
+      </div>
 
-        {/* Footer nav */}
-        <div className="mt-8 flex items-center justify-between gap-4">
+      {/* Footer nav — pinned at the bottom of the modal so it never scrolls off-screen */}
+      <div
+        className="shrink-0 px-4 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-3 sm:px-10 sm:pt-4 lg:px-14"
+        style={{ borderTop: `1px solid ${P.border}` }}
+      >
+        <div className="mx-auto flex w-full max-w-6xl items-center justify-between gap-3">
           {/* Back */}
           <button
             onClick={back}
             disabled={index === 0}
-            className="flex items-center gap-1.5 rounded-full px-4 py-2 text-[12px] font-medium transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+            className="flex items-center gap-1.5 rounded-full px-3 py-2 text-[12px] font-medium transition-colors disabled:opacity-30 disabled:cursor-not-allowed sm:px-4"
             style={{
               color: P.textSecondary,
               background: P.bgCard,
@@ -183,11 +188,11 @@ function TourBody({
             }}
           >
             <DirIcon ltr={ArrowLeft} rtl={ArrowRight} className="h-3.5 w-3.5" />
-            {t("tour:back")}
+            <span className="hidden sm:inline">{t("tour:back")}</span>
           </button>
 
           {/* Progress dots */}
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1.5 sm:gap-2">
             {SLIDES.map((s, i) => (
               <button
                 key={s.id}
@@ -207,14 +212,15 @@ function TourBody({
           {isLast ? (
             <button
               onClick={finish}
-              className="group flex items-center gap-2 rounded-full px-5 py-2.5 text-[13px] font-semibold text-white transition-all hover:-translate-y-px"
+              className="group flex items-center gap-2 rounded-full px-4 py-2.5 text-[13px] font-semibold text-white transition-all hover:-translate-y-px sm:px-5"
               style={{
                 background: P.accent,
                 boxShadow: `0 10px 25px -10px ${P.accent}80`,
               }}
             >
               <Sparkles className="h-4 w-4" />
-              {t("tour:writeFirstTask")}
+              <span className="hidden sm:inline">{t("tour:writeFirstTask")}</span>
+              <span className="sm:hidden">{t("tour:next")}</span>
               <DirIcon
                 ltr={ArrowRight}
                 rtl={ArrowLeft}
@@ -224,7 +230,7 @@ function TourBody({
           ) : (
             <button
               onClick={next}
-              className="flex items-center gap-1.5 rounded-full px-5 py-2 text-[12px] font-semibold transition-all hover:-translate-y-px"
+              className="flex items-center gap-1.5 rounded-full px-4 py-2 text-[12px] font-semibold transition-all hover:-translate-y-px sm:px-5"
               style={{ background: P.text, color: P.paper }}
             >
               {t("tour:next")}

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -294,16 +294,13 @@ export function Sidebar() {
           />
         </div>
       )}
-      {collapsed && (
+      {collapsed && !isMobile && (
         <Button
           variant="ghost"
           size="icon"
           aria-label={t("sidebar:expandSidebar")}
           title={t("sidebar:expandSidebar")}
-          className={cn(
-            "absolute top-3 h-7 w-7",
-            isMobile ? "start-3 z-50" : "start-2 z-20"
-          )}
+          className="absolute top-3 start-2 z-20 h-7 w-7"
           onClick={() => setCollapsed(false)}
         >
           <PanelLeft className="h-4 w-4 rtl:rotate-180" />

--- a/src/components/tasks/board/filter-bar.tsx
+++ b/src/components/tasks/board/filter-bar.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { Users, Check, ChevronDown } from "lucide-react";
+import {
+  Users,
+  Check,
+  ChevronDown,
+  ListFilter,
+  Bot,
+  Clock3,
+  HeartPulse,
+} from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -177,6 +185,112 @@ export function AgentFilterDropdown({
                 </span>
               </span>
               {active && <Check className="size-3.5 text-primary" />}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+const TRIGGER_OPTIONS: {
+  value: TriggerFilter;
+  label: string;
+  description: string;
+  icon: typeof Bot;
+}[] = [
+  {
+    value: "all",
+    label: "All",
+    description: "Every task, regardless of how it started",
+    icon: ListFilter,
+  },
+  {
+    value: "manual",
+    label: "Manual",
+    description: "Tasks you launched directly",
+    icon: Bot,
+  },
+  {
+    value: "job",
+    label: "Jobs",
+    description: "Scheduled recurring runs",
+    icon: Clock3,
+  },
+  {
+    value: "heartbeat",
+    label: "Heartbeat",
+    description: "Self-directed agent runs",
+    icon: HeartPulse,
+  },
+];
+
+/**
+ * Trigger filter as a dropdown — replaces the inline All/Manual/Jobs/Heartbeat
+ * chip row. Styled to match DepthDropdown / AgentFilterDropdown so the board
+ * header reads as one consistent set of filter controls (and so it doesn't
+ * overflow on narrow viewports).
+ */
+export function TriggerFilterDropdown({
+  value,
+  onChange,
+  count,
+  className,
+}: {
+  value: TriggerFilter;
+  onChange: (next: TriggerFilter) => void;
+  /** Shown next to the trigger label when "all" is selected. */
+  count?: React.ReactNode;
+  className?: string;
+}) {
+  const current =
+    TRIGGER_OPTIONS.find((o) => o.value === value) ?? TRIGGER_OPTIONS[0];
+  const CurrentIcon = current.icon;
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        title={`Filter by trigger: ${current.label}`}
+        aria-label={`Filter by trigger: ${current.label}`}
+        className={cn(
+          "inline-flex h-7 items-center gap-1.5 rounded-md border border-border/70 bg-card/60 px-2 text-[11px] text-foreground/80 transition-colors hover:bg-accent hover:text-foreground hover:border-border data-[popup-open]:bg-accent",
+          value !== "all" && "border-primary/60",
+          className
+        )}
+      >
+        <CurrentIcon className="size-3" />
+        <span className="font-medium">{current.label}</span>
+        {value === "all" && count != null && (
+          <span className="tabular-nums opacity-60">{count}</span>
+        )}
+        <ChevronDown className="size-3 opacity-60" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-[240px]">
+        <div className="px-2 pt-1.5 pb-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/70">
+          Filter by trigger
+        </div>
+        {TRIGGER_OPTIONS.map((opt) => {
+          const active = opt.value === value;
+          const Icon = opt.icon;
+          return (
+            <DropdownMenuItem
+              key={opt.value}
+              onClick={() => onChange(opt.value)}
+              className="flex items-start justify-between gap-3 py-1.5"
+            >
+              <span className="flex items-start gap-2">
+                <Icon className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+                <span className="flex flex-col gap-0.5">
+                  <span className="text-[12.5px] leading-tight">
+                    {opt.label}
+                  </span>
+                  <span className="text-[11px] leading-tight text-muted-foreground/80">
+                    {opt.description}
+                  </span>
+                </span>
+              </span>
+              {active && (
+                <Check className="mt-1 size-3.5 shrink-0 text-primary" />
+              )}
             </DropdownMenuItem>
           );
         })}

--- a/src/components/tasks/board/kanban-view.tsx
+++ b/src/components/tasks/board/kanban-view.tsx
@@ -374,7 +374,7 @@ export function KanbanView({
   }
 
   return (
-    <div className="flex min-h-0 w-full min-w-0 flex-1 gap-3 overflow-x-auto overflow-y-hidden p-4">
+    <div className="flex min-h-0 w-full min-w-0 flex-1 gap-3 overflow-x-auto overflow-y-hidden p-4 snap-x snap-mandatory md:snap-none">
       {LANES.map((lane) => {
         const allItems = byLane[lane.key];
         const isArchive = lane.key === "archive";
@@ -398,8 +398,8 @@ export function KanbanView({
             key={lane.key}
             lane={lane.key}
             className={cn(
-              "flex min-h-0 shrink-0 flex-col rounded-lg border border-border/60 bg-muted/20",
-              collapsed ? "w-12" : "w-[280px]"
+              "flex min-h-0 shrink-0 flex-col rounded-lg border border-border/60 bg-muted/20 snap-start",
+              collapsed ? "w-12" : "w-[85vw] max-w-[280px] md:w-[280px]"
             )}
           >
             {collapsed ? (

--- a/src/components/tasks/board/tasks-board.tsx
+++ b/src/components/tasks/board/tasks-board.tsx
@@ -5,10 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import {
   ArrowLeft,
   ArrowRightLeft,
-  Bot,
   ChevronDown,
-  Clock3,
-  HeartPulse,
   Loader2,
   Plus,
   Repeat,
@@ -38,7 +35,11 @@ import { ScheduleView } from "./schedule-view";
 import { DetailPanel } from "./detail-panel";
 import { ViewToggle, type BoardViewMode } from "./view-toggle";
 import { DensityToggle, type BoardDensity } from "./density-toggle";
-import { AgentFilterDropdown, TriggerChip, type TriggerFilter } from "./filter-bar";
+import {
+  AgentFilterDropdown,
+  TriggerFilterDropdown,
+  type TriggerFilter,
+} from "./filter-bar";
 import { UndoToast, type PendingUndo } from "./undo-toast";
 import { ConfirmPopover, type PendingConfirm } from "./confirm-popover";
 import { StartWorkDialog, type StartWorkMode } from "@/components/composer/start-work-dialog";
@@ -290,47 +291,17 @@ export function TasksBoard({
 
           <div className="h-3.5 w-px bg-border/60" />
 
-          {/* trigger filter chips — "All" carries the task count */}
-          <div className="flex items-center gap-1">
-            <TriggerChip
-              active={triggerFilter === "all"}
-              onClick={() => setTriggerFilter("all")}
-              count={
-                agentFilter
-                  ? `${filteredTasks.length}/${tasks.length}`
-                  : tasks.length
-              }
-            >
-              All
-            </TriggerChip>
-            <TriggerChip
-              active={triggerFilter === "manual"}
-              onClick={() => setTriggerFilter("manual")}
-              icon={<Bot className="size-3" />}
-              tone="sky"
-              title={t("tasksBoard:manualTooltip")}
-            >
-              Manual
-            </TriggerChip>
-            <TriggerChip
-              active={triggerFilter === "job"}
-              onClick={() => setTriggerFilter("job")}
-              icon={<Clock3 className="size-3" />}
-              tone="emerald"
-              title={t("tasksBoard:jobsTooltip")}
-            >
-              Jobs
-            </TriggerChip>
-            <TriggerChip
-              active={triggerFilter === "heartbeat"}
-              onClick={() => setTriggerFilter("heartbeat")}
-              icon={<HeartPulse className="size-3" />}
-              tone="pink"
-              title={t("tasksBoard:heartbeatTooltip")}
-            >
-              Heartbeat
-            </TriggerChip>
-          </div>
+          {/* trigger filter — dropdown, styled like the cabinet-scope and
+              agent-filter dropdowns. "All" carries the task count. */}
+          <TriggerFilterDropdown
+            value={triggerFilter}
+            onChange={setTriggerFilter}
+            count={
+              agentFilter
+                ? `${filteredTasks.length}/${tasks.length}`
+                : tasks.length
+            }
+          />
 
           {selection.size > 0 && (
             <>

--- a/src/hooks/use-is-mobile.ts
+++ b/src/hooks/use-is-mobile.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+export const MOBILE_BREAKPOINT = 768;
+
+function subscribe(onChange: () => void) {
+  const media = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+  media.addEventListener("change", onChange);
+  window.addEventListener("resize", onChange);
+  return () => {
+    media.removeEventListener("change", onChange);
+    window.removeEventListener("resize", onChange);
+  };
+}
+
+export function useIsMobile() {
+  return useSyncExternalStore(
+    subscribe,
+    () => window.innerWidth < MOBILE_BREAKPOINT,
+    () => false
+  );
+}


### PR DESCRIPTION
## Summary

Makes Cabinet usable on phones (375–430px) without regressing desktop. Picks up the intent of the long-stalled #21.

- **Native-feeling shell** — fixed bottom-tab nav (Home / Agents / Tasks / AI / Menu, 56px targets, safe-area inset, `md:hidden`); status bar + narrow-viewport hint hidden on mobile; shared `useIsMobile` hook.
- **AI panel** — full-screen overlay + scrim on mobile (`max-md:fixed inset-0 z-50`); unchanged 480px side-rail on desktop.
- **Agents / Tasks headers** — flex-wrap; agents tab strip drops to its own row on mobile; kanban columns `w-[85vw]` with `snap-x mandatory`.
- **Onboarding tour** — modal is now a flex column with scrollable middle + pinned footer (Back/dots/Next no longer clipped off-screen at 375); slides stack single-column on mobile, full multi-column at md+.
- **Tasks trigger filter** — All/Manual/Jobs/Heartbeat moved from an inline chip row into a dropdown styled like the cabinet-scope / agent-filter dropdowns.

Rebased onto latest `main` (resolved one conflict in `agents/v2/tabs-layout.tsx` — kept the new i18n strings + the mobile-responsive classes). `tsc --noEmit` passes.

Full before/after audit with screenshots lives in the audits cabinet (`audit-2026-05-15-mobile-responsive`, 10 findings, all fixed) — not in git since `data/` is gitignored.

## Test plan

- [ ] Home / Agents / Tasks / Settings / Help at 375 — no horizontal scroll, bottom nav reachable
- [ ] AI tab opens full-screen overlay; scrim dismisses it
- [ ] Onboarding tour: all 7 slides show Back/dots/Next within the viewport at 375
- [ ] Tasks trigger dropdown selects + persists; count rides "All"
- [ ] Desktop 1440 unchanged: sidebar, status bar, AI side-rail, 3-column tour

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile navigation bar for quick access to Home, Agents, Tasks, AI, and Menu sections
  * Implemented full-screen mobile overlay for the AI assistant panel
  * Added trigger filter dropdown for task management

* **Documentation**
  * Added mobile responsiveness reference documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hilash/cabinet/pull/87)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->