### PR TITLE
fix(tasks): surface Codex failures immediately with actionable error …

### DIFF
--- a/server/cabinet-daemon.ts
+++ b/server/cabinet-daemon.ts
@@ -472,10 +472,6 @@ async function finalizeSessionConversation(session: ActiveSession): Promise<void
   }
 
   const plain = stripAnsi(session.output.join(""));
-  if (meta.status !== "running") {
-    completedOutput.set(session.id, { output: plain, completedAt: Date.now() });
-    return;
-  }
   const adapterUsage =
     session.kind === "structured" ? session.adapterUsage ?? null : null;
   const adapterErrorKind =
@@ -484,6 +480,47 @@ async function finalizeSessionConversation(session: ActiveSession): Promise<void
     session.kind === "structured" ? session.adapterErrorHint ?? null : null;
   const adapterErrorRetryAfterSec =
     session.kind === "structured" ? session.adapterErrorRetryAfterSec ?? null : null;
+  const completedPayload = {
+    output: plain,
+    completedAt: Date.now(),
+    status:
+      session.resolvedStatus ??
+      (session.exitCode === 0 ? "completed" : "failed"),
+    exitCode: session.exitCode,
+    adapterErrorKind,
+    adapterErrorHint,
+    adapterErrorRetryAfterSec,
+  };
+
+  if (meta.status !== "running") {
+    completedOutput.set(session.id, completedPayload);
+    // Transcript-driven finalize can flip meta to failed before the adapter
+    // child exits and classification runs — patch missing hints here.
+    if (
+      session.kind === "structured" &&
+      completedPayload.status === "failed" &&
+      !meta.errorHint?.trim() &&
+      adapterErrorHint?.trim()
+    ) {
+      await finalizeConversation(
+        session.id,
+        {
+          status: "failed",
+          exitCode: session.exitCode ?? meta.exitCode ?? 1,
+          errorKind: adapterErrorKind ?? undefined,
+          errorHint: adapterErrorHint ?? undefined,
+          errorRetryAfterSec: adapterErrorRetryAfterSec ?? undefined,
+        },
+        meta.cabinetPath
+      ).catch((err) => {
+        console.warn(
+          `[cabinet-daemon] failed to patch error hints for ${session.id}:`,
+          err
+        );
+      });
+    }
+    return;
+  }
 
   // For legacy PTY sessions, substitute a distilled 1-liner for summary
   // extraction so the task detail doesn't render random box-drawing chars as
@@ -908,8 +945,21 @@ function createStructuredSession(input: {
       }
 
       const plain = stripAnsi(session.output.join(""));
-      completedOutput.set(input.sessionId, { output: plain, completedAt: Date.now() });
-      await finalizeSessionConversation(session).catch(() => {});
+      completedOutput.set(input.sessionId, {
+        output: plain,
+        completedAt: Date.now(),
+        status: session.resolvedStatus ?? (session.exitCode === 0 ? "completed" : "failed"),
+        exitCode: session.exitCode,
+        adapterErrorKind: session.adapterErrorKind ?? null,
+        adapterErrorHint: session.adapterErrorHint ?? null,
+        adapterErrorRetryAfterSec: session.adapterErrorRetryAfterSec ?? null,
+      });
+      await finalizeSessionConversation(session).catch((err) => {
+        console.warn(
+          `[cabinet-daemon] finalizeSessionConversation failed for ${input.sessionId}:`,
+          err
+        );
+      });
 
       // Persist the adapter's resume handle + codec blob to the conversation
       // directory so future continues can resume. This only works when the
@@ -972,8 +1022,21 @@ function createStructuredSession(input: {
       }
       clearSessionStopFallbackTimer(session);
       const plain = stripAnsi(session.output.join(""));
-      completedOutput.set(input.sessionId, { output: plain, completedAt: Date.now() });
-      await finalizeSessionConversation(session).catch(() => {});
+      completedOutput.set(input.sessionId, {
+        output: plain,
+        completedAt: Date.now(),
+        status: session.resolvedStatus ?? (session.exitCode === 0 ? "completed" : "failed"),
+        exitCode: session.exitCode,
+        adapterErrorKind: session.adapterErrorKind ?? null,
+        adapterErrorHint: session.adapterErrorHint ?? null,
+        adapterErrorRetryAfterSec: session.adapterErrorRetryAfterSec ?? null,
+      });
+      await finalizeSessionConversation(session).catch((err) => {
+        console.warn(
+          `[cabinet-daemon] finalizeSessionConversation failed for ${input.sessionId}:`,
+          err
+        );
+      });
 
       if (session.ws && session.ws.readyState === WebSocket.OPEN) {
         sessions.delete(input.sessionId);
@@ -1428,6 +1491,19 @@ const server = http.createServer(async (req, res) => {
     }
 
     const conversationMeta = await readConversationMeta(sessionId).catch(() => null);
+    const completed = completedOutput.get(sessionId);
+    if (completed && completed.status && completed.status !== "running") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          sessionId,
+          status: completed.status,
+          output: completed.output,
+        })
+      );
+      return;
+    }
+
     if (conversationMeta) {
       const transcript = await readConversationTranscript(sessionId).catch(() => "");
       const plainTranscript = stripAnsi(transcript);
@@ -1477,10 +1553,15 @@ const server = http.createServer(async (req, res) => {
       return;
     }
 
-    const completed = completedOutput.get(sessionId);
     if (completed) {
       res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ sessionId, status: "completed", output: completed.output }));
+      res.end(
+        JSON.stringify({
+          sessionId,
+          status: completed.status ?? "completed",
+          output: completed.output,
+        })
+      );
       return;
     }
 
@@ -1488,8 +1569,6 @@ const server = http.createServer(async (req, res) => {
     res.end(JSON.stringify({ error: "Session not found" }));
     return;
   }
-
-  // POST /sessions — create a detached session without a WebSocket (for agent heartbeats)
   if (url.pathname === "/sessions" && req.method === "POST") {
     let body = "";
     req.on("data", (chunk) => (body += chunk));

--- a/server/pty/types.ts
+++ b/server/pty/types.ts
@@ -68,4 +68,9 @@ export interface PtySession extends BaseSession {
 export interface CompletedOutputEntry {
   output: string;
   completedAt: number;
+  status?: "running" | "completed" | "failed";
+  exitCode?: number | null;
+  adapterErrorKind?: string | null;
+  adapterErrorHint?: string | null;
+  adapterErrorRetryAfterSec?: number | null;
 }

--- a/src/app/api/agents/conversations/[id]/route.ts
+++ b/src/app/api/agents/conversations/[id]/route.ts
@@ -16,6 +16,8 @@ import { normalizeRuntimeOverride } from "@/lib/agents/runtime-overrides";
 import { publishConversationEvent } from "@/lib/agents/conversation-events";
 import type { ConversationMeta } from "@/types/conversations";
 
+export const dynamic = "force-dynamic";
+
 export async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> }

--- a/src/app/api/agents/conversations/[id]/route.ts
+++ b/src/app/api/agents/conversations/[id]/route.ts
@@ -40,11 +40,21 @@ export async function DELETE(
 ) {
   const { id } = await params;
   const cabinetPath = req.nextUrl.searchParams.get("cabinetPath") || undefined;
-  const deleted = await deleteConversation(id, cabinetPath);
+  const meta = await readConversationMeta(id, cabinetPath);
+  if (!meta) {
+    return NextResponse.json({ error: "Conversation not found" }, { status: 404 });
+  }
 
+  const deleted = await deleteConversation(id, cabinetPath);
   if (!deleted) {
     return NextResponse.json({ error: "Conversation not found" }, { status: 404 });
   }
+
+  publishConversationEvent({
+    type: "task.deleted",
+    taskId: id,
+    cabinetPath: meta.cabinetPath ?? cabinetPath,
+  });
 
   return NextResponse.json({ ok: true });
 }

--- a/src/components/sidebar/recent-tasks.tsx
+++ b/src/components/sidebar/recent-tasks.tsx
@@ -155,8 +155,13 @@ export function RecentTasks({
     };
     es.onmessage = (msg) => {
       try {
-        const event = JSON.parse(msg.data) as { type: string };
+        const event = JSON.parse(msg.data) as { type: string; taskId?: string };
         if (event.type === "ping") return;
+        if (event.type === "task.deleted" && event.taskId) {
+          setTasks((prev) =>
+            prev ? prev.filter((task) => task.id !== event.taskId) : prev
+          );
+        }
         scheduleReload();
       } catch {
         // ignore

--- a/src/components/tasks/board/board-actions.ts
+++ b/src/components/tasks/board/board-actions.ts
@@ -1,5 +1,8 @@
 "use client";
 
+import { invalidateDedupFetch } from "@/lib/api/dedup-fetch";
+import { useAppStore } from "@/stores/app-store";
+
 /**
  * Thin client helpers for the v2 task board's write actions. Each maps to a
  * PATCH on /api/agents/conversations/[id]. Server shape is defined in
@@ -131,6 +134,13 @@ export async function deleteConversation(
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(`delete ${id} failed: ${res.status} ${text}`);
+  }
+
+  invalidateDedupFetch("/api/agents/conversations");
+
+  const open = useAppStore.getState().taskPanelConversation;
+  if (open?.id === id) {
+    useAppStore.getState().setTaskPanelConversation(null);
   }
 }
 

--- a/src/components/tasks/board/use-board-data.ts
+++ b/src/components/tasks/board/use-board-data.ts
@@ -142,8 +142,16 @@ export function useBoardData({ cabinetPath, visibilityMode = "own" }: Options): 
     let debounceTimer: ReturnType<typeof setTimeout> | null = null;
     es.onmessage = (msg) => {
       try {
-        const event = JSON.parse(msg.data) as { type?: string };
+        const event = JSON.parse(msg.data) as {
+          type?: string;
+          taskId?: string;
+        };
         if (!event.type || event.type === "ping") return;
+        if (event.type === "task.deleted" && event.taskId) {
+          setConversations((prev) =>
+            prev.filter((conversation) => conversation.id !== event.taskId)
+          );
+        }
         if (debounceTimer) clearTimeout(debounceTimer);
         debounceTimer = setTimeout(() => {
           void refreshConversations();

--- a/src/components/tasks/conversation/task-conversation-page.tsx
+++ b/src/components/tasks/conversation/task-conversation-page.tsx
@@ -69,6 +69,61 @@ import { compactTask, fetchTask, patchTask, postTurn } from "@/lib/agents/task-c
 import { peekTaskIsTerminal } from "@/lib/agents/terminal-mode-cache";
 import { buildRuntimeLabel } from "@/lib/agents/runtime-format";
 
+/** Map ConversationMeta.status from SSE payloads → Task UI status. */
+function conversationStatusToTaskStatus(status: string): TaskStatus | null {
+  if (status === "failed") return "failed";
+  if (status === "completed") return "idle";
+  if (status === "running") return "running";
+  return null;
+}
+
+/** Clear pending and backfill empty agent bubbles on quick failures. */
+function fillEmptyAgentTurnContent(task: Task, status: TaskStatus): Task {
+  const failedFallback =
+    task.meta.errorHint?.trim() ||
+    "The agent run failed before producing a response.";
+  return {
+    ...task,
+    turns: task.turns.map((turn) => {
+      if (turn.role !== "agent") {
+        return turn.pending ? { ...turn, pending: undefined } : turn;
+      }
+      const content =
+        turn.content.trim() ||
+        (status === "failed" ? failedFallback : turn.content);
+      return { ...turn, pending: undefined, content };
+    }),
+  };
+}
+
+/** Apply a terminal task.updated payload without waiting on refetch. */
+function applyTerminalPayloadToTask(
+  prev: Task,
+  payload: Record<string, unknown> | undefined
+): Task | null {
+  if (!payload || payload.streaming === true) return null;
+  const raw = payload.status;
+  if (typeof raw !== "string") return null;
+  const taskStatus = conversationStatusToTaskStatus(raw);
+  if (!taskStatus || taskStatus === "running") return null;
+  if (prev.meta.status === taskStatus) return null;
+  const errorHint =
+    typeof payload.errorHint === "string"
+      ? payload.errorHint
+      : prev.meta.errorHint;
+  const errorKind =
+    typeof payload.errorKind === "string"
+      ? payload.errorKind
+      : prev.meta.errorKind;
+  return fillEmptyAgentTurnContent(
+    {
+      ...prev,
+      meta: { ...prev.meta, status: taskStatus, errorHint, errorKind },
+    },
+    taskStatus
+  );
+}
+
 const STATUS_META: Record<
   TaskStatus,
   { label: string; tone: string; icon: React.ComponentType<{ className?: string }> }
@@ -333,6 +388,7 @@ export interface TaskConversationPageProps {
   returnContext?: import("@/stores/app-store").SelectedSection;
 }
 
+/** Dev-only on-page log strip — survives Next.js removeConsole for console.log. */
 export function TaskConversationPage({
   taskId,
   cabinetPath,
@@ -360,6 +416,11 @@ export function TaskConversationPage({
   const [busy, setBusy] = useState(false);
   const settleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const chatScrollRef = useRef<HTMLDivElement>(null);
+  const prevTaskStatusRef = useRef<TaskStatus | null>(null);
+
+  useEffect(() => {
+    prevTaskStatusRef.current = null;
+  }, [taskId, cabinetPath, variant, isDemo]);
 
   // Callback ref on the panel root: scroll doesn't bubble, so we listen in
   // the capture phase to catch scrolling inside any tab's content. A
@@ -558,7 +619,9 @@ export function TaskConversationPage({
     setLoadError(null);
     setConnectTimedOut(false);
     const watchdog = setTimeout(() => {
-      if (!cancelled) setConnectTimedOut(true);
+      if (!cancelled) {
+        setConnectTimedOut(true);
+      }
     }, 8000);
     fetchTask(taskId, cabinetPath || undefined)
       .then((t) => {
@@ -622,12 +685,22 @@ export function TaskConversationPage({
       try {
         const event = JSON.parse(msg.data) as TaskEvent | { type: "ping" };
         if (event.type === "ping") return;
-        if (event.type === "task.deleted") return;
+        if (event.type === "task.deleted") {
+          return;
+        }
+        const eventPayload =
+          "payload" in event && event.payload
+            ? (event.payload as Record<string, unknown>)
+            : undefined;
+        setTask((prev) => {
+          if (!prev) return prev;
+          return applyTerminalPayloadToTask(prev, eventPayload) ?? prev;
+        });
         // Re-fetch on any task/turn event — simple, durable
-        const fresh = await fetchTask(taskId);
+        const fresh = await fetchTask(taskId, cabinetPath || undefined);
         setTask(fresh);
       } catch {
-        // ignore malformed events
+        // ignore malformed frames / transient fetch errors
       }
     };
     es.onerror = () => {
@@ -636,7 +709,157 @@ export function TaskConversationPage({
     return () => {
       es.close();
     };
-  }, [isDemo, taskId]);
+  }, [isDemo, taskId, cabinetPath]);
+
+  // Global conversation bus — catches task.updated events published on the
+  // Next.js side (e.g. waitForConversationCompletion) even when the
+  // per-conversation SSE reconnects late. Debounced to match the board.
+  useEffect(() => {
+    if (isDemo) return;
+    const es = new EventSource("/api/agents/conversations/events");
+    let debounce: ReturnType<typeof setTimeout> | null = null;
+    const scheduleRefetch = (_reason: string) => {
+      if (debounce) clearTimeout(debounce);
+      debounce = setTimeout(() => {
+        void fetchTask(taskId, cabinetPath || undefined)
+          .then((fresh) => {
+            setTask(fresh);
+          })
+          .catch(() => {});
+      }, 200);
+    };
+    es.onmessage = (msg) => {
+      try {
+        const event = JSON.parse(msg.data) as TaskEvent | { type: "ping" };
+        if (event.type === "ping") return;
+        if ("taskId" in event && event.taskId && event.taskId !== taskId) return;
+        const eventPayload =
+          "payload" in event && event.payload
+            ? (event.payload as Record<string, unknown>)
+            : undefined;
+        setTask((prev) => {
+          if (!prev) return prev;
+          return applyTerminalPayloadToTask(prev, eventPayload) ?? prev;
+        });
+        scheduleRefetch(event.type);
+      } catch {
+        // ignore malformed frames
+      }
+    };
+    return () => {
+      if (debounce) clearTimeout(debounce);
+      es.close();
+    };
+  }, [isDemo, taskId, cabinetPath]);
+
+  // When the app-shell completion toast fires, mirror the terminal status
+  // into the open drawer immediately — the toast and waitForConversationCompletion
+  // can observe failure before meta.json / refetch catches up.
+  useEffect(() => {
+    if (isDemo) return;
+    const handler = (event: Event) => {
+      const batch = (event as CustomEvent).detail as Array<{
+        id: string;
+        status: string;
+      }>;
+      const match = batch?.find((n) => n.id === taskId);
+      if (!match) return;
+      setTask((prev) => {
+        if (!prev) return prev;
+        return (
+          applyTerminalPayloadToTask(prev, { status: match.status }) ?? prev
+        );
+      });
+      void fetchTask(taskId, cabinetPath || undefined)
+        .then((fresh) => setTask(fresh))
+        .catch(() => {});
+    };
+    window.addEventListener("cabinet:conversation-completed", handler);
+    return () =>
+      window.removeEventListener("cabinet:conversation-completed", handler);
+  }, [isDemo, taskId, cabinetPath]);
+
+  // Safety poll while the task is alive (or not yet loaded). Per-conversation
+  // SSE can miss terminal updates when the run finishes before the browser
+  // connects — notifications use a separate channel and may arrive first.
+  useEffect(() => {
+    if (isDemo) return;
+    const status = task?.meta.status;
+    const shouldPoll =
+      !task || status === "running" || status === "awaiting-input";
+    if (!shouldPoll) return;
+
+    const tick = () => {
+      void (async () => {
+        try {
+          const [fresh, daemonRes] = await Promise.all([
+            fetchTask(taskId, cabinetPath || undefined),
+            fetch(`/api/daemon/session/${encodeURIComponent(taskId)}/output`).then(
+              (r) => (r.ok ? r.json() : null)
+            ) as Promise<{
+              status?: string;
+              adapterErrorHint?: string | null;
+              adapterErrorKind?: string | null;
+            } | null>,
+          ]);
+          let next = fresh;
+          // When meta.json is stale but the daemon already knows the session
+          // ended, reflect the terminal status immediately in the drawer.
+          if (
+            daemonRes?.status &&
+            (daemonRes.status === "failed" || daemonRes.status === "completed") &&
+            fresh.meta.status === "running"
+          ) {
+            const taskStatus =
+              daemonRes.status === "completed" ? "idle" : "failed";
+            next = fillEmptyAgentTurnContent(
+              {
+                ...fresh,
+                meta: {
+                  ...fresh.meta,
+                  status: taskStatus,
+                  errorHint:
+                    daemonRes.adapterErrorHint?.trim() ||
+                    fresh.meta.errorHint,
+                  errorKind:
+                    daemonRes.adapterErrorKind ||
+                    fresh.meta.errorKind,
+                },
+              },
+              taskStatus
+            );
+          }
+          setTask((prev) => {
+            if (
+              prev?.meta.status === next.meta.status &&
+              prev.turns.length === next.turns.length
+            ) {
+              return prev;
+            }
+            return next;
+          });
+        } catch {
+          // ignore transient poll failures
+        }
+      })();
+    };
+
+    // Fast ticks for the first 30s after open — that's when quick failures
+    // happen and the user is staring at the drawer waiting.
+    tick();
+    let slowInterval: ReturnType<typeof setInterval> | null = null;
+    const fastInterval = window.setInterval(tick, 500);
+    const slowSwitch = window.setTimeout(() => {
+      window.clearInterval(fastInterval);
+      slowInterval = window.setInterval(tick, 1500);
+    }, 30_000);
+
+    return () => {
+      window.clearInterval(fastInterval);
+      if (slowInterval) window.clearInterval(slowInterval);
+      window.clearTimeout(slowSwitch);
+    };
+  }, [isDemo, taskId, cabinetPath, task?.meta.status]);
 
   // Cleanup demo settle timer
   useEffect(() => {
@@ -671,6 +894,13 @@ export function TaskConversationPage({
   );
   const terminalModeActive =
     isTerminalMode || (!task && earlyIsTerminal === true);
+
+  useEffect(() => {
+    const status = task?.meta.status ?? null;
+    if (prevTaskStatusRef.current === status) return;
+    prevTaskStatusRef.current = status;
+  }, [task?.meta.status]);
+
   const firstUserTurn = task?.turns.find((t) => t.role === "user") || null;
   const terminalPrompt = firstUserTurn?.content || task?.meta.title || "";
   const attachedSkills = task ? readRuntimeSkills(task.meta.adapterConfig) : null;

--- a/src/components/tasks/conversation/task-conversation-page.tsx
+++ b/src/components/tasks/conversation/task-conversation-page.tsx
@@ -96,6 +96,43 @@ function fillEmptyAgentTurnContent(task: Task, status: TaskStatus): Task {
   };
 }
 
+/** True when a safety-poll refetch would not change drawer-visible state. */
+function isSameTaskPollState(prev: Task | null | undefined, next: Task): boolean {
+  if (!prev) return false;
+  const pm = prev.meta;
+  const nm = next.meta;
+  if (
+    pm.status !== nm.status ||
+    pm.errorHint !== nm.errorHint ||
+    pm.errorKind !== nm.errorKind ||
+    pm.lastActivityAt !== nm.lastActivityAt ||
+    (pm.tokens?.total ?? 0) !== (nm.tokens?.total ?? 0)
+  ) {
+    return false;
+  }
+  const pendingIds = (actions: Task["meta"]["pendingActions"]) =>
+    actions?.map((a) => a.id).join("\0") ?? "";
+  if (pendingIds(pm.pendingActions) !== pendingIds(nm.pendingActions)) {
+    return false;
+  }
+  if (prev.turns.length !== next.turns.length) return false;
+  for (let i = 0; i < prev.turns.length; i++) {
+    const a = prev.turns[i];
+    const b = next.turns[i];
+    if (
+      a.id !== b.id ||
+      a.content !== b.content ||
+      !!a.pending !== !!b.pending ||
+      !!a.awaitingInput !== !!b.awaitingInput ||
+      (a.artifacts?.length ?? 0) !== (b.artifacts?.length ?? 0)
+    ) {
+      return false;
+    }
+  }
+  if (!!prev.session?.alive !== !!next.session?.alive) return false;
+  return true;
+}
+
 /** Apply a terminal task.updated payload without waiting on refetch. */
 function applyTerminalPayloadToTask(
   prev: Task,
@@ -828,15 +865,9 @@ export function TaskConversationPage({
               taskStatus
             );
           }
-          setTask((prev) => {
-            if (
-              prev?.meta.status === next.meta.status &&
-              prev.turns.length === next.turns.length
-            ) {
-              return prev;
-            }
-            return next;
-          });
+          setTask((prev) =>
+            isSameTaskPollState(prev, next) ? prev : next
+          );
         } catch {
           // ignore transient poll failures
         }

--- a/src/components/tasks/conversation/task-conversation-page.tsx
+++ b/src/components/tasks/conversation/task-conversation-page.tsx
@@ -388,7 +388,6 @@ export interface TaskConversationPageProps {
   returnContext?: import("@/stores/app-store").SelectedSection;
 }
 
-/** Dev-only on-page log strip — survives Next.js removeConsole for console.log. */
 export function TaskConversationPage({
   taskId,
   cabinetPath,
@@ -1110,7 +1109,7 @@ export function TaskConversationPage({
     setBusy(true);
     try {
       await deleteConversation(taskId, task.meta.cabinetPath);
-      if (typeof window !== "undefined") {
+      if (variant === "full" && typeof window !== "undefined") {
         window.location.hash = "#/";
       }
     } catch (e) {
@@ -1118,7 +1117,7 @@ export function TaskConversationPage({
     } finally {
       setBusy(false);
     }
-  }, [task, isDemo, taskId]);
+  }, [task, isDemo, taskId, variant]);
 
   if (loadError && !task) {
     return (

--- a/src/components/tasks/conversation/task-conversation-page.tsx
+++ b/src/components/tasks/conversation/task-conversation-page.tsx
@@ -143,7 +143,6 @@ function applyTerminalPayloadToTask(
   if (typeof raw !== "string") return null;
   const taskStatus = conversationStatusToTaskStatus(raw);
   if (!taskStatus || taskStatus === "running") return null;
-  if (prev.meta.status === taskStatus) return null;
   const errorHint =
     typeof payload.errorHint === "string"
       ? payload.errorHint
@@ -152,6 +151,13 @@ function applyTerminalPayloadToTask(
     typeof payload.errorKind === "string"
       ? payload.errorKind
       : prev.meta.errorKind;
+  if (
+    prev.meta.status === taskStatus &&
+    prev.meta.errorHint === errorHint &&
+    prev.meta.errorKind === errorKind
+  ) {
+    return null;
+  }
   return fillEmptyAgentTurnContent(
     {
       ...prev,

--- a/src/components/tasks/rail/use-task-rail-data.ts
+++ b/src/components/tasks/rail/use-task-rail-data.ts
@@ -148,8 +148,11 @@ export function useTaskRailData(): TaskRailData {
     };
     es.onmessage = (msg) => {
       try {
-        const event = JSON.parse(msg.data) as { type: string };
+        const event = JSON.parse(msg.data) as { type: string; taskId?: string };
         if (event.type === "ping") return;
+        if (event.type === "task.deleted" && event.taskId) {
+          setItems((prev) => prev.filter((item) => item.task.id !== event.taskId));
+        }
         scheduleReload();
       } catch {
         // ignore malformed frames

--- a/src/components/tasks/task-detail-panel.tsx
+++ b/src/components/tasks/task-detail-panel.tsx
@@ -141,6 +141,7 @@ export function TaskDetailPanel() {
         </div>
         <TaskConversationPage
           taskId={conversation.id}
+          cabinetPath={conversation.cabinetPath}
           variant="compact"
           returnContext={{
             type: "task",

--- a/src/components/terminal/web-terminal.tsx
+++ b/src/components/terminal/web-terminal.tsx
@@ -123,7 +123,7 @@ export function WebTerminal({
       pendingWrites.length = 0;
     };
 
-    const finishSession = (closeSocket = false) => {
+    const finishSession = (closeSocket = false, reason = "unknown") => {
       if (disposed || sessionFinished) return;
       sessionFinished = true;
       if (statusPollHandle) {
@@ -207,7 +207,7 @@ export function WebTerminal({
 
         ws.onclose = () => {
           if (disposed) return;
-          finishSession(false);
+          finishSession(false, "ws.close");
         };
 
         statusPollHandle = setInterval(() => {
@@ -218,14 +218,14 @@ export function WebTerminal({
               if (!response.ok) return;
               const data = (await response.json()) as { status?: string };
               if (data.status && data.status !== "running") {
-                finishSession(true);
+                finishSession(true, `poll:${data.status}`);
               }
             } catch {
               // Ignore transient polling failures; the socket remains the primary signal.
             }
           })();
         }, 3000);
-      } catch {
+      } catch (err) {
         if (disposed) return;
         setError("Connection failed. Is the daemon running?");
         writeToTerminal(

--- a/src/components/terminal/web-terminal.tsx
+++ b/src/components/terminal/web-terminal.tsx
@@ -84,6 +84,7 @@ export function WebTerminal({
   }, [onClose]);
 
   useEffect(() => {
+    const effectiveSessionId = sessionId || `session-${Date.now()}`;
     let terminal: import("@xterm/xterm").Terminal | null = null;
     let ws: WebSocket | null = null;
     let resizeObserver: ResizeObserver | null = null;
@@ -126,6 +127,11 @@ export function WebTerminal({
     const finishSession = (closeSocket = false, reason = "unknown") => {
       if (disposed || sessionFinished) return;
       sessionFinished = true;
+      console.debug("[WebTerminal] session ended", {
+        sessionId: effectiveSessionId,
+        reason,
+        closeSocket,
+      });
       if (statusPollHandle) {
         clearInterval(statusPollHandle);
         statusPollHandle = null;
@@ -139,7 +145,7 @@ export function WebTerminal({
 
     // ----- Chain A: connection (auth + WebSocket). Fires immediately. -----
     const startConnection = async () => {
-      const id = sessionId || `session-${Date.now()}`;
+      const id = effectiveSessionId;
       try {
         const authResponse = await fetch("/api/daemon/auth");
         if (!authResponse.ok) {

--- a/src/lib/agents/adapters/codex-local.ts
+++ b/src/lib/agents/adapters/codex-local.ts
@@ -202,15 +202,20 @@ export const codexLocalAdapter: AgentExecutionAdapter = {
     const output = stdoutAccumulator.display.trim() || null;
     const summaryLine =
       firstNonEmptyLine(stdoutAccumulator.lastAgentMessage || output || "")?.slice(0, 300) || null;
+    const streamError = stdoutAccumulator.errorMessage?.trim() || null;
+    const synthesizedExitCode =
+      streamError && (result.exitCode ?? 0) === 0 && !result.timedOut
+        ? 1
+        : result.exitCode;
 
     return {
-      exitCode: result.exitCode,
+      exitCode: synthesizedExitCode,
       signal: result.signal,
       timedOut: result.timedOut,
       errorMessage:
-        result.exitCode === 0
+        (synthesizedExitCode ?? 0) === 0
           ? null
-          : stdoutAccumulator.errorMessage
+          : streamError
             || filteredStderr
             || result.stderr.trim()
             || output

--- a/src/lib/agents/adapters/codex-stream.ts
+++ b/src/lib/agents/adapters/codex-stream.ts
@@ -146,17 +146,22 @@ function consumeCodexEvent(
     // Prefer the first `"error"` event's message; only fall back to
     // `turn.failed` when nothing has been captured yet — the two typically
     // arrive in quick succession and carry identical text.
+    // Surface the message in the display stream so the transcript + task
+    // drawer show the failure immediately (previously errors were captured
+    // only in errorMessage and the UI stayed "Running" until process exit).
     if (payload.type === "error") {
+      const message = extractErrorMessage(payload.message);
       if (!accumulator.errorMessage) {
-        accumulator.errorMessage = extractErrorMessage(payload.message);
+        accumulator.errorMessage = message;
       }
-      return "";
+      return message ? appendDisplay(accumulator, `${message}\n`) : "";
     }
     if (payload.type === "turn.failed") {
+      const message = extractErrorMessage(payload.error?.message);
       if (!accumulator.errorMessage) {
-        accumulator.errorMessage = extractErrorMessage(payload.error?.message);
+        accumulator.errorMessage = message;
       }
-      return "";
+      return message ? appendDisplay(accumulator, `${message}\n`) : "";
     }
 
     if (!payload.item) {

--- a/src/lib/agents/conversation-runner.ts
+++ b/src/lib/agents/conversation-runner.ts
@@ -710,9 +710,10 @@ export async function startConversationRun(
     throw error;
   }
 
-  if (input.onComplete) {
-    void waitForConversationCompletion(meta.id, input.onComplete);
-  }
+  // Always poll for terminal status on the Next.js side. The daemon process
+  // finalizes + enqueues notifications in its own memory — those never reach
+  // the SSE tick that drives toasts unless we mirror completion here.
+  void waitForConversationCompletion(meta.id, input.onComplete);
 
   return meta;
 }
@@ -728,8 +729,8 @@ export async function waitForConversationCompletion(
   // and the user is most sensitive to latency between their prompt and the
   // first streamed bytes. Back off to the steady-state 700 ms interval after
   // the adapter is clearly producing.
-  const FAST_POLL_WINDOW_MS = 5000;
-  const FAST_POLL_INTERVAL_MS = 250;
+  const FAST_POLL_WINDOW_MS = 15_000;
+  const FAST_POLL_INTERVAL_MS = 100;
   const STEADY_POLL_INTERVAL_MS = 700;
   let lastOutputLength = 0;
   let firstPoll = true;
@@ -768,26 +769,53 @@ export async function waitForConversationCompletion(
 
       const normalizedStatus = data.status === "completed" ? "completed" : "failed";
       const currentMeta = await readConversationMeta(conversationId);
+      const cp = currentMeta?.cabinetPath;
       let finalMeta =
         currentMeta?.status === "running"
-          ? await finalizeConversation(conversationId, {
-              status: normalizedStatus,
+          ? await finalizeConversation(
+              conversationId,
+              {
+                status: normalizedStatus,
+                output: data.output,
+                exitCode: normalizedStatus === "completed" ? 0 : 1,
+                tokens: data.adapterUsage
+                  ? {
+                      input: data.adapterUsage.inputTokens,
+                      output: data.adapterUsage.outputTokens,
+                      cache: data.adapterUsage.cachedInputTokens,
+                      total:
+                        data.adapterUsage.inputTokens +
+                        data.adapterUsage.outputTokens,
+                    }
+                  : undefined,
+                errorKind: data.adapterErrorKind ?? undefined,
+                errorHint: data.adapterErrorHint ?? undefined,
+                errorRetryAfterSec: data.adapterErrorRetryAfterSec ?? undefined,
+              },
+              cp
+            )
+          : currentMeta;
+
+      if (
+        finalMeta &&
+        normalizedStatus === "failed" &&
+        !finalMeta.errorHint?.trim() &&
+        (data.adapterErrorHint?.trim() || data.output?.trim())
+      ) {
+        finalMeta =
+          (await finalizeConversation(
+            conversationId,
+            {
+              status: "failed",
+              exitCode: 1,
               output: data.output,
-              exitCode: normalizedStatus === "completed" ? 0 : 1,
-              tokens: data.adapterUsage
-                ? {
-                    input: data.adapterUsage.inputTokens,
-                    output: data.adapterUsage.outputTokens,
-                    cache: data.adapterUsage.cachedInputTokens,
-                    total:
-                      data.adapterUsage.inputTokens + data.adapterUsage.outputTokens,
-                  }
-                : undefined,
               errorKind: data.adapterErrorKind ?? undefined,
               errorHint: data.adapterErrorHint ?? undefined,
               errorRetryAfterSec: data.adapterErrorRetryAfterSec ?? undefined,
-            })
-          : currentMeta;
+            },
+            cp
+          )) || finalMeta;
+      }
 
       if (!finalMeta) {
         throw new Error(`Conversation ${conversationId} disappeared during completion`);
@@ -829,6 +857,8 @@ export async function waitForConversationCompletion(
         payload: {
           status: finalMeta.status,
           artifactPaths: finalMeta.artifactPaths,
+          ...(finalMeta.errorKind ? { errorKind: finalMeta.errorKind } : {}),
+          ...(finalMeta.errorHint ? { errorHint: finalMeta.errorHint } : {}),
         },
       });
 

--- a/src/lib/agents/conversation-store-turns.test.ts
+++ b/src/lib/agents/conversation-store-turns.test.ts
@@ -295,3 +295,28 @@ test("isCabinetBlockMissing returns true for an empty cabinet fence (no fields)"
   const empty = "Done.\n```cabinet\n```";
   assert.equal(store.isCabinetBlockMissing(empty), true);
 });
+
+test("finalizeConversation classifies codex model_unavailable when errorHint is omitted", async () => {
+  const errorMsg =
+    "The 'gpt-5.2-codex' model is not supported when using Codex with a ChatGPT account.";
+  const meta = await store.createConversation({
+    agentSlug: "general",
+    title: "Model gate",
+    trigger: "manual",
+    prompt: "User request:\ntest",
+    adapterType: "codex_local",
+    providerId: "codex-cli",
+  });
+  await store.appendConversationTranscript(meta.id, errorMsg);
+  const finalized = await store.finalizeConversation(meta.id, {
+    status: "failed",
+    exitCode: 1,
+    output: errorMsg,
+  });
+  assert.equal(finalized?.errorKind, "model_unavailable");
+  assert.match(finalized?.errorHint ?? "", /isn't available on this account's plan/i);
+
+  const turns = await store.readConversationTurns(finalized!.id);
+  const agent = turns.find((turn) => turn.role === "agent");
+  assert.match(agent?.content ?? "", /not supported when using Codex/i);
+});

--- a/src/lib/agents/conversation-store.ts
+++ b/src/lib/agents/conversation-store.ts
@@ -25,6 +25,8 @@ import {
   turnsDir as turnsDirFs,
 } from "./conversation-turns";
 import { publishConversationEvent } from "./conversation-events";
+import { isLegacyAdapterType } from "./adapters/legacy-ids";
+import { agentAdapterRegistry } from "./adapters/registry";
 import { discoverCabinetPaths } from "../cabinets/discovery";
 import { buildConversationInstanceKey } from "./conversation-identity";
 import { fingerprint, parseAgentActions } from "./action-parser";
@@ -53,6 +55,62 @@ import {
 } from "../storage/fs-operations";
 
 export const CONVERSATIONS_DIR = path.join(DATA_DIR, ".agents", ".conversations");
+
+/** Classify adapter-reported failure text when the daemon hasn't set hints yet. */
+function classifyAdapterFailure(
+  adapterType: string | undefined | null,
+  output: string,
+  exitCode: number | null = 1
+): {
+  errorKind?: ConversationErrorKind;
+  errorHint?: string;
+  errorRetryAfterSec?: number;
+} {
+  const text = output.trim();
+  if (!text) return {};
+  const adapter = adapterType ? agentAdapterRegistry.get(adapterType) : undefined;
+  if (!adapter?.classifyError) return {};
+  try {
+    const classified = adapter.classifyError(text, exitCode);
+    return {
+      errorKind: classified.kind,
+      errorHint: classified.hint,
+      errorRetryAfterSec: classified.retryAfterSec,
+    };
+  } catch {
+    return { errorKind: "unknown" };
+  }
+}
+
+function resolveConversationFailureHints(
+  adapterType: string | undefined | null,
+  output: string | undefined,
+  exitCode: number | null | undefined,
+  input: {
+    errorKind?: ConversationErrorKind | null;
+    errorHint?: string | null;
+    errorRetryAfterSec?: number | null;
+  }
+): {
+  errorKind?: ConversationErrorKind;
+  errorHint?: string;
+  errorRetryAfterSec?: number;
+} {
+  let errorKind = input.errorKind ?? undefined;
+  let errorHint = input.errorHint ?? undefined;
+  let errorRetryAfterSec = input.errorRetryAfterSec ?? undefined;
+  if (!errorHint?.trim() && output?.trim()) {
+    const classified = classifyAdapterFailure(
+      adapterType,
+      output,
+      exitCode ?? 1
+    );
+    errorKind = errorKind ?? classified.errorKind;
+    errorHint = errorHint ?? classified.errorHint;
+    errorRetryAfterSec = errorRetryAfterSec ?? classified.errorRetryAfterSec;
+  }
+  return { errorKind, errorHint, errorRetryAfterSec };
+}
 
 function resolveConversationsDir(cabinetPath?: string): string {
   if (cabinetPath) return path.join(DATA_DIR, cabinetPath, ".agents", ".conversations");
@@ -984,6 +1042,208 @@ export function transcriptShowsCompletedRun(transcript: string, prompt?: string)
   return hasClaudePromptTail(transcript, prompt);
 }
 
+/**
+ * Structured adapters (codex_local, etc.) can emit a terminal error on stdout
+ * before the child process reaps. When meta.json is still `running` but the
+ * transcript already carries an error line, treat the run as failed.
+ */
+function transcriptShowsStructuredFailure(
+  transcript: string,
+  adapterType?: string | null
+): boolean {
+  const text = transcript.trim();
+  if (!text) return false;
+
+  if (adapterType === "codex_local") {
+    const lower = text.toLowerCase();
+    if (lower.includes("invalid_request_error")) return true;
+    if (lower.includes("model") && lower.includes("not supported")) return true;
+    if (lower.includes("codex") && lower.includes("failed")) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Heal conversations whose meta.json still says `running` after the daemon
+ * session has already exited. `finalizeSessionConversation` can fail silently
+ * (`.catch(() => {})` in the daemon); structured adapters like codex_local
+ * then leave a zombie "running" meta that blocks `maybeResolveCompletedConversation`
+ * via the manual-trigger guard. Polling the daemon on each detail fetch closes
+ * that gap — this is what the task drawer poll/SSE path relies on.
+ */
+async function finalizeMetaFromDaemonOutput(
+  meta: ConversationMeta,
+  data: {
+    status: string;
+    output?: string;
+    adapterUsage?: {
+      inputTokens: number;
+      outputTokens: number;
+      cachedInputTokens?: number;
+    } | null;
+    adapterErrorKind?: ConversationErrorKind | null;
+    adapterErrorHint?: string | null;
+    adapterErrorRetryAfterSec?: number | null;
+  },
+  reason: string
+): Promise<ConversationMeta> {
+  const normalizedStatus: ConversationStatus =
+    data.status === "completed" ? "completed" : "failed";
+  const failureHints =
+    normalizedStatus === "failed"
+      ? resolveConversationFailureHints(
+          meta.adapterType,
+          data.output,
+          normalizedStatus === "failed" ? 1 : 0,
+          {
+            errorKind: data.adapterErrorKind,
+            errorHint: data.adapterErrorHint,
+            errorRetryAfterSec: data.adapterErrorRetryAfterSec,
+          }
+        )
+      : {};
+
+  const finalized = await finalizeConversation(
+    meta.id,
+    {
+      status: normalizedStatus,
+      output: data.output,
+      exitCode: normalizedStatus === "completed" ? 0 : 1,
+      tokens: data.adapterUsage
+        ? {
+            input: data.adapterUsage.inputTokens,
+            output: data.adapterUsage.outputTokens,
+            cache: data.adapterUsage.cachedInputTokens,
+            total:
+              data.adapterUsage.inputTokens + data.adapterUsage.outputTokens,
+          }
+        : undefined,
+      errorKind: failureHints.errorKind,
+      errorHint: failureHints.errorHint,
+      errorRetryAfterSec: failureHints.errorRetryAfterSec,
+    },
+    meta.cabinetPath
+  );
+  return finalized || meta;
+}
+
+async function reconcileStaleRunningMeta(
+  meta: ConversationMeta
+): Promise<ConversationMeta> {
+  if (meta.status !== "running") return meta;
+
+  // Manual legacy PTY sessions stay running until the user closes the xterm.
+  if (meta.trigger === "manual" && isLegacyAdapterType(meta.adapterType)) {
+    return meta;
+  }
+
+  const { getDaemonSessionOutput, listDaemonSessions } = await import(
+    "./daemon-client"
+  );
+
+  const tryHeal = async (
+    data: Awaited<ReturnType<typeof getDaemonSessionOutput>>,
+    reason: string
+  ) => {
+    if (data.status === "running") return null;
+    return finalizeMetaFromDaemonOutput(meta, data, reason);
+  };
+
+  try {
+    const primary = await getDaemonSessionOutput(meta.id);
+    const healed = await tryHeal(primary, "primary-session");
+    if (healed) return healed;
+
+    // Continue-turn runs use synthetic ids (`convId::tN::uuid`). The
+    // conversation id poll won't see them via the primary lookup above.
+    const sessions = await listDaemonSessions();
+    const related = sessions.filter(
+      (s) => s.id === meta.id || s.id.startsWith(`${meta.id}::`)
+    );
+    const exited = related.filter((s) => s.exited);
+    for (const session of exited.sort((a, b) => {
+      const aScore = (a.exitCode ?? 0) !== 0 ? 1 : 0;
+      const bScore = (b.exitCode ?? 0) !== 0 ? 1 : 0;
+      return bScore - aScore;
+    })) {
+      try {
+        const data = await getDaemonSessionOutput(session.id);
+        const fromRelated = await tryHeal(
+          data,
+          `related-session:${session.id}`
+        );
+        if (fromRelated) return fromRelated;
+      } catch {
+        // try next related session
+      }
+    }
+
+    const alive = related.some((s) => !s.exited);
+    if (alive) {
+      if (!isLegacyAdapterType(meta.adapterType)) {
+        const transcript = await readConversationTranscript(
+          meta.id,
+          meta.cabinetPath
+        );
+        const prompt = (await fileExists(promptPathFs(meta.id, meta.cabinetPath)))
+          ? await readFileContent(promptPathFs(meta.id, meta.cabinetPath))
+          : "";
+        if (
+          transcript.trim() &&
+          !transcriptShowsCompletedRun(transcript, prompt) &&
+          transcriptShowsStructuredFailure(transcript, meta.adapterType)
+        ) {
+          return finalizeMetaFromDaemonOutput(
+            meta,
+            {
+              status: "failed",
+              output: transcript,
+              adapterErrorKind: primary.adapterErrorKind ?? undefined,
+              adapterErrorHint: primary.adapterErrorHint ?? undefined,
+              adapterErrorRetryAfterSec:
+                primary.adapterErrorRetryAfterSec ?? undefined,
+            },
+            "structured-transcript-error-while-alive"
+          );
+        }
+      }
+      return meta;
+    }
+
+    // Daemon session is gone (or exited) but meta.json still says running —
+    // `finalizeSessionConversation` likely failed. For structured adapters,
+    // any non-empty transcript means the run produced output and should not
+    // stay "running" forever.
+    if (!isLegacyAdapterType(meta.adapterType)) {
+      const transcript = await readConversationTranscript(
+        meta.id,
+        meta.cabinetPath
+      );
+      if (transcript.trim()) {
+        const completedRun = transcriptShowsCompletedRun(
+          transcript,
+          (await fileExists(promptPathFs(meta.id, meta.cabinetPath)))
+            ? await readFileContent(promptPathFs(meta.id, meta.cabinetPath))
+            : ""
+        );
+        return finalizeMetaFromDaemonOutput(
+          meta,
+          {
+            status: completedRun ? "completed" : "failed",
+            output: transcript,
+          },
+          "structured-transcript-fallback"
+        );
+      }
+    }
+
+    return meta;
+  } catch (err) {
+    return meta;
+  }
+}
+
 async function maybeResolveCompletedConversation(
   meta: ConversationMeta | null
 ): Promise<ConversationMeta | null> {
@@ -994,14 +1254,44 @@ async function maybeResolveCompletedConversation(
   const prompt = (await fileExists(promptPathFs(meta.id, cabinetPath)))
     ? await readFileContent(promptPathFs(meta.id, cabinetPath))
     : "";
-  // Manual terminal-mode sessions stay "running" until the user closes
-  // them explicitly (Done button or /exit in the xterm). An idle CLI
-  // prompt is awaiting-input, not completed. Never silently flip these
-  // to status=completed from a detail-fetch side effect.
-  if (meta.status === "running" && meta.trigger === "manual") {
+  // Manual legacy PTY sessions stay "running" until the user closes them
+  // explicitly (Done button or /exit in the xterm). Structured adapters
+  // (codex_local, claude_local, …) must not inherit this guard — their
+  // daemon session exits on its own and meta should flip via reconcile/finalize.
+  if (
+    meta.status === "running" &&
+    meta.trigger === "manual" &&
+    isLegacyAdapterType(meta.adapterType)
+  ) {
     return meta;
   }
   if (meta.status === "running" && !transcriptShowsCompletedRun(transcript, prompt)) {
+    if (
+      !isLegacyAdapterType(meta.adapterType) &&
+      transcript.trim() &&
+      transcriptShowsStructuredFailure(transcript, meta.adapterType)
+    ) {
+      const failureHints = resolveConversationFailureHints(
+        meta.adapterType,
+        transcript,
+        1,
+        {}
+      );
+      return (
+        (await finalizeConversation(
+          meta.id,
+          {
+            status: "failed",
+            output: transcript,
+            exitCode: 1,
+            errorKind: failureHints.errorKind,
+            errorHint: failureHints.errorHint,
+            errorRetryAfterSec: failureHints.errorRetryAfterSec,
+          },
+          cabinetPath
+        )) || meta
+      );
+    }
     return meta;
   }
   const parsed = parseCabinetBlock(transcript, prompt);
@@ -1123,10 +1413,16 @@ export async function finalizeConversation(
   const cp = meta.cabinetPath || cabinetPath;
 
   const hasPrompt = await fileExists(promptPathFs(id, cp));
+  const priorTranscript = await readConversationTranscript(id, cp);
   const [output, prompt] = await Promise.all([
-    input.output ? Promise.resolve(input.output) : readConversationTranscript(id, cp),
+    input.output ? Promise.resolve(input.output) : Promise.resolve(priorTranscript),
     hasPrompt ? readFileContent(promptPathFs(id, cp)) : Promise.resolve(""),
   ]);
+  // Quick failures often finalize from daemon output before stream chunks
+  // landed in transcript.txt — persist so turn-1 reads show the error.
+  if (input.output?.trim() && !priorTranscript.trim()) {
+    await writeFileContent(transcriptPathFs(id, cp), input.output);
+  }
   const cleanedOutput = cleanConversationOutputForParsing(output, prompt);
   const parsed = parseCabinetBlock(cleanedOutput, prompt);
   const artifacts = parsed.artifactPaths.map((artifactPath) => ({
@@ -1214,14 +1510,20 @@ export async function finalizeConversation(
     meta.errorHint = undefined;
     meta.errorRetryAfterSec = undefined;
   } else if (input.status === "failed") {
-    if (input.errorKind) {
-      meta.errorKind = input.errorKind;
+    const failureHints = resolveConversationFailureHints(
+      meta.adapterType,
+      cleanedOutput,
+      input.exitCode,
+      input
+    );
+    if (failureHints.errorKind) {
+      meta.errorKind = failureHints.errorKind;
     }
-    if (input.errorHint !== undefined) {
-      meta.errorHint = input.errorHint ?? undefined;
+    if (failureHints.errorHint !== undefined) {
+      meta.errorHint = failureHints.errorHint ?? undefined;
     }
-    if (input.errorRetryAfterSec !== undefined) {
-      meta.errorRetryAfterSec = input.errorRetryAfterSec ?? undefined;
+    if (failureHints.errorRetryAfterSec !== undefined) {
+      meta.errorRetryAfterSec = failureHints.errorRetryAfterSec ?? undefined;
     }
   }
 
@@ -1242,12 +1544,18 @@ export async function finalizeConversation(
   // Broadcast a task.updated so every subscribed surface (task page, tasks
   // board, sidebar file tree) can refresh without waiting on an explicit
   // turn.appended event (first-turn runs never hit that path).
+  const taskUpdatedPayload: Record<string, unknown> = {
+    status: meta.status,
+    artifactPaths: meta.artifactPaths,
+  };
+  if (meta.errorKind) taskUpdatedPayload.errorKind = meta.errorKind;
+  if (meta.errorHint) taskUpdatedPayload.errorHint = meta.errorHint;
+
   const seq = await appendEventLog(
     id,
     {
       type: "task.updated",
-      status: meta.status,
-      artifactPaths: meta.artifactPaths,
+      ...taskUpdatedPayload,
     },
     cp
   );
@@ -1256,10 +1564,7 @@ export async function finalizeConversation(
     taskId: id,
     cabinetPath: cp,
     seq: seq ?? undefined,
-    payload: {
-      status: meta.status,
-      artifactPaths: meta.artifactPaths,
-    },
+    payload: taskUpdatedPayload,
   });
 
   // Push notification for terminal statuses
@@ -1305,7 +1610,10 @@ export async function readConversationDetail(
   cabinetPath?: string,
   options: { withTurns?: boolean } = {}
 ): Promise<ConversationDetail | null> {
-  const meta = await maybeResolveCompletedConversation(await readConversationMeta(id, cabinetPath));
+  const rawMeta = await readConversationMeta(id, cabinetPath);
+  if (!rawMeta) return null;
+  const reconciled = await reconcileStaleRunningMeta(rawMeta);
+  const meta = await maybeResolveCompletedConversation(reconciled);
   if (!meta) return null;
   const cp = meta.cabinetPath || cabinetPath;
 
@@ -1339,7 +1647,7 @@ export async function readConversationDetail(
 
   const [turns, session] = options.withTurns
     ? await Promise.all([
-        readConversationTurns(id, cp),
+        readConversationTurns(id, cp, meta),
         readSession(id, cp),
       ])
     : [undefined, undefined];
@@ -1661,6 +1969,29 @@ export interface UpdateAgentTurnInput {
  * Synthesize turn 1 from prompt.md + transcript.txt. Returns null when the
  * conversation is missing both.
  */
+function failedAgentMessageFromMeta(meta: ConversationMeta): string {
+  if (meta.errorHint?.trim()) return meta.errorHint.trim();
+  if (meta.summary?.trim() && !isPlaceholderCabinetValue(meta.summary)) {
+    return meta.summary.trim();
+  }
+  return "The agent run failed before producing a response.";
+}
+
+function resolveAgentTurnOneContent(
+  meta: ConversationMeta,
+  transcript: string,
+  prompt: string
+): string {
+  const fromTranscript = extractAgentTurnContent(transcript, prompt);
+  if (fromTranscript.trim()) return fromTranscript;
+  const rawTranscript = stripAnsiText(transcript).trim();
+  if (rawTranscript && meta.status === "failed") return rawTranscript;
+  if (meta.status === "failed") {
+    return failedAgentMessageFromMeta(meta);
+  }
+  return "";
+}
+
 async function readTurnOne(
   id: string,
   meta: ConversationMeta,
@@ -1709,10 +2040,22 @@ async function readTurnOne(
       };
       return { user, agent: placeholder };
     }
+    if (meta.status === "failed") {
+      const agent: ConversationTurn = {
+        id: `${id}-t1a`,
+        turn: 1,
+        role: "agent",
+        ts: meta.completedAt || meta.startedAt,
+        content: failedAgentMessageFromMeta(meta),
+        exitCode: meta.exitCode,
+        error: meta.errorHint,
+      };
+      return { user, agent };
+    }
     return { user, agent: null };
   }
 
-  const agentContent = extractAgentTurnContent(transcript, prompt);
+  const agentContent = resolveAgentTurnOneContent(meta, transcript, prompt);
   const agent: ConversationTurn = {
     id: `${id}-t1a`,
     turn: 1,
@@ -1724,8 +2067,14 @@ async function readTurnOne(
     awaitingInput: meta.awaitingInput,
     // Pending when the conversation hasn't finalized yet AND turn 1 is the
     // only turn. Once later turns exist, turn 1 agent is historical.
+    // Clear pending as soon as the transcript carries a structured error
+    // (Codex plan rejections, etc.) even if meta.json hasn't caught up.
     pending:
-      meta.status === "running" && !meta.completedAt ? true : undefined,
+      meta.status === "running" &&
+      !meta.completedAt &&
+      !transcriptShowsStructuredFailure(transcript, meta.adapterType)
+        ? true
+        : undefined,
   };
 
   return { user, agent };
@@ -1760,9 +2109,10 @@ async function readAdditionalTurns(
  */
 export async function readConversationTurns(
   id: string,
-  cabinetPath?: string
+  cabinetPath?: string,
+  metaOverride?: ConversationMeta
 ): Promise<ConversationTurn[]> {
-  const meta = await readConversationMeta(id, cabinetPath);
+  const meta = metaOverride ?? (await readConversationMeta(id, cabinetPath));
   if (!meta) return [];
   const cp = meta.cabinetPath || cabinetPath;
 

--- a/src/lib/api/dedup-fetch.ts
+++ b/src/lib/api/dedup-fetch.ts
@@ -90,3 +90,20 @@ export function resetDedupFetch(): void {
   inflight.clear();
   recent.clear();
 }
+
+/**
+ * Drop cached GET responses whose dedup key contains `urlIncludes`.
+ * Call after mutations (e.g. delete) so the next list refresh cannot
+ * resurrect stale rows from the short TTL cache.
+ */
+export function invalidateDedupFetch(urlIncludes?: string): void {
+  if (!urlIncludes) {
+    recent.clear();
+    return;
+  }
+  for (const key of recent.keys()) {
+    if (key.includes(urlIncludes)) {
+      recent.delete(key);
+    }
+  }
+}

--- a/src/stores/app-store.ts
+++ b/src/stores/app-store.ts
@@ -522,7 +522,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   // (start-work-dialog / new-task-button.onStarted). `meta` opens the
   // animated drawer in conversation mode; `null` closes it (the
   // conversation is kept so the desktop close tween can play out).
-  setTaskPanelConversation: (conversation) =>
+  setTaskPanelConversation: (conversation) => {
     set(
       conversation
         ? {
@@ -535,15 +535,17 @@ export const useAppStore = create<AppState>((set, get) => ({
             ),
           }
         : { taskPanelOpen: false }
-    ),
+    );
+  },
 
-  openTaskPanelCompose: (context) =>
+  openTaskPanelCompose: (context) => {
     set({
       taskPanelOpen: true,
       taskPanelMode: "compose",
       taskPanelComposeContext: context ?? null,
       taskPanelConversation: null,
-    }),
+    });
+  },
 
   closeTaskPanel: () => set({ taskPanelOpen: false }),
 
@@ -562,7 +564,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   // Compose -> live swap: keep the SAME drawer mounted (width unchanged),
   // unlike the external setTaskPanelConversation.
-  swapToConversation: (conversation) =>
+  swapToConversation: (conversation) => {
     set({
       taskPanelConversation: conversation,
       taskPanelMode: "conversation",
@@ -571,7 +573,8 @@ export const useAppStore = create<AppState>((set, get) => ({
         get().recentlyOpenedTaskIds,
         conversation.id
       ),
-    }),
+    });
+  },
 
   toggleTaskRail: () => set({ taskRailOpen: !get().taskRailOpen }),
 


### PR DESCRIPTION

Quick codex_local runs (e.g. model unavailable) could finalize as failed before the daemon classified the error, leaving meta without errorHint and the drawer stuck on Running or showing a generic fallback. Classify failures from adapter output when hints are missing, propagate errorHint through daemon output and task.updated SSE, and update the task drawer without waiting on refetch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale "running" states by reconciling daemon/session output and finalizing lingering sessions.
  * Fixed terminal failure display so agent responses and error hints appear consistently.

* **New Features**
  * Completed session payloads now include status, exit codes, and structured adapter error hints.
  * Deleted tasks are removed immediately from lists and sidebars.

* **Improvements**
  * Prefer cached completed output for faster responses; improved polling/backoff and optimistic UI updates.
  * Added tests covering adapter failure classification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hilash/cabinet/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->