### PR TITLE
Gpt fixes

### DIFF
--- a/src/components/composer/task-runtime-picker.tsx
+++ b/src/components/composer/task-runtime-picker.tsx
@@ -10,6 +10,7 @@ import {
   Search,
   Sparkles,
   Terminal,
+  X,
 } from "lucide-react";
 import { ProviderGlyph } from "@/components/agents/provider-glyph";
 import { cn } from "@/lib/utils";
@@ -1624,33 +1625,48 @@ export function TaskRuntimePicker({
             }}
             className="mx-1.5 mt-1.5"
             trailing={
-              <button
-                type="button"
-                className={cn(
-                  "shrink-0 rounded-full border px-2.5 py-1 text-[9px] font-medium transition-colors",
-                  sameSelection(normalizedValue, appDefaultSelection)
-                    ? "border-foreground/20 bg-accent text-accent-foreground"
-                    : "border-border/70 bg-background text-muted-foreground hover:text-foreground"
-                )}
-                onClick={(event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  resetToDefault();
-                }}
-                title={[
-                  appDefaultModelInfo?.name || t("runtime:defaultModel"),
-                  appDefaultSelection.effort
-                    ? formatEffortName(appDefaultSelection.effort)
-                    : t("runtime:auto"),
-                  appDefaultProvider?.name || null,
-                ]
-                  .filter(Boolean)
-                  .join(" · ")}
-              >
-                {sameSelection(normalizedValue, appDefaultSelection)
-                  ? t("runtime:appDefault")
-                  : t("runtime:selectAppDefault")}
-              </button>
+              <div className="flex shrink-0 items-center gap-1">
+                <button
+                  type="button"
+                  className={cn(
+                    "shrink-0 rounded-full border px-2.5 py-1 text-[9px] font-medium transition-colors",
+                    sameSelection(normalizedValue, appDefaultSelection)
+                      ? "border-foreground/20 bg-accent text-accent-foreground"
+                      : "border-border/70 bg-background text-muted-foreground hover:text-foreground"
+                  )}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    resetToDefault();
+                  }}
+                  title={[
+                    appDefaultModelInfo?.name || t("runtime:defaultModel"),
+                    appDefaultSelection.effort
+                      ? formatEffortName(appDefaultSelection.effort)
+                      : t("runtime:auto"),
+                    appDefaultProvider?.name || null,
+                  ]
+                    .filter(Boolean)
+                    .join(" · ")}
+                >
+                  {sameSelection(normalizedValue, appDefaultSelection)
+                    ? t("runtime:appDefault")
+                    : t("runtime:selectAppDefault")}
+                </button>
+                <button
+                  type="button"
+                  className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground/60 transition-colors hover:bg-muted hover:text-foreground"
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    setOpen(false);
+                  }}
+                  title={t("startWork:close")}
+                  aria-label={t("startWork:close")}
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
             }
           />
         </DropdownMenuGroup>

--- a/src/components/tasks/conversation/task-conversation-page.tsx
+++ b/src/components/tasks/conversation/task-conversation-page.tsx
@@ -837,7 +837,7 @@ export function TaskConversationPage({
           const [fresh, daemonRes] = await Promise.all([
             fetchTask(taskId, cabinetPath || undefined),
             fetch(`/api/daemon/session/${encodeURIComponent(taskId)}/output`).then(
-              (r) => (r.ok ? r.json() : null)
+              (r) => r.ok ? r.json() : null
             ) as Promise<{
               status?: string;
               adapterErrorHint?: string | null;

--- a/src/lib/agents/conversation-runner.ts
+++ b/src/lib/agents/conversation-runner.ts
@@ -826,8 +826,20 @@ export async function waitForConversationCompletion(
       // agent still has full context of the work it just did, so the retry is
       // scoped to this conversation — no cross-agent bleed like a git-diff
       // fallback would have. One retry only; a second miss is recorded as-is.
+      //
+      // Only applies to Claude adapters: the cabinet block is a Claude Code
+      // convention injected via the system prompt epilogue. Non-Claude providers
+      // (opencode/pi/codex/gemini/etc.) don't produce this block and never will,
+      // so triggering the retry for them desynchronises the daemon session status
+      // from meta.status ("running" during retry vs "completed" original session),
+      // which causes the safety poll to prematurely mark the task idle and
+      // prevents live updates in the task detail view.
+      const adapterSupportsCabinetBlock =
+        finalMeta.adapterType === "claude_local" ||
+        finalMeta.adapterType === "claude_code_legacy";
       if (
         normalizedStatus === "completed" &&
+        adapterSupportsCabinetBlock &&
         isCabinetBlockMissing(data.output || "")
       ) {
         try {


### PR DESCRIPTION
One bug fixed - for gpt adapters (openai) , on successful  task finish , correctly show the notification, and change the task window.
still open issue: do not show the agent response in the task window. after reopening task the response is there


fix: real-time updates for non-Claude (Codex CLI) tasks

Gate the cabinet-block retry to Claude adapters only (claude_local,
claude_code_legacy). Non-Claude providers don't emit the cabinet block,
so triggering the retry desynchronised the daemon session status from
meta.status, causing the safety poll to prematurely mark the task idle
and preventing live updates and completion notifications in the task
detail view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an explicit close button to the runtime picker dropdown, giving users direct control over dismissing the selection dialog without making changes.

* **Bug Fixes**
  * Fixed incorrect retry behavior that was triggering for incompatible adapter types, preventing potential daemon session and metadata status desynchronization issues.

* **Refactor**
  * Improved and simplified conditional logic in conversation handling callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->