### PR TITLE
fix(editor+artifacts): blank-page on task-panel artifact click

### DIFF
--- a/src/components/agents/conversation-live-view.tsx
+++ b/src/components/agents/conversation-live-view.tsx
@@ -60,8 +60,8 @@ export function ConversationLiveView({
   const promptText = detail.request || detail.meta.title;
   const [promptHtml, setPromptHtml] = useState("");
   const artifactTreePaths = useMemo(
-    () => detail.artifacts.map((a) => artifactPathToTreePath(a.path)),
-    [detail.artifacts]
+    () => detail.artifacts.map((a) => artifactPathToTreePath(a.path, detail.meta.cabinetPath)),
+    [detail.artifacts, detail.meta.cabinetPath]
   );
   const artifactMeta = usePageMeta(artifactTreePaths);
 
@@ -179,7 +179,7 @@ export function ConversationLiveView({
             </div>
             <div className="space-y-2">
               {detail.artifacts.map((artifact) => {
-                const treePath = artifactPathToTreePath(artifact.path);
+                const treePath = artifactPathToTreePath(artifact.path, detail.meta.cabinetPath);
                 const kind = artifactMeta.get(treePath)?.type ?? inferPageTypeFromPath(artifact.path);
                 const Icon = pageTypeIcon(kind);
                 const color = pageTypeColor(kind);

--- a/src/components/agents/conversation-result-view.tsx
+++ b/src/components/agents/conversation-result-view.tsx
@@ -54,8 +54,8 @@ export function ConversationResultView({
   const promptText = detail.request || detail.meta.title;
   const [promptHtml, setPromptHtml] = useState("");
   const artifactTreePaths = useMemo(
-    () => detail.artifacts.map((a) => artifactPathToTreePath(a.path)),
-    [detail.artifacts]
+    () => detail.artifacts.map((a) => artifactPathToTreePath(a.path, detail.meta.cabinetPath)),
+    [detail.artifacts, detail.meta.cabinetPath]
   );
   const artifactMeta = usePageMeta(artifactTreePaths);
 
@@ -189,7 +189,7 @@ export function ConversationResultView({
           {detail.artifacts.length > 0 ? (
             <div className="space-y-2">
               {detail.artifacts.map((artifact) => {
-                const treePath = artifactPathToTreePath(artifact.path);
+                const treePath = artifactPathToTreePath(artifact.path, detail.meta.cabinetPath);
                 const kind = artifactMeta.get(treePath)?.type ?? inferPageTypeFromPath(artifact.path);
                 const Icon = pageTypeIcon(kind);
                 const color = pageTypeColor(kind);

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -322,6 +322,14 @@ export function KBEditor() {
   const prevPathRef = useRef<string | null>(null);
   const renderedKeyRef = useRef<string | null>(null);
   const [renderedPath, setRenderedPath] = useState<string | null>(null);
+  // Tracks whether the *current* renderedKeyRef came from a loadStatus="ok"
+  // render. Without this, an early empty-content paint (cached paint where
+  // isLoading flipped false before the real fetch resolved, or any other
+  // transient `content=""` state) could lock renderedKeyRef = "<path>\0",
+  // and a later state echo that re-evaluates to the same (path, "") tuple
+  // would early-return via the dedupe check and never re-render the real
+  // content — surfacing as a permanently blank editor.
+  const renderedOkRef = useRef<boolean>(false);
   useEffect(() => {
     if (!editor || currentPath === null) return;
     // Skip if content hasn't actually changed (same path, dirty edit)
@@ -331,10 +339,16 @@ export function KBEditor() {
     // pure waste — every extension runs a full schema pass twice per
     // navigation. Skip until the real content arrives.
     if (isLoading && content === "") return;
+    // Don't commit an empty render for a path whose fetch hasn't reported
+    // success yet. If a cached paint or transient state lands `content=""`
+    // before loadStatus flips to "ok", waiting prevents the dedupe check
+    // below from locking in the empty key for this path.
+    if (content === "" && loadStatus !== "ok") return;
     // Dedupe identical (path, content) renders — e.g. cached paint followed
-    // by a fresh fetch that returned the same markdown.
+    // by a fresh fetch that returned the same markdown. Gated on
+    // renderedOkRef so a stale empty render never blocks a real one.
     const key = `${currentPath}\u0000${content}`;
-    if (renderedKeyRef.current === key) {
+    if (renderedKeyRef.current === key && renderedOkRef.current) {
       if (renderedPath !== currentPath) setRenderedPath(currentPath);
       return;
     }
@@ -342,17 +356,52 @@ export function KBEditor() {
 
     const setContent = async () => {
       isLoadingRef.current = true;
-      const html = await markdownToHtml(content, currentPath);
-      editor.commands.setContent(html);
-      renderedKeyRef.current = key;
-      setRenderedPath(currentPath);
-      setTimeout(() => {
-        isLoadingRef.current = false;
-      }, 50);
+      try {
+        const html = await markdownToHtml(content, currentPath);
+        editor.commands.setContent(html);
+        renderedKeyRef.current = key;
+        renderedOkRef.current = loadStatus === "ok";
+        setRenderedPath(currentPath);
+        // Surface a known-bad state instead of silently rendering blank: the
+        // store says we have content, but ProseMirror parsed it down to
+        // nothing. Almost always means a schema/extension mismatch (unknown
+        // element, malformed table, ...) — log so it's debuggable rather
+        // than leaving the user staring at an empty page.
+        if (content && editor.isEmpty) {
+          console.warn(
+            "[KBEditor] rendered empty document despite non-empty markdown",
+            { path: currentPath, contentLength: content.length },
+          );
+        }
+      } catch (err) {
+        // Clear the dedupe so the next state tick can retry instead of
+        // being blocked by a stale key from a failed render.
+        renderedKeyRef.current = null;
+        renderedOkRef.current = false;
+        console.error("[KBEditor] failed to render markdown", err, {
+          path: currentPath,
+          contentLength: content.length,
+        });
+      } finally {
+        setTimeout(() => {
+          isLoadingRef.current = false;
+        }, 50);
+      }
     };
 
     setContent();
-  }, [editor, content, currentPath, isLoading, renderedPath]);
+  }, [editor, content, currentPath, isLoading, loadStatus, renderedPath]);
+
+  // Source mode snapshots the markdown when toggled on, but doesn't listen
+  // for store updates — so navigating to a new page while source mode is
+  // open used to leave the textarea showing the previous page's content.
+  // Re-sync whenever the store's content changes for this path and the user
+  // hasn't started editing.
+  useEffect(() => {
+    if (!sourceMode) return;
+    if (useEditorStore.getState().isDirty) return;
+    setSourceText(content);
+  }, [sourceMode, content, currentPath]);
 
   // Push frontmatter.dir into the ProseMirror contenteditable element so list
   // indentation, table cell alignment, and block direction all flip when the

--- a/src/components/sidebar/recent-tasks.tsx
+++ b/src/components/sidebar/recent-tasks.tsx
@@ -376,7 +376,7 @@ export function RecentTasks({
                       key={path}
                       type="button"
                       onClick={() => {
-                        const treePath = artifactPathToTreePath(path);
+                        const treePath = artifactPathToTreePath(path, task.cabinetPath);
                         focusPath(treePath);
                         setSection({
                           type: "page",

--- a/src/components/sidebar/recent-tasks.tsx
+++ b/src/components/sidebar/recent-tasks.tsx
@@ -9,6 +9,7 @@ import { useEditorStore } from "@/stores/editor-store";
 import {
   artifactPathToTreePath,
   inferPageTypeFromPath,
+  isExternalArtifactPath,
   pageTypeIcon,
 } from "@/lib/ui/page-type-icons";
 import { dedupFetch } from "@/lib/api/dedup-fetch";
@@ -376,6 +377,17 @@ export function RecentTasks({
                       key={path}
                       type="button"
                       onClick={() => {
+                        if (isExternalArtifactPath(path)) {
+                          window.dispatchEvent(
+                            new CustomEvent("cabinet:toast", {
+                              detail: {
+                                kind: "info",
+                                message: `Outside cabinet — ${path}`,
+                              },
+                            }),
+                          );
+                          return;
+                        }
                         const treePath = artifactPathToTreePath(path, task.cabinetPath);
                         focusPath(treePath);
                         setSection({

--- a/src/components/tasks/conversation/artifacts-list.tsx
+++ b/src/components/tasks/conversation/artifacts-list.tsx
@@ -8,6 +8,7 @@ import { useTreeStore } from "@/stores/tree-store";
 import {
   artifactPathToTreePath,
   inferPageTypeFromPath,
+  isExternalArtifactPath,
   pageTypeColor,
   pageTypeIcon,
 } from "@/lib/ui/page-type-icons";
@@ -79,6 +80,21 @@ export function ArtifactsList({
             key={path}
             type="button"
             onClick={() => {
+              if (isExternalArtifactPath(path)) {
+                // Artifact lives outside DATA_DIR (e.g. an agent wrote to
+                // Claude Code's auto-memory dir). The page API would 404
+                // and the editor would render blank — surface the path
+                // instead so the user can open it manually.
+                window.dispatchEvent(
+                  new CustomEvent("cabinet:toast", {
+                    detail: {
+                      kind: "info",
+                      message: `Outside cabinet — ${path}`,
+                    },
+                  }),
+                );
+                return;
+              }
               const from = returnContext ?? useAppStore.getState().section;
               const treePath = artifactPathToTreePath(path, from.cabinetPath);
               focusPath(treePath);

--- a/src/components/tasks/conversation/artifacts-list.tsx
+++ b/src/components/tasks/conversation/artifacts-list.tsx
@@ -79,8 +79,8 @@ export function ArtifactsList({
             key={path}
             type="button"
             onClick={() => {
-              const treePath = artifactPathToTreePath(path);
               const from = returnContext ?? useAppStore.getState().section;
+              const treePath = artifactPathToTreePath(path, from.cabinetPath);
               focusPath(treePath);
               pushSection({ type: "page", cabinetPath: from.cabinetPath }, from);
               void loadPage(treePath);

--- a/src/components/tasks/conversation/turn-block.tsx
+++ b/src/components/tasks/conversation/turn-block.tsx
@@ -5,6 +5,7 @@ import { ChevronRight, Pause, Sparkles, User } from "lucide-react";
 import {
   artifactPathToTreePath,
   inferPageTypeFromPath,
+  isExternalArtifactPath,
   pageTypeColor,
   pageTypeIcon,
 } from "@/lib/ui/page-type-icons";
@@ -152,6 +153,17 @@ function KbArtifactRow({
     <button
       type="button"
       onClick={() => {
+        if (isExternalArtifactPath(path)) {
+          window.dispatchEvent(
+            new CustomEvent("cabinet:toast", {
+              detail: {
+                kind: "info",
+                message: `Outside cabinet — ${path}`,
+              },
+            }),
+          );
+          return;
+        }
         const from = returnContext ?? useAppStore.getState().section;
         const treePath = artifactPathToTreePath(path, from.cabinetPath);
         focusPath(treePath);

--- a/src/components/tasks/conversation/turn-block.tsx
+++ b/src/components/tasks/conversation/turn-block.tsx
@@ -152,8 +152,8 @@ function KbArtifactRow({
     <button
       type="button"
       onClick={() => {
-        const treePath = artifactPathToTreePath(path);
         const from = returnContext ?? useAppStore.getState().section;
+        const treePath = artifactPathToTreePath(path, from.cabinetPath);
         focusPath(treePath);
         pushSection({ type: "page", cabinetPath: from.cabinetPath }, from);
         void loadPage(treePath);

--- a/src/lib/navigation/open-artifact-path.ts
+++ b/src/lib/navigation/open-artifact-path.ts
@@ -2,7 +2,7 @@ import { useAppStore, type SelectedSection } from "@/stores/app-store";
 import { useEditorStore } from "@/stores/editor-store";
 import { useTreeStore } from "@/stores/tree-store";
 import { findNodeByPath } from "@/lib/cabinets/tree";
-import { artifactPathToTreePath } from "@/lib/ui/page-type-icons";
+import { artifactPathToTreePath, isExternalArtifactPath } from "@/lib/ui/page-type-icons";
 
 const NON_TEXT_ARTIFACT_EXTENSIONS = [
   ".pdf",
@@ -42,6 +42,17 @@ export async function openArtifactPath(
   path: string,
   section: SelectedSection
 ): Promise<void> {
+  if (isExternalArtifactPath(path)) {
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(
+        new CustomEvent("cabinet:toast", {
+          detail: { kind: "info", message: `Outside cabinet — ${path}` },
+        }),
+      );
+    }
+    return;
+  }
+
   const { setSection } = useAppStore.getState();
   const { focusPath, loadTree } = useTreeStore.getState();
   const { loadPage } = useEditorStore.getState();

--- a/src/lib/navigation/open-artifact-path.ts
+++ b/src/lib/navigation/open-artifact-path.ts
@@ -46,7 +46,7 @@ export async function openArtifactPath(
   const { focusPath, loadTree } = useTreeStore.getState();
   const { loadPage } = useEditorStore.getState();
 
-  const treePath = artifactPathToTreePath(path);
+  const treePath = artifactPathToTreePath(path, section.cabinetPath);
 
   setSection(section);
   focusPath(treePath);

--- a/src/lib/ui/page-type-icons.tsx
+++ b/src/lib/ui/page-type-icons.tsx
@@ -96,9 +96,18 @@ export function inferPageTypeFromPath(path: string): PageTypeKind {
  * drop `.md` / `/index.md` extensions, so e.g. `data/have-fun/bellatrix.md`
  * must be rewritten to `have-fun/bellatrix` before calling `selectPage`.
  *
- * Idempotent — safe to apply twice.
+ * Agents writing inside a sub-cabinet record paths CABINET-relative
+ * ("kb/reports/foo.md"), not DATA_DIR-relative
+ * ("zeropoint-capital/kb/reports/foo.md"). Pass `cabinetPath` so the
+ * cabinet prefix gets added when it's missing — without this,
+ * `loadPage("kb/reports/foo")` fetches `/api/pages/kb/...` which 404s
+ * under any non-root cabinet (manifested as a permanently blank editor
+ * when an artifact is clicked from a task panel).
+ *
+ * Idempotent — safe to apply twice. Safe to call with `cabinetPath`
+ * omitted for root-cabinet (".") paths.
  */
-export function artifactPathToTreePath(path: string): string {
+export function artifactPathToTreePath(path: string, cabinetPath?: string): string {
   if (!path) return path;
   let next = path.trim();
   next = next.replace(/^\/+/, "");
@@ -106,5 +115,13 @@ export function artifactPathToTreePath(path: string): string {
   next = next.replace(/\/index\.md$/, "");
   next = next.replace(/\/index\.html$/, "");
   next = next.replace(/\.md$/, "");
+  if (
+    cabinetPath &&
+    cabinetPath !== "." &&
+    next !== cabinetPath &&
+    !next.startsWith(`${cabinetPath}/`)
+  ) {
+    next = `${cabinetPath}/${next}`;
+  }
   return next;
 }

--- a/src/lib/ui/page-type-icons.tsx
+++ b/src/lib/ui/page-type-icons.tsx
@@ -115,7 +115,13 @@ export function artifactPathToTreePath(path: string, cabinetPath?: string): stri
   next = next.replace(/\/index\.md$/, "");
   next = next.replace(/\/index\.html$/, "");
   next = next.replace(/\.md$/, "");
+  // External (absolute-system) artifact paths must NOT get the cabinet
+  // prefix — they live outside DATA_DIR and the page API can't read them.
+  // See isExternalArtifactPath for the heuristic. Callers should check
+  // isExternalArtifactPath first and short-circuit the navigation; this
+  // guard is a backstop in case they don't.
   if (
+    !isExternalArtifactPath(path) &&
     cabinetPath &&
     cabinetPath !== "." &&
     next !== cabinetPath &&
@@ -124,4 +130,48 @@ export function artifactPathToTreePath(path: string, cabinetPath?: string): stri
     next = `${cabinetPath}/${next}`;
   }
   return next;
+}
+
+/**
+ * macOS/Linux system-root segments that an artifact path under DATA_DIR
+ * could never legitimately start with. Used to detect absolute filesystem
+ * paths an agent recorded as artifacts (e.g. files it wrote to Claude
+ * Code's auto-memory dir at `/Users/.../.claude/projects/.../memory/`).
+ * The page API path-traversal guard refuses anything outside DATA_DIR, so
+ * these would silently 404 if we tried to render them through the editor.
+ */
+const EXTERNAL_PATH_ROOTS = new Set([
+  "Users",
+  "home",
+  "private",
+  "tmp",
+  "var",
+  "etc",
+  "opt",
+  "bin",
+  "sbin",
+  "lib",
+  "usr",
+  "dev",
+  "Volumes",
+  "Library",
+  "Applications",
+  "System",
+]);
+
+/**
+ * True when an artifact path points outside the cabinet's DATA_DIR. Such
+ * paths can't be rendered through the page API — callers should either
+ * disable navigation or surface a clear "outside cabinet" message instead
+ * of letting the editor render blank.
+ */
+export function isExternalArtifactPath(path: string): boolean {
+  if (!path) return false;
+  const trimmed = path.trim();
+  // Windows drive prefixes (C:/, D:\, ...) are unambiguously absolute.
+  if (/^[a-zA-Z]:[\\/]/.test(trimmed)) return true;
+  const noSlashes = trimmed.replace(/^\/+/, "");
+  if (noSlashes.startsWith("data/")) return false;
+  const firstSeg = noSlashes.split("/", 1)[0] ?? "";
+  return EXTERNAL_PATH_ROOTS.has(firstSeg);
 }


### PR DESCRIPTION
## Summary

Two bugs both surfacing as "page is empty in the UI" for KB artifacts. The first fully explains the user-visible bug on this PR's repro; the second is a defense-in-depth fix in the same render path.

### Bug 1 — Click handler dropped the cabinet prefix (the real cause)

Agent-authored artifact paths in conversation events are stored CABINET-RELATIVE (e.g. `kb/reports/foo.md`) — not DATA_DIR-relative (`zeropoint-capital/kb/reports/foo.md`). `artifactPathToTreePath` only stripped `data/` and `.md`, so clicking an artifact called `loadPage("kb/reports/foo")` which hits `/api/pages/kb/reports/foo` → **404** under any non-root cabinet. Editor went to a `loadStatus: "missing"`-ish state and rendered blank.

Refreshing the URL worked because the route parser at `use-hash-route.ts` constructs the correctly-prefixed pagePath (`zeropoint-capital/kb/reports/foo`) from the URL itself — bypassing the click code path entirely. That mismatch is why "refresh works, click doesn't."

`artifactPathToTreePath` now accepts an optional `cabinetPath` and prepends it when the result doesn't already start with the cabinet prefix. Idempotent. No-op for root-cabinet (`"."`) paths. All callers (artifacts-list, turn-block KbArtifactRow, recent-tasks sidebar, both agent conversation views, `openArtifactPath` navigation helper) now pass the relevant `cabinetPath`.

### Bug 2 — KBEditor render-dedupe could lock on a transient empty render (defense-in-depth)

The `(path, content)` render-dedupe ref in KBEditor could commit a `<path>\0` empty-content key during a cached paint that lands `isLoading: false` before `loadStatus` flips to `"ok"`. Later state echoes that re-evaluated to the same tuple would early-return via the dedupe check, leaving the editor blank even when the store eventually held real content. With Bug 1 fixed this is mostly latent, but it could still trip under unusual cache-warming sequences.

- Added `if (content === "" && loadStatus !== "ok") return` so empty content can't be committed before the fetch succeeds.
- Added `renderedOkRef` — dedupe early-return now requires both key match AND that the prior render came from a `loadStatus === "ok"` state.
- Wrapped `setContent` in try/catch — failures clear `renderedKeyRef` so the next state tick can retry; failures log via `console.error`.
- `console.warn` when `editor.isEmpty` after rendering non-empty markdown — surfaces silent schema/extension drops instead of a quiet blank page.
- Companion: re-sync `sourceText` when the store's content changes while source mode is open. Without this, navigating in source mode kept showing the previous page's markdown until a manual toggle.

## Repro

1. Inside a non-root cabinet, click an artifact from the task panel (side drawer or full task page).
2. **Before this PR:** main area shows blank editor; the URL bar reads correctly. Refreshing the URL renders the page.
3. **After this PR:** content renders on click without needing a refresh.

## Test plan

- [ ] Click an artifact in the task side drawer (under a non-root cabinet) — content renders.
- [ ] Click an artifact in the full task page's artifacts list — content renders.
- [ ] Click an artifact row from the recent-tasks sidebar — content renders.
- [ ] Click an artifact in the agent conversation live-view / result-view — content renders.
- [ ] Same flows under the root cabinet (`.`) — no double-prefixing, content still renders.
- [ ] Refresh a deep-link URL to a non-root-cabinet KB page — still renders (regression check).
- [ ] Open page A → toggle source mode → navigate to page B via sidebar — source textarea reflects B's markdown without manual toggle.
- [ ] Edit a page, navigate away mid-edit — dirty-edit guard still preserves unsaved changes (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented editor from ending up empty during content sync and improved error handling when rendering fails.
  * Fixed source-mode sync so textarea stays up-to-date when switching modes or content changes.
  * Ensured artifact links and page selection respect the conversation/cabinet context so the correct page opens.
  * Detects external artifact links and shows an informational toast instead of attempting to open them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->