### PR TITLE
fix(tasks): correct slowInterval type to fix `next build`

### DIFF
--- a/src/components/tasks/conversation/task-conversation-page.tsx
+++ b/src/components/tasks/conversation/task-conversation-page.tsx
@@ -883,7 +883,7 @@ export function TaskConversationPage({
     // Fast ticks for the first 30s after open — that's when quick failures
     // happen and the user is staring at the drawer waiting.
     tick();
-    let slowInterval: ReturnType<typeof setInterval> | null = null;
+    let slowInterval: number | null = null;
     const fastInterval = window.setInterval(tick, 500);
     const slowSwitch = window.setTimeout(() => {
       window.clearInterval(fastInterval);


### PR DESCRIPTION
## Problem

`next build` fails type-checking on `main`:

```
./src/components/tasks/conversation/task-conversation-page.tsx:890:7
Type error: Type 'number' is not assignable to type 'Timeout'.
```

In `task-conversation-page.tsx`, `slowInterval` is declared as:

```ts
let slowInterval: ReturnType<typeof setInterval> | null = null;
```

`ReturnType<typeof setInterval>` resolves the **global** `setInterval` to Node's overload (via `@types/node`), which returns `NodeJS.Timeout`. But the variable is assigned the result of **`window.setInterval(...)`**, which uses the DOM overload returning `number`. The two don't match, so the build's type-check step rejects it.

There's no `typescript.ignoreBuildErrors` in `next.config.ts`, so this breaks `npm run build` on a clean checkout.

## Fix

Type it as `number | null` to match the browser API that's actually used (consistent with the sibling `fastInterval`/`slowSwitch` `window.*` timers in the same effect).

```diff
-    let slowInterval: ReturnType<typeof setInterval> | null = null;
+    let slowInterval: number | null = null;
```

Introduced in 2fd1e33.

## Verification

- `npx tsc --noEmit` → 0 errors (was 1)
- `next build` completes and type-checks successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected type annotation for interval handling to improve code reliability and alignment with browser standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->