### PR TITLE
fix(electron): surface startup failures instead of dying silently

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -710,7 +710,22 @@ app.on("second-instance", () => {
 
 app.whenReady().then(async () => {
   configureAutoUpdates();
-  await createWindow();
+  try {
+    await createWindow();
+  } catch (error) {
+    // Without this, a failed bootstrap (most commonly: no `npm run dev` server
+    // for the dev build to attach to) rejects unhandled and leaves a silent,
+    // windowless Electron process. Surface the cause instead.
+    const message = error instanceof Error ? error.message : String(error);
+    dialog.showErrorBox(
+      "Cabinet failed to start",
+      isDev
+        ? `${message}\n\nStart the dev server with \`npm run dev\` (or \`npm run dev:all\`) before \`npm run electron:start\`.`
+        : message
+    );
+    app.quit();
+    return;
+  }
 
   app.on("activate", async () => {
     if (BrowserWindow.getAllWindows().length === 0) {


### PR DESCRIPTION
## Problem

`npm run electron:start` (dev build) can produce a **running-but-windowless Electron process** with no error of any kind. The most common trigger: no Next dev server is running for Electron to attach to.

In `electron/main.cjs`:

```js
app.whenReady().then(async () => {
  configureAutoUpdates();
  await createWindow();   // <-- can reject; nothing catches it
  ...
});
```

`createWindow()` → `startEmbeddedCabinet()` → `resolveDevAppUrl()`, which polls `127.0.0.1:4000–4010/api/health` for 45s and then **throws** if nothing answers. Because the `whenReady().then(...)` chain has no `.catch`, that rejection is unhandled — the app stays alive (single-instance lock held) but never creates a window, and the user gets no indication why.

## Fix

Wrap `createWindow()` in try/catch: show an error dialog and quit. In dev, include an actionable hint to start the dev server first.

```js
try {
  await createWindow();
} catch (error) {
  const message = error instanceof Error ? error.message : String(error);
  dialog.showErrorBox(
    "Cabinet failed to start",
    isDev
      ? `${message}\n\nStart the dev server with \`npm run dev\` (or \`npm run dev:all\`) before \`npm run electron:start\`.`
      : message
  );
  app.quit();
  return;
}
```

Now the failure is visible and the process doesn't linger. The packaged build benefits too — any bootstrap failure (e.g. embedded server health timeout) shows a dialog instead of a silent hang.

## Verification

- `node --check electron/main.cjs` passes.
- Reproduced the original silent failure (run `electron:start` with no dev server) → confirmed windowless process. With the dev server running, the window opens normally; with the fix, the no-server case shows the error dialog and exits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced startup error handling: when app initialization fails, users now receive an error dialog describing the issue and the app gracefully exits, preventing silent failures where the application would hang unresponsively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->