### PR TITLE
fix(search): "Open page" now navigates to the selected page

### DIFF
--- a/src/components/search/search-palette.tsx
+++ b/src/components/search/search-palette.tsx
@@ -329,6 +329,26 @@ export function SearchPalette() {
       commitRecentQuery(query);
       if (entry.kind === "page") {
         commitRecentPage(entry.hit.id);
+        // Derive cabinetPath from the hit's path: search hits use
+        // DATA_DIR-relative paths where the first segment is the top-level
+        // cabinet (room). Fall back to activeRoom for single-segment
+        // (root-level) paths. The hit's own cabinet is the source of truth
+        // — using activeRoom alone breaks when the result is from a
+        // different cabinet than the current view.
+        const firstSegment = entry.hit.path.split("/")[0];
+        const hitCabinetPath =
+          entry.hit.path.includes("/") && firstSegment ? firstSegment : "";
+        const cabinetPath = hitCabinetPath || activeRoom;
+        // Set the section FIRST so the section.type === "page" branch
+        // wins the render race. Order matters: if selectPage triggers
+        // the tree-store subscriber while section.type is still "cabinet"
+        // (the prior view), buildHash silently emits the cabinet URL,
+        // not the page URL.
+        setSection(
+          cabinetPath
+            ? { type: "page", cabinetPath }
+            : { type: "page" }
+        );
         selectPage(entry.hit.path);
         void loadPage(entry.hit.path);
       } else if (entry.kind === "agent") {
@@ -338,7 +358,7 @@ export function SearchPalette() {
       }
       closePalette();
     },
-    [commitRecentQuery, commitRecentPage, selectPage, loadPage, setSection, closePalette, query]
+    [commitRecentQuery, commitRecentPage, selectPage, loadPage, setSection, closePalette, query, activeRoom]
   );
 
   const runCommand = useCallback(


### PR DESCRIPTION
## Summary

Clicking **Open page** in the search palette closed the dialog but didn't navigate to the result — the page was loaded into editor state in the background while the user stayed on the prior view (cabinet dashboard, home, agents, tasks, settings).

Agent and task results already called `setSection`; pages were the only kind that didn't. This mirrors the tree-node click flow which sets section + selected path + loads content together.

Two extra details that matter:

1. **`cabinetPath` is derived from the hit's path** (its first segment), not from `activeRoom`. `activeRoom` can disagree with the result's room when search returns cross-room hits, which produced a wrong URL form for the navigation.

2. **`setSection` runs *before* `selectPage`** so the tree-store subscriber that rebuilds the URL hash sees `section.type === "page"` on its first pass. Otherwise the URL briefly emits the prior-section's form before the section update catches up.

Affects all three open-paths through `openEntry`: clicking the **Open page** button in the right pane, double-clicking a row in the left pane, and pressing Enter.

## Test plan

- [ ] Open Cmd+K from the home view, search for a page, click **Open page** → editor renders the page, URL updates to `#/p/{path}` (root cabinet) or `#/cabinet/{cabinet}/data/{rest}` (nested).
- [ ] Open Cmd+K from a cabinet dashboard, search, click **Open page** → view flips from CabinetView to the editor showing the selected page.
- [ ] Open Cmd+K from the agents / tasks / settings views and confirm same.
- [ ] Press Enter on a selected page result → same navigation behavior.
- [ ] Double-click a row in the left pane → same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced search result navigation for pages. When opening page search results, the app now properly derives the destination context from the search result metadata with fallback handling. The page section is updated before loading to ensure correct display and render timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->