### PR TITLE
fix(perf): pause background-tab polling so two cabinet URLs can coexist

### DIFF
--- a/src/components/cabinets/activity-feed.tsx
+++ b/src/components/cabinets/activity-feed.tsx
@@ -10,6 +10,7 @@ import { StatusIcon, type CardState } from "@/components/tasks/board/status-icon
 import { ProviderGlyph } from "@/components/agents/provider-glyph";
 import { useProviderIcons } from "@/hooks/use-provider-icons";
 import { formatRelative } from "./cabinet-utils";
+import { useVisibleInterval } from "@/hooks/use-visible-interval";
 import type { ConversationMeta } from "@/types/conversations";
 import type { CabinetAgentSummary } from "@/types/cabinets";
 import type { TaskStatus } from "@/types/tasks";
@@ -81,11 +82,9 @@ export function ActivityFeed({
     }
   }, [cabinetPath, visibilityMode, agentSlug]);
 
-  useEffect(() => {
-    void refresh();
-    const iv = setInterval(() => void refresh(), 6000);
-    return () => clearInterval(iv);
-  }, [refresh]);
+  // Pause the 6s refresh when the tab is hidden so background tabs
+  // don't burn the per-origin HTTP/1.1 connection budget.
+  useVisibleInterval(refresh, 6000);
 
   // Pin running conversations to top
   const sorted = useMemo(() => {

--- a/src/components/cabinets/agent-status-grid.tsx
+++ b/src/components/cabinets/agent-status-grid.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 import { DepthDropdown } from "./depth-dropdown";
 import { sortOrgAgents, startCase } from "./cabinet-utils";
 import { AgentStatusCard } from "./agent-status-card";
+import { useVisibleInterval } from "@/hooks/use-visible-interval";
 import type { AgentConversationInfo } from "./agent-status-card";
 import type {
   CabinetAgentSummary,
@@ -70,11 +71,9 @@ export function AgentStatusGrid({
     }
   }, [cabinetPath, visibilityMode]);
 
-  useEffect(() => {
-    void fetchConversations();
-    const iv = setInterval(() => void fetchConversations(), 8000);
-    return () => clearInterval(iv);
-  }, [fetchConversations]);
+  // Pause polling when the tab is hidden to keep the per-origin
+  // HTTP/1.1 connection budget free for the foreground tab.
+  useVisibleInterval(fetchConversations, 8000);
 
   const sorted = useMemo(() => [...agents].sort(sortOrgAgents), [agents]);
 

--- a/src/components/cabinets/cabinet-view.tsx
+++ b/src/components/cabinets/cabinet-view.tsx
@@ -21,6 +21,7 @@ import type { JobConfig } from "@/types/jobs";
 import { ActivityFeed } from "@/components/cabinets/activity-feed";
 import { DepthDropdown } from "@/components/cabinets/depth-dropdown";
 import { fetchCabinetOverviewClient } from "@/lib/cabinets/overview-client";
+import { useVisibleInterval } from "@/hooks/use-visible-interval";
 import { useAppStore } from "@/stores/app-store";
 import { useTreeStore } from "@/stores/tree-store";
 import { useEditorStore } from "@/stores/editor-store";
@@ -124,16 +125,10 @@ export function CabinetView({ cabinetPath }: { cabinetPath: string }) {
     }
   }, [cabinetPath, cabinetVisibilityMode]);
 
-  useEffect(() => {
-    void loadOverview();
-    const interval = window.setInterval(() => void loadOverview(), 15000);
-    const onFocus = () => void loadOverview();
-    window.addEventListener("focus", onFocus);
-    return () => {
-      window.clearInterval(interval);
-      window.removeEventListener("focus", onFocus);
-    };
-  }, [loadOverview]);
+  // Pause overview polling when this tab is hidden. With two Cabinet
+  // tabs open this avoids burning HTTP/1.1 connection slots on a
+  // background tab that nobody is looking at.
+  useVisibleInterval(loadOverview, 15000);
 
   // Tick `now` every minute so Next-up labels stay fresh.
   useEffect(() => {

--- a/src/components/layout/status-bar.tsx
+++ b/src/components/layout/status-bar.tsx
@@ -17,6 +17,7 @@ import { useTaskRail } from "@/components/tasks/rail/task-rail-context";
 import { dedupFetch } from "@/lib/api/dedup-fetch";
 import { useLocale } from "@/i18n/use-locale";
 import { useUserProfile } from "@/hooks/use-user-profile";
+import { useVisibleInterval } from "@/hooks/use-visible-interval";
 import type { TFunction } from "i18next";
 
 const DISCORD_SUPPORT_URL = "https://discord.gg/hJa5TRTbTH";
@@ -365,30 +366,12 @@ export function StatusBar() {
     return () => window.clearTimeout(initialPull);
   }, [pullAndRefresh]);
 
-  // Poll git status
-  useEffect(() => {
-    const initialFetch = window.setTimeout(() => {
-      void fetchGitStatus();
-    }, 0);
-    const interval = setInterval(fetchGitStatus, 15000);
-    // Audit #058: refresh on tab focus so a banner stuck at "1 uncommitted"
-    // updates the moment the user comes back. The 15s interval still
-    // catches background changes between focus events.
-    const onFocus = () => {
-      void fetchGitStatus();
-    };
-    const onVisibility = () => {
-      if (document.visibilityState === "visible") void fetchGitStatus();
-    };
-    window.addEventListener("focus", onFocus);
-    document.addEventListener("visibilitychange", onVisibility);
-    return () => {
-      window.clearTimeout(initialFetch);
-      clearInterval(interval);
-      window.removeEventListener("focus", onFocus);
-      document.removeEventListener("visibilitychange", onVisibility);
-    };
-  }, []);
+  // Poll git status. Audit #058: refresh on tab focus so a banner stuck
+  // at "1 uncommitted" updates the moment the user comes back.
+  // useVisibleInterval pauses the 15s tick while the tab is hidden and
+  // also fires once on visibility change, replacing the manual focus +
+  // visibilitychange listeners that used to live here.
+  useVisibleInterval(fetchGitStatus, 15000);
 
   useEffect(() => {
     void fetchStars();

--- a/src/components/mission-control/slack-panel.tsx
+++ b/src/components/mission-control/slack-panel.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import type { SlackMessage } from "@/types/agents";
 import { useLocale } from "@/i18n/use-locale";
+import { useVisibleInterval } from "@/hooks/use-visible-interval";
 
 interface AgentMention {
   slug: string;
@@ -247,17 +248,18 @@ export function SlackPanel({ height: initialHeight = 200, onOpenFile }: SlackPan
   }, []);
 
   useEffect(() => {
-    loadMessages();
     // Listen for SSE slack refresh events
     const handleRefresh = () => loadMessages();
     window.addEventListener("cabinet:slack-refresh", handleRefresh);
-    // Fallback poll every 10s (was 5s, now SSE handles real-time)
-    const interval = setInterval(loadMessages, 10000);
     return () => {
-      clearInterval(interval);
       window.removeEventListener("cabinet:slack-refresh", handleRefresh);
     };
   }, [loadMessages]);
+
+  // Fallback poll every 10s (SSE handles real-time; this catches gaps).
+  // Pause polling when the tab is hidden to free per-origin connection
+  // slots for the foreground tab.
+  useVisibleInterval(loadMessages, 10000);
 
   useEffect(() => {
     if (scrollRef.current) {

--- a/src/hooks/use-visible-interval.ts
+++ b/src/hooks/use-visible-interval.ts
@@ -1,0 +1,57 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Run `callback` on `intervalMs` ticks, but only while the document is
+ * visible. When the tab is hidden the interval skips firing; when it
+ * becomes visible again the callback runs once immediately (catch-up)
+ * and the regular cadence resumes.
+ *
+ * Why this exists: Cabinet polls several endpoints on short intervals
+ * (overview, git status, agent status, activity feed). With multiple
+ * tabs open against the same dev origin, the per-tab pollers plus
+ * Next.js HMR sockets quickly saturate the browser's per-origin
+ * HTTP/1.1 connection budget (~6 connections per host), and any
+ * foreground tab's new requests queue forever as "Pending, 0 KB". By
+ * silencing background tabs' polling we leave the foreground tab's
+ * budget free.
+ *
+ * Companion to the pattern already in `tree-view.tsx` (`if
+ * (document.visibilityState === "visible")` inside the interval body),
+ * generalized so every poller picks it up consistently.
+ */
+export function useVisibleInterval(
+  callback: () => void | Promise<void>,
+  intervalMs: number,
+  options: { fireOnMount?: boolean } = { fireOnMount: true }
+): void {
+  // Pin the latest callback in a ref so the effect can stay mounted
+  // across renders without restarting the interval each time the
+  // caller passes a new closure.
+  const cbRef = useRef(callback);
+  cbRef.current = callback;
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    let cancelled = false;
+    const run = () => {
+      if (cancelled) return;
+      if (document.visibilityState !== "visible") return;
+      void cbRef.current();
+    };
+
+    if (options.fireOnMount) run();
+
+    const interval = window.setInterval(run, intervalMs);
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") run();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [intervalMs, options.fireOnMount]);
+}


### PR DESCRIPTION
## Summary

Two Cabinet URLs in the same browser couldn't coexist — opening a second tab caused the foreground tab's API requests to stick at \`(pending) 0.0 kB\` indefinitely (confirmed reproducer: cabinet-view's overview, status-bar's git/commit, and the document itself all hang). Closing the other tab unblocks the foreground tab instantly.

## Root cause

Each Cabinet tab fires several recurring fetches plus an HMR websocket:

| Endpoint | Cadence | Component |
| --- | --- | --- |
| \`/api/cabinets/overview\` | 15s | \`cabinet-view\` |
| \`/api/git/commit\` (GET) | 15s | \`status-bar\` |
| conversations | 8s | \`agent-status-grid\` |
| activity refresh | 6s | \`activity-feed\` |
| slack fallback | 10s | \`mission-control/slack-panel\` |

With two tabs open against \`localhost:4000\`, the browser's per-host HTTP/1.1 connection budget (~6) is consumed by background-tab pollers + HMR sockets, starving the foreground tab.

## Fix

Add \`useVisibleInterval(callback, ms)\` — fires only while \`document.visibilityState === "visible"\` and also runs once on visibility change so a backgrounded tab resyncs immediately when the user returns. \`tree-view.tsx\` already used this pattern inline; the hook generalizes it.

Applied to the five highest-cadence network pollers (listed above). The slack-panel keeps its SSE listener; only its polling fallback is gated.

## Test plan

- [ ] Open two Cabinet tabs at different cabinets, switch back and forth — both load promptly, no hang.
- [ ] Backgrounded tab: open DevTools Network — confirm no \`overview\` / \`commit\` / activity requests fire while the tab is hidden.
- [ ] Switch back to the previously hidden tab — confirm one immediate catch-up request per poller, then the normal cadence resumes.
- [ ] Slack panel still updates in near-real-time via the \`cabinet:slack-refresh\` SSE event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Background polling operations now pause when the browser tab is inactive, reducing unnecessary resource consumption. Polling resumes automatically when the tab becomes active again.
  * Affected operations: conversation activity refresh, agent status updates, cabinet overview, git status monitoring, and Slack message loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->