### PR TITLE
fix(conversation-runner): honor adapterErrorKind in session-expired recovery

### DIFF
--- a/src/lib/agents/conversation-runner.ts
+++ b/src/lib/agents/conversation-runner.ts
@@ -1863,10 +1863,21 @@ export async function continueConversationRun(
 
     // Fallback: session expired (Claude --resume failed). Retry in replay
     // mode with full history.
+    //
+    // Trust the daemon's classification first — the adapter-side
+    // classifyError already saw the raw stderr and returned the canonical
+    // ConversationErrorKind. The textual fallback (`result.errorMessage ||
+    // result.output`) is for adapters that don't populate
+    // adapterErrorKind, but it only matched if the keyword leaked into
+    // output/errorMessage, which for the daemon path it usually doesn't —
+    // executeViaDaemon synthesises errorMessage from `result.output`, so a
+    // session-expired stderr classified by the daemon would never trip the
+    // string check, leaving session.alive=true and re-failing every turn.
     if (
       canResume &&
       result.status === "failed" &&
-      isSessionExpiredError(result.errorMessage || result.output)
+      (result.adapterErrorKind === "session_expired" ||
+        isSessionExpiredError(result.errorMessage || result.output))
     ) {
       await writeSession(
         conversationId,


### PR DESCRIPTION
## Summary
When Claude Code's `--resume` handle is rejected, Cabinet is supposed to mark `session.alive = false`, surface "Cabinet will retry with the full conversation history on the next turn", and replay with full history. In practice on the daemon path (the default under `next dev`), the recovery code never fires and every subsequent turn fast-fails with the same dead resume id.

## Root cause
The fallback gate in `continueConversationRun` (`src/lib/agents/conversation-runner.ts:1866-1870`) checks only:
```ts
isSessionExpiredError(result.errorMessage || result.output)
```
On the daemon path, `executeViaDaemon` synthesises `errorMessage` from `result.output` (line 1836), which is the rendered turn output — not the raw stderr the daemon's classifier saw. The daemon-side classifier in `src/lib/agents/adapters/error-classification.ts:69-78` correctly tags `result.adapterErrorKind = "session_expired"` (which is exactly how the user-visible hint at line 76 gets surfaced), but the runner ignores that authoritative field at the fallback gate.

Net effect:
- ✗ Replay-fallback never runs.
- ✗ `writeSession({alive: false})` (line 1871) never executes.
- ✗ Next turn re-reads `alive: true`, recomputes `canResume = true`, retries with the same dead resume id → identical `session_expired` failure.
- The misleading hint compounds the bug: the message promises retry, but no retry happens.

Repro signature on a stuck task:
- `events.log` shows multiple consecutive `task.updated status=failed errorKind=session_expired` entries on different turns (often hours apart, each failing in 1-3s).
- `session.json` still has `"alive": true` with a stale `lastUsedAt` from before the first failure.

## Fix
Accept `result.adapterErrorKind === "session_expired"` as a trigger in addition to the existing string-match. The textual fallback stays as belt-and-braces for adapters that don't populate `adapterErrorKind`.

## Recovery for already-stuck tasks
Set `"alive": false` in the task's `session.json`, then send a new turn — `canResume` will be false and the runner will go straight to replay mode:
```bash
sed -i '' 's/"alive": true/"alive": false/' <task-dir>/session.json
```

## Test plan
- [x] `tsc --noEmit` clean on the changed file
- [x] Verified against a real stuck task (`session.json` shows `alive:true` from `lastUsedAt: 12:54:42`, three subsequent turns at 12:54 / 14:51 / 15:17 all fast-fail with session_expired); the workaround above unsticks it immediately
- [ ] Reviewer: simulate a session_expired by setting a bogus `resumeId` in a task's `session.json` (keep `alive:true`), send a new turn; confirm the runner now flips `alive` to false and the replay completes within the same turn

## Notes
- The symmetric in-process path at `conversation-runner.ts:1213-1217` has a related shape — its `result` is `AdapterExecutionResult` which doesn't carry `adapterErrorKind` directly, so a parallel fix there needs the adapter's `classifyError` to run before the gate. Left for a follow-up; the daemon path is what users hit under `next dev`.
- Same fix was filed against the downstream fork at alpha8eta/zeropoint-cabinet#3 so a recurrent local install bug gets unblocked while this lands upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session expiration detection and recovery mechanisms in conversations, enabling more reliable error handling and reducing potential retry failures during connection interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->