### PR TITLE
Fix dev-origin allowlist over remote hosts, board-less page navigation, and add Fable 5

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,13 +6,23 @@ import type { NextConfig } from "next";
 // in which case the operator sets CABINET_APP_ORIGIN. Auto-allow its host.
 function resolveAllowedDevOrigins(): string[] {
   const origins = new Set<string>(["127.0.0.1", "localhost"]);
+  // CABINET_APP_ORIGIN may be a single origin OR a comma-separated allowlist
+  // (e.g. a loopback origin plus a Tailscale/LAN hostname) — the daemon CORS
+  // allowlist already parses it that way. Parse each entry independently: a
+  // single new URL() over the whole comma string throws and silently drops
+  // every host, which makes Next block /_next/* (403) from the extra origins
+  // and leaves the app non-interactive there.
   const appOrigin = process.env.CABINET_APP_ORIGIN?.trim();
   if (appOrigin) {
-    try {
-      const { hostname } = new URL(appOrigin);
-      if (hostname) origins.add(hostname);
-    } catch {
-      // Malformed CABINET_APP_ORIGIN — ignore.
+    for (const entry of appOrigin.split(",")) {
+      const value = entry.trim();
+      if (!value) continue;
+      try {
+        const { hostname } = new URL(value);
+        if (hostname) origins.add(hostname);
+      } catch {
+        // Malformed entry — ignore just this one.
+      }
     }
   }
   return Array.from(origins);

--- a/scripts/dev-next.mjs
+++ b/scripts/dev-next.mjs
@@ -5,6 +5,30 @@ import { spawn } from "child_process";
 
 const PROJECT_ROOT = process.cwd();
 
+// dev-next.mjs is frequently launched by launchd / a process manager rather
+// than an interactive shell, so it does NOT inherit exported env and nothing
+// auto-loads `.env`. next.config.ts reads CABINET_APP_ORIGIN to allow
+// non-loopback dev origins (Tailscale / LAN) through Next's dev-origin guard;
+// without it the loopback default set on the child below wins and remote hosts
+// get 403 on /_next/* (page loads but can't hydrate). Seed it from `.env` when
+// it isn't already present in the environment.
+if (!process.env.CABINET_APP_ORIGIN) {
+  try {
+    const envRaw = fs.readFileSync(path.join(PROJECT_ROOT, ".env"), "utf8");
+    for (const line of envRaw.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const eq = trimmed.indexOf("=");
+      if (eq === -1 || trimmed.slice(0, eq).trim() !== "CABINET_APP_ORIGIN") continue;
+      const value = trimmed.slice(eq + 1).trim().replace(/^["']|["']$/g, "");
+      if (value) process.env.CABINET_APP_ORIGIN = value;
+      break;
+    }
+  } catch {
+    // No `.env` / unreadable — fall back to the loopback default below.
+  }
+}
+
 function parsePort(value, fallback) {
   const parsed = Number.parseInt(String(value || ""), 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;

--- a/src/components/sidebar/recent-tasks.tsx
+++ b/src/components/sidebar/recent-tasks.tsx
@@ -12,6 +12,7 @@ import {
   pageTypeIcon,
 } from "@/lib/ui/page-type-icons";
 import { dedupFetch } from "@/lib/api/dedup-fetch";
+import { ensureCabinetPrefixedPagePath } from "@/lib/cabinets/paths";
 import { conversationMetaToTaskMeta } from "@/lib/agents/conversation-to-task-view";
 import { getAgentColor, tintFromHex } from "@/lib/agents/cron-compute";
 import { isLegacyAdapterType } from "@/lib/agents/adapters/legacy-ids";
@@ -376,7 +377,10 @@ export function RecentTasks({
                       key={path}
                       type="button"
                       onClick={() => {
-                        const treePath = artifactPathToTreePath(path);
+                        const treePath = ensureCabinetPrefixedPagePath(
+                          task.cabinetPath,
+                          artifactPathToTreePath(path)
+                        );
                         focusPath(treePath);
                         setSection({
                           type: "page",

--- a/src/components/tasks/conversation/artifacts-list.tsx
+++ b/src/components/tasks/conversation/artifacts-list.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from "react";
 import { ChevronRight } from "lucide-react";
 import { useAppStore, type SelectedSection } from "@/stores/app-store";
+import { ensureCabinetPrefixedPagePath } from "@/lib/cabinets/paths";
 import { useEditorStore } from "@/stores/editor-store";
 import { useTreeStore } from "@/stores/tree-store";
 import {
@@ -79,8 +80,11 @@ export function ArtifactsList({
             key={path}
             type="button"
             onClick={() => {
-              const treePath = artifactPathToTreePath(path);
               const from = returnContext ?? useAppStore.getState().section;
+              const treePath = ensureCabinetPrefixedPagePath(
+                from.cabinetPath,
+                artifactPathToTreePath(path)
+              );
               focusPath(treePath);
               pushSection({ type: "page", cabinetPath: from.cabinetPath }, from);
               void loadPage(treePath);

--- a/src/components/tasks/conversation/task-conversation-page.tsx
+++ b/src/components/tasks/conversation/task-conversation-page.tsx
@@ -143,14 +143,21 @@ function applyTerminalPayloadToTask(
   if (typeof raw !== "string") return null;
   const taskStatus = conversationStatusToTaskStatus(raw);
   if (!taskStatus || taskStatus === "running") return null;
-  const errorHint =
-    typeof payload.errorHint === "string"
+  // Only carry an error while the task is actually failed. A transient error
+  // (e.g. a resume/session blip the runner recovers from via replay) emits a
+  // momentary failed event; when the task later resolves to a non-failed
+  // status, clear the stale errorKind/errorHint so the banner doesn't stick.
+  const isFailed = taskStatus === "failed";
+  const errorHint = isFailed
+    ? typeof payload.errorHint === "string"
       ? payload.errorHint
-      : prev.meta.errorHint;
-  const errorKind =
-    typeof payload.errorKind === "string"
+      : prev.meta.errorHint
+    : undefined;
+  const errorKind = isFailed
+    ? typeof payload.errorKind === "string"
       ? payload.errorKind
-      : prev.meta.errorKind;
+      : prev.meta.errorKind
+    : undefined;
   if (
     prev.meta.status === taskStatus &&
     prev.meta.errorHint === errorHint &&

--- a/src/components/tasks/conversation/turn-block.tsx
+++ b/src/components/tasks/conversation/turn-block.tsx
@@ -9,6 +9,7 @@ import {
   pageTypeIcon,
 } from "@/lib/ui/page-type-icons";
 import { useAppStore, type SelectedSection } from "@/stores/app-store";
+import { ensureCabinetPrefixedPagePath } from "@/lib/cabinets/paths";
 import { useEditorStore } from "@/stores/editor-store";
 import { useTreeStore } from "@/stores/tree-store";
 import { cn } from "@/lib/utils";
@@ -152,8 +153,11 @@ function KbArtifactRow({
     <button
       type="button"
       onClick={() => {
-        const treePath = artifactPathToTreePath(path);
         const from = returnContext ?? useAppStore.getState().section;
+        const treePath = ensureCabinetPrefixedPagePath(
+          from.cabinetPath,
+          artifactPathToTreePath(path)
+        );
         focusPath(treePath);
         pushSection({ type: "page", cabinetPath: from.cabinetPath }, from);
         void loadPage(treePath);

--- a/src/hooks/use-hash-route.ts
+++ b/src/hooks/use-hash-route.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { ROOT_CABINET_PATH } from "@/lib/cabinets/paths";
+import { ROOT_CABINET_PATH, ensureCabinetPrefixedPagePath } from "@/lib/cabinets/paths";
 import { buildTaskHash, buildTasksHash } from "@/lib/navigation/task-route";
 import { useAppStore } from "@/stores/app-store";
 import { useTreeStore } from "@/stores/tree-store";
@@ -223,7 +223,10 @@ function parseHash(hash: string): RouteState {
     }
 
     if (leaf === "data" && parts[3]) {
-      const pagePath = decodePathSegment(parts.slice(3).join("/"));
+      const pagePath = ensureCabinetPrefixedPagePath(
+        cabinetPath,
+        decodePathSegment(parts.slice(3).join("/"))
+      );
       return {
         section: { type: "page", cabinetPath },
         pagePath,
@@ -234,7 +237,10 @@ function parseHash(hash: string): RouteState {
     // (no /data/ segment) used to fall through to the home route, which
     // broke deep-links. Interpret the remaining segments as a page path
     // under the cabinet so reload keeps the user on the page they were on.
-    const pagePath = decodePathSegment(parts.slice(2).join("/"));
+    const pagePath = ensureCabinetPrefixedPagePath(
+      cabinetPath,
+      decodePathSegment(parts.slice(2).join("/"))
+    );
     return {
       section: { type: "page", cabinetPath },
       pagePath,

--- a/src/lib/agents/adapters/error-classification.ts
+++ b/src/lib/agents/adapters/error-classification.ts
@@ -41,7 +41,7 @@ export function classifyCommonError(
 
   // ---- auth_expired ------------------------------------------------------
   if (
-    /(?:not (?:logged in|authenticated)|unauthori[sz]ed|401(?!\d)|403\s*.*(?:auth|login)|missing api key|api[-_ ]?key\s*(?:not\s*(?:set|provided|found)|invalid|expired)|please (?:sign|log) ?in|run .{0,30}(?:login|auth)|session.{0,20}expired|token.{0,20}expired|invalid credentials|credentials (?:not found|missing))/i.test(
+    /(?:not (?:logged in|authenticated)|unauthori[sz]ed|401(?!\d)|403\s*.*(?:auth|login)|missing api key|api[-_ ]?key\s*(?:not\s*(?:set|provided|found)|invalid|expired)|please (?:sign|log) ?in|run .{0,30}(?:login|auth)|token.{0,20}expired|invalid credentials|credentials (?:not found|missing))/i.test(
       text
     )
   ) {

--- a/src/lib/agents/providers/claude-code.ts
+++ b/src/lib/agents/providers/claude-code.ts
@@ -45,15 +45,21 @@ export const claudeCodeProvider: AgentProvider = {
   ],
   models: [
     {
+      id: "fable",
+      name: "Claude Fable 5",
+      description: "Most powerful model, above Opus, with configurable effort",
+      effortLevels: [...OPUS_THINKING_LEVELS],
+    },
+    {
       id: "opus",
-      name: "Claude Opus 4.7",
-      description: "Most intelligent with configurable effort",
+      name: "Claude Opus 4.8",
+      description: "Most intelligent Opus with configurable effort",
       effortLevels: [...OPUS_THINKING_LEVELS],
     },
     {
       id: "opus[1m]",
-      name: "Claude Opus 4.7 (1M context)",
-      description: "Opus 4.7 with 1M-token context for very long sessions",
+      name: "Claude Opus 4.8 (1M context)",
+      description: "Opus 4.8 with 1M-token context for very long sessions",
       effortLevels: [...OPUS_THINKING_LEVELS],
     },
     {

--- a/src/lib/cabinets/paths.ts
+++ b/src/lib/cabinets/paths.ts
@@ -1,5 +1,30 @@
 export const ROOT_CABINET_PATH = ".";
 
+/**
+ * Page paths in named sub-cabinets are data-relative and include the board as
+ * their first segment (e.g. `zeropoint-capital/kb/reports/foo`) — that full
+ * path is what `loadPage`/`readPage` resolve against. Links and artifact paths
+ * are sometimes recorded cabinet-RELATIVE (`kb/reports/foo`, board dropped),
+ * which then 404s and renders the "no index.md" placeholder. Re-add the board
+ * prefix when missing. No-op for the root cabinet, empty paths, or paths that
+ * already carry the board (so canonical paths are never double-prefixed).
+ */
+export function ensureCabinetPrefixedPagePath(
+  cabinetPath: string | undefined,
+  pagePath: string
+): string {
+  if (
+    !cabinetPath ||
+    cabinetPath === ROOT_CABINET_PATH ||
+    !pagePath ||
+    pagePath === cabinetPath ||
+    pagePath.startsWith(`${cabinetPath}/`)
+  ) {
+    return pagePath;
+  }
+  return `${cabinetPath}/${pagePath}`;
+}
+
 export function normalizeCabinetPath(
   value?: string | null,
   fallbackToRoot = false

--- a/src/lib/navigation/open-artifact-path.ts
+++ b/src/lib/navigation/open-artifact-path.ts
@@ -3,6 +3,7 @@ import { useEditorStore } from "@/stores/editor-store";
 import { useTreeStore } from "@/stores/tree-store";
 import { findNodeByPath } from "@/lib/cabinets/tree";
 import { artifactPathToTreePath } from "@/lib/ui/page-type-icons";
+import { ensureCabinetPrefixedPagePath } from "@/lib/cabinets/paths";
 
 const NON_TEXT_ARTIFACT_EXTENSIONS = [
   ".pdf",
@@ -46,7 +47,10 @@ export async function openArtifactPath(
   const { focusPath, loadTree } = useTreeStore.getState();
   const { loadPage } = useEditorStore.getState();
 
-  const treePath = artifactPathToTreePath(path);
+  const treePath = ensureCabinetPrefixedPagePath(
+    section.cabinetPath,
+    artifactPathToTreePath(path)
+  );
 
   setSection(section);
   focusPath(treePath);

--- a/src/lib/runtime/runtime-config.ts
+++ b/src/lib/runtime/runtime-config.ts
@@ -13,7 +13,9 @@ function parsePort(value: string | undefined, fallback: number): number {
 }
 
 function normalizeOrigin(value: string | undefined): string | null {
-  const trimmed = value?.trim();
+  // CABINET_APP_ORIGIN may be a comma-separated allowlist; the first entry is
+  // the canonical origin used for building absolute URLs.
+  const trimmed = value?.split(",")[0]?.trim();
   if (!trimmed) return null;
   return trimmed.replace(/\/+$/, "");
 }

--- a/test/cabinet-paths.test.ts
+++ b/test/cabinet-paths.test.ts
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  ensureCabinetPrefixedPagePath,
+  ROOT_CABINET_PATH,
+} from "@/lib/cabinets/paths";
+
+test("ensureCabinetPrefixedPagePath prepends the board for a board-less path", () => {
+  assert.equal(
+    ensureCabinetPrefixedPagePath("zeropoint-capital", "kb/reports/foo"),
+    "zeropoint-capital/kb/reports/foo"
+  );
+});
+
+test("ensureCabinetPrefixedPagePath leaves an already-board-prefixed path unchanged", () => {
+  assert.equal(
+    ensureCabinetPrefixedPagePath(
+      "zeropoint-capital",
+      "zeropoint-capital/kb/reports/foo"
+    ),
+    "zeropoint-capital/kb/reports/foo"
+  );
+});
+
+test("ensureCabinetPrefixedPagePath is a no-op for the root cabinet", () => {
+  assert.equal(
+    ensureCabinetPrefixedPagePath(ROOT_CABINET_PATH, "kb/reports/foo"),
+    "kb/reports/foo"
+  );
+});
+
+test("ensureCabinetPrefixedPagePath is a no-op when cabinetPath is undefined", () => {
+  assert.equal(
+    ensureCabinetPrefixedPagePath(undefined, "kb/reports/foo"),
+    "kb/reports/foo"
+  );
+});
+
+test("ensureCabinetPrefixedPagePath does not prefix the board's own root page", () => {
+  assert.equal(
+    ensureCabinetPrefixedPagePath("zeropoint-capital", "zeropoint-capital"),
+    "zeropoint-capital"
+  );
+});
+
+test("ensureCabinetPrefixedPagePath leaves an empty page path empty", () => {
+  assert.equal(ensureCabinetPrefixedPagePath("zeropoint-capital", ""), "");
+});

--- a/test/hash-route.test.ts
+++ b/test/hash-route.test.ts
@@ -36,3 +36,29 @@ test("parseHash treats #/cabinet/<path>/<slug> (no /data/) as a page deep-link, 
   assert.equal(route.section.cabinetPath, ".");
   assert.equal(route.pagePath, "getting-started");
 });
+
+test("parseHash re-adds the board prefix for a board-less /data/ deep-link in a named cabinet", () => {
+  const route = parseHash(
+    "#/cabinet/zeropoint-capital/data/kb/reports/income-strategies-low-drawdown-2026-06-10"
+  );
+  assert.equal(route.section.type, "page");
+  assert.equal(route.section.cabinetPath, "zeropoint-capital");
+  assert.equal(
+    route.pagePath,
+    "zeropoint-capital/kb/reports/income-strategies-low-drawdown-2026-06-10"
+  );
+});
+
+test("parseHash does NOT double-prefix a canonical board-prefixed /data/ link", () => {
+  const route = parseHash(
+    "#/cabinet/zeropoint-capital/data/zeropoint-capital/kb/reports/foo"
+  );
+  assert.equal(route.section.type, "page");
+  assert.equal(route.pagePath, "zeropoint-capital/kb/reports/foo");
+});
+
+test("parseHash re-adds the board prefix for the legacy no-/data/ form in a named cabinet", () => {
+  const route = parseHash("#/cabinet/zeropoint-capital/kb/reports/foo");
+  assert.equal(route.section.type, "page");
+  assert.equal(route.pagePath, "zeropoint-capital/kb/reports/foo");
+});


### PR DESCRIPTION
Three independent, self-contained fixes found while running Cabinet as a `next dev` server accessed over Tailscale. Each is its own commit so they can be reviewed (or dropped) individually.

## 1. `fix(dev)`: dev-origin allowlist ignores `.env` / multi-origin `CABINET_APP_ORIGIN`

**Symptom:** over a non-loopback host (Tailscale `*.ts.net`, LAN IP) the page loads (HTML 200) but is non-interactive — e.g. the `/login` form won't submit. `/_next/*` returns **403** from that origin.

**Cause:** Next blocks cross-origin dev requests from hosts not in `allowedDevOrigins`. `next.config.ts` builds that list from `CABINET_APP_ORIGIN`, but:
- `resolveAllowedDevOrigins()` parsed it with a single `new URL()`, which **throws** on a comma-separated value (the multi-origin format the daemon's CORS allowlist in `server/cabinet-daemon.ts` already supports via `.split(",")`) — the `catch` swallows it and every host is dropped.
- `scripts/dev-next.mjs` is frequently launched by **launchd / a process manager** (no shell), so it never loads `.env`. Its loopback default for the child's `CABINET_APP_ORIGIN` then wins, and Next won't override an env var that's already set — so the `.env` value (the documented mechanism, per `.env.example`) never reaches `next.config`.
- `normalizeOrigin()` returned the raw comma string as the canonical app origin.

**Fix:** parse `CABINET_APP_ORIGIN` as a comma-separated allowlist in `next.config.ts`; seed it from `.env` in `dev-next.mjs` when absent; use the first entry as canonical in `normalizeOrigin()`.

## 2. `fix(nav)`: board-less page paths render the "no index.md" placeholder

**Symptom:** opening a KB page in a *named* sub-cabinet from a deep-link or a task/artifact click shows "This folder doesn't have an index.md yet" even though the `.md` exists on disk.

**Cause:** tree node paths are data-relative and include the board (`<board>/kb/reports/foo`), and that full path is what `loadPage`/`readPage` resolve against. But deep-links and recorded artifact paths are sometimes cabinet-**relative** (`kb/reports/foo`, board dropped) — loading that 404s.

**Fix:** add a shared `ensureCabinetPrefixedPagePath()` helper (`src/lib/cabinets/paths.ts`) and apply it at every site that turns a path into a `loadPage` target: `use-hash-route` (the `data` + legacy branches), `open-artifact-path`, `recent-tasks`, `artifacts-list`, `turn-block`. It's a no-op for the root cabinet and already-prefixed paths, so canonical links are never double-prefixed. The two conversation views that only use the path for icon/metadata display (and route clicks through the already-fixed `openArtifactPath`) are intentionally left untouched.

## 3. `feat(providers)`: add Claude Fable 5, refresh Claude Code labels

The Claude Code provider hardcoded "Opus 4.7" labels against the floating `opus` CLI alias (now Opus 4.8), mislabeling the current model. Adds the `fable` entry (alias verified in `@anthropic-ai/claude-code`'s `sdk-tools.d.ts`: `"sonnet" | "opus" | "haiku" | "fable"`) and bumps the Opus labels to 4.8.

## Testing
- New `test/cabinet-paths.test.ts` (6 cases) + 3 added cases in `test/hash-route.test.ts` — full `hash-route` suite 8/8, `cabinet-paths` 6/6 green.
- `node --check scripts/dev-next.mjs` passes.
- Verified end-to-end on a live server: after the dev-origin fix, a real `/_next/static/chunks/*.js` returns 200 from the Tailscale origin (was 403) and the login form works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Claude Fable 5 support and upgraded Claude Opus models to 4.8

* **Bug Fixes**
  * Fixed artifact navigation and cabinet-scoped path handling by re-prefixing page paths
  * Prevented stale error banners by clearing transient error metadata on non-failed updates
  * Improved dev startup: populate CABINET_APP_ORIGIN from .env when needed and support comma-separated allowlist parsing
  * Adjusted error-classification for certain auth-expired stderr patterns
  * Ensure routine editor loads full job data when opened with partial info

* **Tests**
  * Added unit tests for cabinet path handling and hash-route parsing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->