### PR TITLE
Make completed conversation repair idempotent

### DIFF
--- a/src/lib/agents/conversation-store-turns.test.ts
+++ b/src/lib/agents/conversation-store-turns.test.ts
@@ -203,6 +203,50 @@ test("finalizeConversation preserves artifacts merged from later turns", async (
   );
 });
 
+test("read-repair strips placeholder artifacts and then stays idempotent", async () => {
+  const meta = await makeSingleShotConversation(
+    "Placeholder repair",
+    "User request:\nstart",
+    "Done.\n```cabinet\nSUMMARY: done\nARTIFACT: reports/real.md\n```"
+  );
+
+  // Inject the unfilled ARTIFACT hint into stored meta — the placeholder shape
+  // that `needsRepair` flags via isPlaceholderCabinetValue. (Matches
+  // PLACEHOLDER_ARTIFACT_HINT in conversation-store.ts.)
+  const metaFile = path.join(
+    tempRoot, ".agents", ".conversations", meta.id, "meta.json"
+  );
+  const stored = JSON.parse(await fs.readFile(metaFile, "utf8"));
+  stored.artifactPaths = [
+    "relative/path/to/file for every KB file you created or updated",
+    ...stored.artifactPaths,
+  ];
+  await fs.writeFile(metaFile, JSON.stringify(stored, null, 2));
+
+  // First read triggers repair: the placeholder is dropped, the real path kept.
+  await store.readConversationDetail(meta.id);
+  const repaired = await store.readConversationMeta(meta.id);
+  assert.deepEqual(repaired?.artifactPaths, ["reports/real.md"]);
+
+  // artifacts.json mirrors the cleaned list.
+  const artifactFile = await fs.readFile(
+    path.join(tempRoot, ".agents", ".conversations", meta.id, "artifacts.json"),
+    "utf8"
+  );
+  assert.deepEqual(JSON.parse(artifactFile), [{ path: "reports/real.md" }]);
+
+  // Idempotent: now that the placeholder is gone, a further read must not
+  // re-finalize (no new task.updated event).
+  const before = await store.readEventLog(meta.id);
+  await store.readConversationDetail(meta.id);
+  const after = await store.readEventLog(meta.id);
+  assert.equal(
+    after.length,
+    before.length,
+    "a placeholder-repaired conversation must not re-finalize on later reads"
+  );
+});
+
 test("writeSession + readSession round-trip", async () => {
   const meta = await makeSingleShotConversation(
     "Session",

--- a/src/lib/agents/conversation-store-turns.test.ts
+++ b/src/lib/agents/conversation-store-turns.test.ts
@@ -154,6 +154,55 @@ test("updateAgentTurn settles a pending turn", async () => {
   assert.ok(reread?.artifactPaths.includes("a.md"));
 });
 
+test("finalizeConversation preserves artifacts merged from later turns", async () => {
+  const meta = await makeSingleShotConversation(
+    "Late finalize",
+    "User request:\nstart",
+    "Initial.\n```cabinet\nSUMMARY: initial\nARTIFACT: reports/source.md\n```"
+  );
+  await store.appendUserTurn(meta.id, { content: "render as png" });
+  await store.appendAgentTurn(meta.id, {
+    content: "Rendering...",
+    pending: true,
+  });
+  await store.updateAgentTurn(meta.id, 2, {
+    content:
+      "Rendered.\n```cabinet\nSUMMARY: rendered\nARTIFACT: reports/output.png\n```",
+    pending: false,
+  });
+
+  await store.finalizeConversation(meta.id, {
+    status: "completed",
+    exitCode: 0,
+    output: "Initial.\n```cabinet\nSUMMARY: initial\nARTIFACT: reports/source.md\n```",
+  });
+
+  const reread = await store.readConversationMeta(meta.id);
+  assert.deepEqual(reread?.artifactPaths, [
+    "reports/source.md",
+    "reports/output.png",
+  ]);
+
+  const artifactFile = await fs.readFile(
+    path.join(tempRoot, ".agents", ".conversations", meta.id, "artifacts.json"),
+    "utf8"
+  );
+  assert.deepEqual(JSON.parse(artifactFile), [
+    { path: "reports/source.md" },
+    { path: "reports/output.png" },
+  ]);
+
+  const eventsBeforeRead = await store.readEventLog(meta.id);
+  const detail = await store.readConversationDetail(meta.id);
+  assert.ok(detail);
+  const eventsAfterRead = await store.readEventLog(meta.id);
+  assert.equal(
+    eventsAfterRead.length,
+    eventsBeforeRead.length,
+    "reading a repaired conversation must not append another task.updated event"
+  );
+});
+
 test("writeSession + readSession round-trip", async () => {
   const meta = await makeSingleShotConversation(
     "Session",

--- a/src/lib/agents/conversation-store.ts
+++ b/src/lib/agents/conversation-store.ts
@@ -1479,13 +1479,23 @@ export async function finalizeConversation(
   if (parsed.contextSummary) {
     meta.contextSummary = parsed.contextSummary;
   }
+  // Drop placeholder artifact entries from the stored list before merging.
+  // `needsRepair` treats a placeholder in meta.artifactPaths as repair-required,
+  // and the merge below preserves existing entries — so without this filter a
+  // placeholder would survive finalize, keep `needsRepair` true, and re-trigger
+  // finalize on every read (the non-idempotency this PR exists to fix). Incoming
+  // parsed artifacts are already placeholder-free (parser rejects them), so the
+  // union ends up clean.
+  const sanitizedArtifactPaths = (meta.artifactPaths ?? []).filter(
+    (artifactPath) => !isPlaceholderCabinetValue(artifactPath)
+  );
   if (artifacts.length > 0) {
     meta.artifactPaths = mergeArtifactPaths(
-      meta.artifactPaths,
+      sanitizedArtifactPaths,
       artifacts.map((artifact) => artifact.path)
     );
-  } else if (!meta.artifactPaths) {
-    meta.artifactPaths = [];
+  } else {
+    meta.artifactPaths = sanitizedArtifactPaths;
   }
 
   // First-turn tokens — G7. Only write when the caller provided a reading and
@@ -1532,14 +1542,12 @@ export async function finalizeConversation(
     }
   }
 
-  // Keep artifacts.json in sync with the value we actually committed to
-  // meta.artifactPaths above — if we preserved a prior stream-extracted
-  // list (because this finalize had no fresh artifacts), write that back
-  // instead of a blank array.
-  const artifactsToWrite =
-    artifacts.length > 0
-      ? meta.artifactPaths.map((artifactPath) => ({ path: artifactPath }))
-      : (meta.artifactPaths ?? []).map((artifactPath) => ({ path: artifactPath }));
+  // Keep artifacts.json in sync with the exact (sanitized + merged) list we
+  // committed to meta.artifactPaths above — covers both fresh-artifact and
+  // preserved-prior-list finalizes, with placeholders already stripped.
+  const artifactsToWrite = meta.artifactPaths.map((artifactPath) => ({
+    path: artifactPath,
+  }));
   await Promise.all([
     writeConversationMeta(meta),
     replaceConversationArtifacts(id, artifactsToWrite, cp),

--- a/src/lib/agents/conversation-store.ts
+++ b/src/lib/agents/conversation-store.ts
@@ -1295,6 +1295,9 @@ async function maybeResolveCompletedConversation(
     return meta;
   }
   const parsed = parseCabinetBlock(transcript, prompt);
+  const parsedArtifactsMissingFromMeta = parsed.artifactPaths.some(
+    (artifactPath) => !meta.artifactPaths.includes(artifactPath)
+  );
   const needsRepair =
     meta.status === "running" ||
     isPlaceholderCabinetValue(meta.summary) ||
@@ -1302,8 +1305,7 @@ async function maybeResolveCompletedConversation(
     meta.artifactPaths.some((artifactPath) => isPlaceholderCabinetValue(artifactPath)) ||
     (!!parsed.summary && parsed.summary !== meta.summary) ||
     (!!parsed.contextSummary && parsed.contextSummary !== meta.contextSummary) ||
-    (parsed.artifactPaths.length > 0 &&
-      parsed.artifactPaths.join("|") !== meta.artifactPaths.join("|"));
+    parsedArtifactsMissingFromMeta;
 
   if (!needsRepair) {
     return meta;
@@ -1478,7 +1480,10 @@ export async function finalizeConversation(
     meta.contextSummary = parsed.contextSummary;
   }
   if (artifacts.length > 0) {
-    meta.artifactPaths = artifacts.map((artifact) => artifact.path);
+    meta.artifactPaths = mergeArtifactPaths(
+      meta.artifactPaths,
+      artifacts.map((artifact) => artifact.path)
+    );
   } else if (!meta.artifactPaths) {
     meta.artifactPaths = [];
   }
@@ -1533,7 +1538,7 @@ export async function finalizeConversation(
   // instead of a blank array.
   const artifactsToWrite =
     artifacts.length > 0
-      ? artifacts
+      ? meta.artifactPaths.map((artifactPath) => ({ path: artifactPath }))
       : (meta.artifactPaths ?? []).map((artifactPath) => ({ path: artifactPath }));
   await Promise.all([
     writeConversationMeta(meta),


### PR DESCRIPTION
## Summary
- Preserve existing artifact paths when finalizing a conversation with parsed artifacts
- Treat parsed transcript artifacts as a subset of stored meta artifacts during completed-conversation repair
- Add a regression test that reading a repaired conversation does not append another `task.updated` event

## Why
A completed task can accumulate artifacts across later turns or manual repair. The read-time repair path compared parsed transcript artifacts to `meta.artifactPaths` with exact equality, so a valid superset in meta caused every task detail read to re-finalize the conversation and emit another `task.updated`. That can trigger continuous UI refresh/readiness blinking.

## Validation
- `npx tsx --test --test-name-pattern 'finalizeConversation preserves artifacts merged from later turns' src/lib/agents/conversation-store-turns.test.ts`
- `git diff --check -- src/lib/agents/conversation-store.ts src/lib/agents/conversation-store-turns.test.ts`
- `npx eslint src/lib/agents/conversation-store.ts src/lib/agents/conversation-store-turns.test.ts` (passes with existing warnings: unused `reason`, unused `err` in `conversation-store.ts`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Fixed artifact preservation in conversations. Artifact paths from multiple conversation turns are now properly merged during finalization, preventing missing or overwritten artifact references.
- Improved conversation integrity validation to detect missing artifact references and automatically repair placeholder entries without duplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->