### PR TITLE
fix(tasks): share one SSE connection for conversation events

### DIFF
--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -41,6 +41,7 @@ import { NarrowViewportHint } from "@/components/layout/narrow-viewport-hint";
 import { ConfirmDialogHost } from "@/components/ui/confirm-dialog-host";
 import { useGlobalHotkeys } from "@/hooks/use-global-hotkeys";
 import { dedupFetch } from "@/lib/api/dedup-fetch";
+import { subscribeConversationEvents } from "@/lib/agents/conversation-events-client";
 import { StatusBar } from "@/components/layout/status-bar";
 import { DaemonHealthBanner } from "@/components/layout/daemon-health-banner";
 import { TourModal } from "@/components/onboarding/tour/tour-modal";
@@ -278,7 +279,6 @@ export function AppShell() {
   // non-empty we reload the tree (debounced) so new files appear without a
   // manual refresh. App-wide so it works from any section.
   useEffect(() => {
-    const es = new EventSource("/api/agents/conversations/events");
     let timer: number | null = null;
     const scheduleRefresh = () => {
       if (timer !== null) return;
@@ -287,9 +287,9 @@ export function AppShell() {
         void loadTree();
       }, 400);
     };
-    es.onmessage = (msg) => {
+    const unsubscribe = subscribeConversationEvents((data) => {
       try {
-        const ev = JSON.parse(msg.data) as {
+        const ev = JSON.parse(data) as {
           type?: string;
           payload?: { artifactPaths?: unknown };
         };
@@ -301,9 +301,9 @@ export function AppShell() {
       } catch {
         // ignore malformed frames / pings
       }
-    };
+    });
     return () => {
-      es.close();
+      unsubscribe();
       if (timer !== null) window.clearTimeout(timer);
     };
   }, [loadTree]);

--- a/src/components/sidebar/recent-tasks.tsx
+++ b/src/components/sidebar/recent-tasks.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/lib/ui/page-type-icons";
 import { dedupFetch } from "@/lib/api/dedup-fetch";
 import { conversationMetaToTaskMeta } from "@/lib/agents/conversation-to-task-view";
+import { subscribeConversationEvents } from "@/lib/agents/conversation-events-client";
 import { getAgentColor, tintFromHex } from "@/lib/agents/cron-compute";
 import { isLegacyAdapterType } from "@/lib/agents/adapters/legacy-ids";
 import { TelegramMark } from "@/components/integrations/telegram-mark";
@@ -145,7 +146,6 @@ export function RecentTasks({
 
     // Auto-refresh via the global conversation SSE. Debounce so a burst of
     // messages (common during a run) collapses into one reload instead of N.
-    const es = new EventSource("/api/agents/conversations/events");
     let reloadTimer: number | null = null;
     const scheduleReload = () => {
       if (reloadTimer !== null) return;
@@ -154,9 +154,9 @@ export function RecentTasks({
         void loadTasks();
       }, 200);
     };
-    es.onmessage = (msg) => {
+    const unsubscribe = subscribeConversationEvents((data) => {
       try {
-        const event = JSON.parse(msg.data) as { type: string; taskId?: string };
+        const event = JSON.parse(data) as { type: string; taskId?: string };
         if (event.type === "ping") return;
         if (event.type === "task.deleted" && event.taskId) {
           setTasks((prev) =>
@@ -167,7 +167,7 @@ export function RecentTasks({
       } catch {
         // ignore
       }
-    };
+    });
 
     // Tick once a minute so "fresh done" green dots fade back to muted without
     // waiting for the next SSE event.
@@ -175,7 +175,7 @@ export function RecentTasks({
 
     return () => {
       cancelled = true;
-      es.close();
+      unsubscribe();
       if (reloadTimer !== null) window.clearTimeout(reloadTimer);
       clearInterval(tick);
     };

--- a/src/components/tasks/board/use-board-data.ts
+++ b/src/components/tasks/board/use-board-data.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { fetchCabinetOverviewClient } from "@/lib/cabinets/overview-client";
 import { dedupFetch } from "@/lib/api/dedup-fetch";
 import { conversationMetaToTaskMeta } from "@/lib/agents/conversation-to-task-view";
+import { subscribeConversationEvents } from "@/lib/agents/conversation-events-client";
 import type { ConversationMeta } from "@/types/conversations";
 import type { TaskMeta } from "@/types/tasks";
 import type { CabinetOverview, CabinetAgentSummary, CabinetJobSummary, CabinetVisibilityMode } from "@/types/cabinets";
@@ -138,11 +139,10 @@ export function useBoardData({ cabinetPath, visibilityMode = "own" }: Options): 
         if (mountedRef.current) setLoading(false);
       });
 
-    const es = new EventSource("/api/agents/conversations/events");
     let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-    es.onmessage = (msg) => {
+    const unsubscribe = subscribeConversationEvents((data) => {
       try {
-        const event = JSON.parse(msg.data) as {
+        const event = JSON.parse(data) as {
           type?: string;
           taskId?: string;
         };
@@ -159,7 +159,7 @@ export function useBoardData({ cabinetPath, visibilityMode = "own" }: Options): 
       } catch {
         // ignore malformed events
       }
-    };
+    });
 
     const onFocus = () => void refresh();
     window.addEventListener("focus", onFocus);
@@ -169,7 +169,7 @@ export function useBoardData({ cabinetPath, visibilityMode = "own" }: Options): 
     return () => {
       mountedRef.current = false;
       if (debounceTimer) clearTimeout(debounceTimer);
-      es.close();
+      unsubscribe();
       window.removeEventListener("focus", onFocus);
       clearInterval(tick);
     };

--- a/src/components/tasks/conversation/task-conversation-page.tsx
+++ b/src/components/tasks/conversation/task-conversation-page.tsx
@@ -66,6 +66,7 @@ import type { Task, TaskEvent, TaskStatus } from "@/types/tasks";
 import type { AgentListItem } from "@/types/agents";
 import type { CabinetAgentSummary } from "@/types/cabinets";
 import { compactTask, fetchTask, patchTask, postTurn } from "@/lib/agents/task-client";
+import { subscribeConversationEvents } from "@/lib/agents/conversation-events-client";
 import { peekTaskIsTerminal } from "@/lib/agents/terminal-mode-cache";
 import { buildRuntimeLabel } from "@/lib/agents/runtime-format";
 
@@ -758,7 +759,6 @@ export function TaskConversationPage({
   // per-conversation SSE reconnects late. Debounced to match the board.
   useEffect(() => {
     if (isDemo) return;
-    const es = new EventSource("/api/agents/conversations/events");
     let debounce: ReturnType<typeof setTimeout> | null = null;
     const scheduleRefetch = (_reason: string) => {
       if (debounce) clearTimeout(debounce);
@@ -770,9 +770,9 @@ export function TaskConversationPage({
           .catch(() => {});
       }, 200);
     };
-    es.onmessage = (msg) => {
+    const unsubscribe = subscribeConversationEvents((data) => {
       try {
-        const event = JSON.parse(msg.data) as TaskEvent | { type: "ping" };
+        const event = JSON.parse(data) as TaskEvent | { type: "ping" };
         if (event.type === "ping") return;
         if ("taskId" in event && event.taskId && event.taskId !== taskId) return;
         const eventPayload =
@@ -787,10 +787,10 @@ export function TaskConversationPage({
       } catch {
         // ignore malformed frames
       }
-    };
+    });
     return () => {
       if (debounce) clearTimeout(debounce);
-      es.close();
+      unsubscribe();
     };
   }, [isDemo, taskId, cabinetPath]);
 

--- a/src/components/tasks/rail/use-task-rail-data.ts
+++ b/src/components/tasks/rail/use-task-rail-data.ts
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { dedupFetch } from "@/lib/api/dedup-fetch";
 import { conversationMetaToTaskMeta } from "@/lib/agents/conversation-to-task-view";
+import { subscribeConversationEvents } from "@/lib/agents/conversation-events-client";
 import { fetchCabinetOverviewClient } from "@/lib/cabinets/overview-client";
 import { ROOT_CABINET_PATH } from "@/lib/cabinets/paths";
 import { useAppStore } from "@/stores/app-store";
@@ -137,7 +138,6 @@ export function useTaskRailData(): TaskRailData {
 
     // Live refresh on the shared conversation SSE, debounced so a burst of
     // turn events during a run collapses into one reload.
-    const es = new EventSource("/api/agents/conversations/events");
     let reloadTimer: number | null = null;
     const scheduleReload = () => {
       if (reloadTimer !== null) return;
@@ -146,9 +146,9 @@ export function useTaskRailData(): TaskRailData {
         void load();
       }, 200);
     };
-    es.onmessage = (msg) => {
+    const unsubscribe = subscribeConversationEvents((data) => {
       try {
-        const event = JSON.parse(msg.data) as { type: string; taskId?: string };
+        const event = JSON.parse(data) as { type: string; taskId?: string };
         if (event.type === "ping") return;
         if (event.type === "task.deleted" && event.taskId) {
           setItems((prev) => prev.filter((item) => item.task.id !== event.taskId));
@@ -157,14 +157,14 @@ export function useTaskRailData(): TaskRailData {
       } catch {
         // ignore malformed frames
       }
-    };
+    });
 
     // Refresh relative timestamps in tooltips once a minute.
     const tick = window.setInterval(() => setNow(Date.now()), 60_000);
 
     return () => {
       cancelled = true;
-      es.close();
+      unsubscribe();
       if (reloadTimer !== null) window.clearTimeout(reloadTimer);
       if (flashTimerRef.current !== null) {
         window.clearTimeout(flashTimerRef.current);

--- a/src/hooks/use-task-file-sync.ts
+++ b/src/hooks/use-task-file-sync.ts
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { useTreeStore } from "@/stores/tree-store";
 import { useEditorStore } from "@/stores/editor-store";
 import { artifactPathToTreePath } from "@/lib/ui/page-type-icons";
+import { subscribeConversationEvents } from "@/lib/agents/conversation-events-client";
 
 /**
  * Keeps the sidebar + open editor in sync with files that agent tasks create or
@@ -18,13 +19,11 @@ import { artifactPathToTreePath } from "@/lib/ui/page-type-icons";
  *     unsaved edits, offer a non-destructive "Reload" toast instead of
  *     clobbering them.
  *
- * Mount once (in the app shell). Rides the same global event stream the recent-
- * tasks list uses, so it costs one extra SSE subscription.
+ * Mount once (in the app shell). Rides the shared conversation event stream,
+ * so it costs no extra connection.
  */
 export function useTaskFileSync(): void {
   useEffect(() => {
-    const es = new EventSource("/api/agents/conversations/events");
-
     let pending = new Set<string>();
     let flushTimer: number | null = null;
     // Don't re-toast the same dirty page on every debounce tick during a run.
@@ -71,9 +70,9 @@ export function useTaskFileSync(): void {
       if (flushTimer === null) flushTimer = window.setTimeout(flush, 250);
     };
 
-    es.onmessage = (msg) => {
+    const unsubscribe = subscribeConversationEvents((data) => {
       try {
-        const event = JSON.parse(msg.data) as {
+        const event = JSON.parse(data) as {
           type?: string;
           payload?: { artifactPaths?: unknown; artifacts?: unknown };
         };
@@ -87,11 +86,11 @@ export function useTaskFileSync(): void {
       } catch {
         // ignore malformed events
       }
-    };
+    });
 
     return () => {
       if (flushTimer !== null) window.clearTimeout(flushTimer);
-      es.close();
+      unsubscribe();
     };
   }, []);
 }

--- a/src/lib/agents/conversation-events-client.ts
+++ b/src/lib/agents/conversation-events-client.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared client-side subscription to `/api/agents/conversations/events`.
+ *
+ * Six different surfaces (sidebar recent-tasks, board, rail, file-sync,
+ * app-shell tree refresh, conversation page) used to open their own
+ * EventSource to this URL. Browsers cap HTTP/1.1 connections at 6 per
+ * origin, so with a few surfaces mounted the SSE streams consumed the whole
+ * pool and every other fetch to the app queued indefinitely — tasks
+ * "stuck on Starting…", panels spinning forever. One real connection,
+ * fanned out to any number of listeners, keeps the pool free.
+ *
+ * Listeners receive the raw `MessageEvent.data` string and keep their own
+ * parsing/filtering, so call sites stay byte-for-byte compatible with what
+ * they did when they owned the EventSource.
+ */
+
+type ConversationEventListener = (data: string) => void;
+
+const listeners = new Set<ConversationEventListener>();
+let source: EventSource | null = null;
+
+function ensureSource(): void {
+  if (source) return;
+  source = new EventSource("/api/agents/conversations/events");
+  source.onmessage = (msg) => {
+    for (const listener of [...listeners]) {
+      try {
+        listener(msg.data);
+      } catch {
+        // One bad listener must not starve the others.
+      }
+    }
+  };
+  // No onerror handling needed: EventSource reconnects on its own, and we
+  // never want to tear the shared stream down while subscribers exist.
+}
+
+/**
+ * Subscribe to the shared conversation event stream. Opens the underlying
+ * EventSource on first subscribe, closes it when the last subscriber leaves.
+ * Returns an unsubscribe function (idempotent).
+ */
+export function subscribeConversationEvents(
+  listener: ConversationEventListener
+): () => void {
+  listeners.add(listener);
+  ensureSource();
+  let active = true;
+  return () => {
+    if (!active) return;
+    active = false;
+    listeners.delete(listener);
+    if (listeners.size === 0 && source) {
+      source.close();
+      source = null;
+    }
+  };
+}

--- a/src/lib/agents/conversation-events-client.ts
+++ b/src/lib/agents/conversation-events-client.ts
@@ -18,11 +18,15 @@ type ConversationEventListener = (data: string) => void;
 
 const listeners = new Set<ConversationEventListener>();
 let source: EventSource | null = null;
+let retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+const RETRY_MS = 2000;
 
 function ensureSource(): void {
   if (source) return;
-  source = new EventSource("/api/agents/conversations/events");
-  source.onmessage = (msg) => {
+  const es = new EventSource("/api/agents/conversations/events");
+  source = es;
+  es.onmessage = (msg) => {
     for (const listener of [...listeners]) {
       try {
         listener(msg.data);
@@ -31,8 +35,21 @@ function ensureSource(): void {
       }
     }
   };
-  // No onerror handling needed: EventSource reconnects on its own, and we
-  // never want to tear the shared stream down while subscribers exist.
+  // EventSource reconnects on its own from transient errors (readyState
+  // stays CONNECTING), but a fatal failure — e.g. an HTTP error response
+  // during a dev-server recompile — closes it permanently. Recreate the
+  // stream after a short delay while subscribers still exist, so one bad
+  // response doesn't kill live updates for the rest of the session.
+  es.onerror = () => {
+    if (source !== es || es.readyState !== EventSource.CLOSED) return;
+    source = null;
+    if (listeners.size > 0 && retryTimer === null) {
+      retryTimer = setTimeout(() => {
+        retryTimer = null;
+        if (listeners.size > 0) ensureSource();
+      }, RETRY_MS);
+    }
+  };
 }
 
 /**
@@ -50,8 +67,12 @@ export function subscribeConversationEvents(
     if (!active) return;
     active = false;
     listeners.delete(listener);
-    if (listeners.size === 0 && source) {
-      source.close();
+    if (listeners.size === 0) {
+      if (retryTimer !== null) {
+        clearTimeout(retryTimer);
+        retryTimer = null;
+      }
+      source?.close();
       source = null;
     }
   };


### PR DESCRIPTION
Fable 5 fixed it :)

Six surfaces (sidebar recent-tasks, board, rail, file-sync, app-shell tree refresh, conversation page) each opened their own EventSource to /api/agents/conversations/events. Browsers cap HTTP/1.1 connections at 6 per origin, so the idle SSE streams consumed the whole pool and every other fetch queued indefinitely — tasks stuck on "Starting…", panels spinning forever, while the same endpoints answered curl instantly.

Add conversation-events-client.ts: a single shared EventSource fanned out to subscribers (ref-counted, closed when the last one unsubscribes). All six consumers now subscribe to it; their parsing and debounce logic is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked real-time update plumbing to use a shared subscription for conversation/task/file events, reducing duplicate connections and improving reliability.
  * Debounced refreshes and safer error handling to make live updates (sidebar, task lists, boards, conversation pages, file sync) more consistent and less prone to missed or noisy reloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->