### PR TITLE
fix(routines): load the full prompt when editing a routine

### DIFF
--- a/src/components/agents/new-routine-dialog.tsx
+++ b/src/components/agents/new-routine-dialog.tsx
@@ -114,6 +114,32 @@ export function NewRoutineDialog({
     };
     if (existingJob) {
       setDraft({ ...base, ...existingJob } as JobConfig);
+      // Routine lists/overview carry only summary fields (id/name/schedule/
+      // enabled), so an edit opened from there arrives without the prompt (and
+      // model/timeout). Fetch the full job config and merge the authoritative
+      // fields so the editor isn't blank. Skip when the prompt is already present.
+      if (existingJob.id && existingJob.prompt === undefined) {
+        const controller = new AbortController();
+        const jobId = existingJob.id;
+        const q = agent.cabinetPath
+          ? `?cabinetPath=${encodeURIComponent(agent.cabinetPath)}`
+          : "";
+        fetch(
+          `/api/agents/${encodeURIComponent(agent.slug)}/jobs/${encodeURIComponent(jobId)}${q}`,
+          { signal: controller.signal }
+        )
+          .then((r) => (r.ok ? r.json() : null))
+          .then((data) => {
+            if (!data?.job) return;
+            setDraft((cur) =>
+              cur && cur.id === jobId
+                ? ({ ...base, ...data.job } as JobConfig)
+                : cur
+            );
+          })
+          .catch(() => {});
+        return () => controller.abort();
+      }
       return;
     }
     setDraft(base);


### PR DESCRIPTION
## Problem

Editing a routine from the routines list (e.g. `…/agents/routines`) opens the Edit dialog with an **empty prompt field**, even though the routine's `.jobs/<id>.yaml` has a full prompt. Because `canSave` requires a non-empty prompt the Save button stays disabled (so it doesn't silently clobber the stored prompt), but the routine is effectively uneditable from that surface — the existing prompt, model, and timeout never load.

## Cause

`NewRoutineDialog` builds its draft as `{ ...base /* prompt: "" */, ...existingJob }`. The routines-list callers (`routines-tab`, `schedule-tab`, `cabinet-view`, `tabs-layout`) pass `existingJob` as a **partial** — only `{ id, name, schedule, enabled }` — because the lean `/api/cabinets/overview` list never carries the prompt/model/timeout. So `existingJob.prompt` is `undefined`, the base `""` wins, and the editor opens blank. (Edits opened from the single-agent detail page work, because that passes the full job from `/api/agents/:slug/jobs`.)

## Fix

When the dialog opens in edit mode without a prompt, fetch the full job config from `GET /api/agents/:slug/jobs/:jobId` and merge the authoritative fields into the draft. Centralized in the dialog so every caller is covered; uses an `AbortController` for cleanup and guards the async `setDraft` with `cur.id === jobId` to avoid stale writes.

## Testing

- Verified on a live instance: a routine whose `.jobs/<id>.yaml` has a 3.4k-char prompt previously opened blank from the routines tab; with the fix the prompt (and model/timeout) populate.
- No behavior change for the single-agent-detail path, which already passes a full `existingJob` (the `prompt === undefined` guard skips the fetch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the job editing experience by automatically loading complete job configuration when opening jobs with incomplete data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->