### PR TITLE
fix(tasks): don't list the _pending staging dir as a phantom conversation

### DIFF
--- a/src/lib/agents/conversation-store.ts
+++ b/src/lib/agents/conversation-store.ts
@@ -1681,7 +1681,13 @@ export async function listConversationMetas(
       return (
         await Promise.all(
           entries
-            .filter((entry) => entry.isDirectory)
+            // Skip reserved/internal dirs (e.g. `_pending`, the attachment
+            // staging area) — they aren't conversations. Without this they
+            // fall through to recoverConversationMeta() and surface as a
+            // phantom "Recovered task _pending" card that can't be deleted
+            // (DELETE 404s — there's no such conversation). Real conversation
+            // ids are timestamp-prefixed, so they never start with "_".
+            .filter((entry) => entry.isDirectory && !entry.name.startsWith("_"))
             .map(async (entry) => {
               const meta = await readConversationMeta(entry.name, cabinetPath);
               if (meta) return maybeResolveCompletedConversation(meta);


### PR DESCRIPTION
## Problem

A phantom **"Recovered task _pending"** card (agent "unknown", status *Failed*) shows up on the tasks board. It can't be removed — deleting it throws:

```
delete _pending failed: 404 {"error":"Conversation not found"}
  at deleteConversation (src/components/tasks/board/board-actions.ts:136)
```

## Cause

`listConversationMetas()` enumerates every directory under `.agents/.conversations/` and filters only by `isDirectory`. That sweeps in `_pending` — the **attachment-staging** directory (`.agents/.conversations/_pending/<uuid>/attachments/`), not a conversation. It has no `meta.json`, so the lister falls through to `recoverConversationMeta("_pending")`, which synthesizes a failed placeholder titled `Recovered task _pending` (`"_pending".slice(0, 8)` === `"_pending"`).

Because there's no real conversation with id `_pending`, the delete endpoint 404s, so the card is stuck.

## Fix

Skip reserved/internal dirs (names starting with `_`) when listing conversations. Real conversation ids are timestamp-prefixed (e.g. `2026-06-11T…`), so they never start with `_` — no real conversation is excluded.

```diff
- .filter((entry) => entry.isDirectory)
+ .filter((entry) => entry.isDirectory && !entry.name.startsWith("_"))
```

## Testing

- Repro: an orphaned `.agents/.conversations/_pending/` dir produced the phantom card; with the fix it no longer appears in `listConversationMetas()`.
- Real (timestamp-prefixed) conversations are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where phantom conversation entries would appear in the list and could not be removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->