### PR TITLE
fix(tasks): resolve artifact paths against task cwd so they open + appear in the sidebar

### DIFF
--- a/src/app/api/tree/route.ts
+++ b/src/app/api/tree/route.ts
@@ -6,7 +6,8 @@ export async function GET(request: NextRequest) {
   try {
     await ensureDataDir();
     const showHidden = request.nextUrl.searchParams.get("showHidden") === "1";
-    const tree = await buildTree(showHidden);
+    const fresh = request.nextUrl.searchParams.get("fresh") === "1";
+    const tree = await buildTree(showHidden, fresh);
     return NextResponse.json(tree);
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";

--- a/src/components/agents/conversation-live-view.tsx
+++ b/src/components/agents/conversation-live-view.tsx
@@ -16,7 +16,7 @@ import { appendConversationCabinetPath } from "@/lib/agents/conversation-identit
 import { ConversationContentViewer } from "@/components/agents/conversation-content-viewer";
 import { SkillsOfferedFooter } from "@/components/skills/skills-offered-footer";
 import {
-  artifactPathToTreePath,
+  resolveArtifactTreePath,
   inferPageTypeFromPath,
   pageTypeColor,
   pageTypeIcon,
@@ -60,8 +60,8 @@ export function ConversationLiveView({
   const promptText = detail.request || detail.meta.title;
   const [promptHtml, setPromptHtml] = useState("");
   const artifactTreePaths = useMemo(
-    () => detail.artifacts.map((a) => artifactPathToTreePath(a.path)),
-    [detail.artifacts]
+    () => detail.artifacts.map((a) => resolveArtifactTreePath(a.path, detail.meta.cabinetPath)),
+    [detail.artifacts, detail.meta.cabinetPath]
   );
   const artifactMeta = usePageMeta(artifactTreePaths);
 
@@ -179,7 +179,7 @@ export function ConversationLiveView({
             </div>
             <div className="space-y-2">
               {detail.artifacts.map((artifact) => {
-                const treePath = artifactPathToTreePath(artifact.path);
+                const treePath = resolveArtifactTreePath(artifact.path, detail.meta.cabinetPath);
                 const kind = artifactMeta.get(treePath)?.type ?? inferPageTypeFromPath(artifact.path);
                 const Icon = pageTypeIcon(kind);
                 const color = pageTypeColor(kind);

--- a/src/components/agents/conversation-result-view.tsx
+++ b/src/components/agents/conversation-result-view.tsx
@@ -8,7 +8,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { appendConversationCabinetPath } from "@/lib/agents/conversation-identity";
 import { buildTaskPath } from "@/lib/navigation/task-route";
 import {
-  artifactPathToTreePath,
+  resolveArtifactTreePath,
   inferPageTypeFromPath,
   pageTypeColor,
   pageTypeIcon,
@@ -54,8 +54,8 @@ export function ConversationResultView({
   const promptText = detail.request || detail.meta.title;
   const [promptHtml, setPromptHtml] = useState("");
   const artifactTreePaths = useMemo(
-    () => detail.artifacts.map((a) => artifactPathToTreePath(a.path)),
-    [detail.artifacts]
+    () => detail.artifacts.map((a) => resolveArtifactTreePath(a.path, detail.meta.cabinetPath)),
+    [detail.artifacts, detail.meta.cabinetPath]
   );
   const artifactMeta = usePageMeta(artifactTreePaths);
 
@@ -191,7 +191,7 @@ export function ConversationResultView({
           {detail.artifacts.length > 0 ? (
             <div className="space-y-2">
               {detail.artifacts.map((artifact) => {
-                const treePath = artifactPathToTreePath(artifact.path);
+                const treePath = resolveArtifactTreePath(artifact.path, detail.meta.cabinetPath);
                 const kind = artifactMeta.get(treePath)?.type ?? inferPageTypeFromPath(artifact.path);
                 const Icon = pageTypeIcon(kind);
                 const color = pageTypeColor(kind);

--- a/src/components/sidebar/recent-tasks.tsx
+++ b/src/components/sidebar/recent-tasks.tsx
@@ -7,7 +7,7 @@ import { useAppStore } from "@/stores/app-store";
 import { useTreeStore } from "@/stores/tree-store";
 import { useEditorStore } from "@/stores/editor-store";
 import {
-  artifactPathToTreePath,
+  resolveArtifactTreePath,
   inferPageTypeFromPath,
   pageTypeIcon,
 } from "@/lib/ui/page-type-icons";
@@ -384,7 +384,10 @@ export function RecentTasks({
                       key={path}
                       type="button"
                       onClick={() => {
-                        const treePath = artifactPathToTreePath(path);
+                        const treePath = resolveArtifactTreePath(
+                          path,
+                          task.cabinetPath
+                        );
                         focusPath(treePath);
                         setSection({
                           type: "page",

--- a/src/components/sidebar/tree-node.tsx
+++ b/src/components/sidebar/tree-node.tsx
@@ -633,9 +633,10 @@ function TreeNodeImpl({
               // right edge in RTL and stays rounded on its inner side.
               isSelected &&
                 "bg-accent/70 text-accent-foreground font-semibold before:absolute before:start-0 before:top-1 before:bottom-1 before:w-[2px] before:rounded-e-full before:bg-primary",
-              // Recently created/changed by a task — subtle tint until opened.
+              // Recently created/changed by a task — subtle tint + an
+              // unread-style bump to fuller, medium-weight text until opened.
               isChanged && !isSelected &&
-                "bg-emerald-500/[0.06] before:absolute before:start-0 before:top-1 before:bottom-1 before:w-[2px] before:rounded-e-full before:bg-emerald-500/70",
+                "bg-emerald-500/[0.06] font-medium text-foreground before:absolute before:start-0 before:top-1 before:bottom-1 before:w-[2px] before:rounded-e-full before:bg-emerald-500/70",
               showInto &&
                 "bg-primary/10 ring-1 ring-primary/30 ring-inset",
               blink && "cabinet-tree-blink",

--- a/src/components/tasks/conversation/artifacts-list.tsx
+++ b/src/components/tasks/conversation/artifacts-list.tsx
@@ -6,7 +6,7 @@ import { useAppStore, type SelectedSection } from "@/stores/app-store";
 import { useEditorStore } from "@/stores/editor-store";
 import { useTreeStore } from "@/stores/tree-store";
 import {
-  artifactPathToTreePath,
+  resolveArtifactTreePath,
   inferPageTypeFromPath,
   pageTypeColor,
   pageTypeIcon,
@@ -30,9 +30,12 @@ function directory(p: string): string {
 export function ArtifactsList({
   turns,
   returnContext,
+  cabinetPath,
 }: {
   turns: Turn[];
   returnContext?: SelectedSection;
+  /** The task's working directory; artifact paths are relative to it. */
+  cabinetPath?: string;
 }) {
   const pushSection = useAppStore((s) => s.pushSection);
   const focusPath = useTreeStore((s) => s.focusPath);
@@ -49,7 +52,14 @@ export function ArtifactsList({
     return [...seen];
   }, [turns]);
 
-  const meta = usePageMeta(paths);
+  // Re-root each cwd-relative artifact path to its `data/`-rooted tree path so
+  // navigation lands on the real page and metadata/title lookups resolve.
+  const treePaths = useMemo(
+    () => paths.map((p) => resolveArtifactTreePath(p, cabinetPath)),
+    [paths, cabinetPath]
+  );
+
+  const meta = usePageMeta(treePaths);
 
   if (paths.length === 0) {
     return (
@@ -67,8 +77,9 @@ export function ArtifactsList({
           {paths.length}
         </span>
       </div>
-      {paths.map((path) => {
-        const entry = meta.get(path);
+      {paths.map((path, i) => {
+        const treePath = treePaths[i];
+        const entry = meta.get(treePath);
         const kind = entry?.type ?? inferPageTypeFromPath(path);
         const Icon = pageTypeIcon(kind);
         const color = pageTypeColor(kind);
@@ -79,7 +90,6 @@ export function ArtifactsList({
             key={path}
             type="button"
             onClick={() => {
-              const treePath = artifactPathToTreePath(path);
               const from = returnContext ?? useAppStore.getState().section;
               focusPath(treePath);
               pushSection({ type: "page", cabinetPath: from.cabinetPath }, from);

--- a/src/components/tasks/conversation/task-conversation-page.tsx
+++ b/src/components/tasks/conversation/task-conversation-page.tsx
@@ -2070,6 +2070,7 @@ export function TaskConversationPage({
                   agent={turnAgent}
                   user={turnUser}
                   returnContext={returnContext}
+                  cabinetPath={task.meta.cabinetPath}
                 />
               ))}
             </div>
@@ -2132,7 +2133,11 @@ export function TaskConversationPage({
         >
           <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin">
             <div className="mx-auto max-w-3xl">
-              <ArtifactsList turns={task.turns} returnContext={returnContext} />
+              <ArtifactsList
+                turns={task.turns}
+                returnContext={returnContext}
+                cabinetPath={task.meta.cabinetPath}
+              />
             </div>
           </div>
         </TabsContent>

--- a/src/components/tasks/conversation/turn-block.tsx
+++ b/src/components/tasks/conversation/turn-block.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useSyncExternalStore } from "react";
 import { ChevronRight, Pause, Sparkles, User } from "lucide-react";
 import {
-  artifactPathToTreePath,
+  resolveArtifactTreePath,
   inferPageTypeFromPath,
   pageTypeColor,
   pageTypeIcon,
@@ -136,9 +136,11 @@ function directory(p: string): string {
 function KbArtifactRow({
   path,
   returnContext,
+  cabinetPath,
 }: {
   path: string;
   returnContext?: SelectedSection;
+  cabinetPath?: string;
 }) {
   const pushSection = useAppStore((s) => s.pushSection);
   const focusPath = useTreeStore((s) => s.focusPath);
@@ -152,8 +154,8 @@ function KbArtifactRow({
     <button
       type="button"
       onClick={() => {
-        const treePath = artifactPathToTreePath(path);
         const from = returnContext ?? useAppStore.getState().section;
+        const treePath = resolveArtifactTreePath(path, cabinetPath ?? from.cabinetPath);
         focusPath(treePath);
         pushSection({ type: "page", cabinetPath: from.cabinetPath }, from);
         void loadPage(treePath);
@@ -196,11 +198,14 @@ export function TurnBlock({
   agent,
   user,
   returnContext,
+  cabinetPath,
 }: {
   turn: Turn;
   agent?: TurnBlockAgent | null;
   user?: TurnBlockUser | null;
   returnContext?: SelectedSection;
+  /** The task's working directory; artifact paths are relative to it. */
+  cabinetPath?: string;
 }) {
   const { t } = useLocale();
   const isUser = turn.role === "user";
@@ -283,7 +288,12 @@ export function TurnBlock({
         {artifactPaths.length > 0 ? (
           <div className="mt-3.5 space-y-1.5 rounded-xl border border-border/60 bg-muted/40 p-2 dark:bg-muted/20">
             {artifactPaths.map((path) => (
-              <KbArtifactRow key={path} path={path} returnContext={returnContext} />
+              <KbArtifactRow
+                key={path}
+                path={path}
+                returnContext={returnContext}
+                cabinetPath={cabinetPath}
+              />
             ))}
           </div>
         ) : null}

--- a/src/hooks/use-task-file-sync.ts
+++ b/src/hooks/use-task-file-sync.ts
@@ -3,7 +3,7 @@
 import { useEffect } from "react";
 import { useTreeStore } from "@/stores/tree-store";
 import { useEditorStore } from "@/stores/editor-store";
-import { artifactPathToTreePath } from "@/lib/ui/page-type-icons";
+import { resolveArtifactTreePath } from "@/lib/ui/page-type-icons";
 import { subscribeConversationEvents } from "@/lib/agents/conversation-events-client";
 
 /**
@@ -40,7 +40,10 @@ export function useTaskFileSync(): void {
 
       // Highlight everything except the page the user is already looking at.
       useTreeStore.getState().markChanged(treePaths.filter((p) => p !== openPath));
-      void useTreeStore.getState().loadTree();
+      // `fresh` busts the server tree cache: agents write straight to disk, so
+      // a plain reload could serve the pre-write snapshot and the new files
+      // wouldn't show until the user hit refresh.
+      void useTreeStore.getState().loadTree({ fresh: true });
 
       if (openPath && treePaths.includes(openPath)) {
         if (!editor.isDirty) {
@@ -62,9 +65,12 @@ export function useTaskFileSync(): void {
       }
     };
 
-    const schedule = (rawPaths: string[]) => {
+    // Artifact paths are reported relative to the task's working directory
+    // (its `cabinetPath`); re-root them to the `data/`-rooted tree path so the
+    // highlight matches real tree nodes and the right page reloads.
+    const schedule = (rawPaths: string[], cabinetPath?: string) => {
       for (const raw of rawPaths) {
-        const tp = artifactPathToTreePath(raw);
+        const tp = resolveArtifactTreePath(raw, cabinetPath);
         if (tp) pending.add(tp);
       }
       if (flushTimer === null) flushTimer = window.setTimeout(flush, 250);
@@ -74,15 +80,18 @@ export function useTaskFileSync(): void {
       try {
         const event = JSON.parse(data) as {
           type?: string;
+          cabinetPath?: unknown;
           payload?: { artifactPaths?: unknown; artifacts?: unknown };
         };
         if (!event || event.type === "ping") return;
         const p = event.payload ?? {};
+        const cabinetPath =
+          typeof event.cabinetPath === "string" ? event.cabinetPath : undefined;
         const raw = [
           ...(Array.isArray(p.artifactPaths) ? p.artifactPaths : []),
           ...(Array.isArray(p.artifacts) ? p.artifacts : []),
         ].filter((x): x is string => typeof x === "string" && x.trim().length > 0);
-        if (raw.length > 0) schedule(raw);
+        if (raw.length > 0) schedule(raw, cabinetPath);
       } catch {
         // ignore malformed events
       }

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -14,9 +14,17 @@ export function buildPageApiUrl(pagePath = ""): string {
   return `/api/pages/${encodedPath}`;
 }
 
-export async function fetchTree(showHidden = false): Promise<TreeNode[]> {
-  const url = showHidden ? "/api/tree?showHidden=1" : "/api/tree";
-  const res = await fetch(url, { cache: "no-store" });
+export async function fetchTree(
+  showHidden = false,
+  fresh = false
+): Promise<TreeNode[]> {
+  const params = new URLSearchParams();
+  if (showHidden) params.set("showHidden", "1");
+  if (fresh) params.set("fresh", "1");
+  const qs = params.toString();
+  const res = await fetch(qs ? `/api/tree?${qs}` : "/api/tree", {
+    cache: "no-store",
+  });
   if (!res.ok) throw new Error("Failed to fetch tree");
   return res.json();
 }

--- a/src/lib/navigation/open-artifact-path.ts
+++ b/src/lib/navigation/open-artifact-path.ts
@@ -2,7 +2,7 @@ import { useAppStore, type SelectedSection } from "@/stores/app-store";
 import { useEditorStore } from "@/stores/editor-store";
 import { useTreeStore } from "@/stores/tree-store";
 import { findNodeByPath } from "@/lib/cabinets/tree";
-import { artifactPathToTreePath } from "@/lib/ui/page-type-icons";
+import { resolveArtifactTreePath } from "@/lib/ui/page-type-icons";
 
 const NON_TEXT_ARTIFACT_EXTENSIONS = [
   ".pdf",
@@ -46,7 +46,7 @@ export async function openArtifactPath(
   const { focusPath, loadTree } = useTreeStore.getState();
   const { loadPage } = useEditorStore.getState();
 
-  const treePath = artifactPathToTreePath(path);
+  const treePath = resolveArtifactTreePath(path, section.cabinetPath);
 
   setSection(section);
   focusPath(treePath);

--- a/src/lib/storage/tree-builder.ts
+++ b/src/lib/storage/tree-builder.ts
@@ -321,7 +321,16 @@ export function invalidateTreeCache() {
   treeCache.invalidate();
 }
 
-export async function buildTree(showHidden = false): Promise<TreeNode[]> {
+export async function buildTree(
+  showHidden = false,
+  fresh = false
+): Promise<TreeNode[]> {
+  // Agents write files straight to disk (their PTY/CLI never hits the
+  // create/move/rename routes that call invalidateTreeCache), so a refresh
+  // fired right after a task finishes would otherwise serve the pre-write
+  // snapshot until the 5s TTL lapses. `fresh` busts the cache so newly
+  // created pages/folders appear immediately.
+  if (fresh) treeCache.invalidate();
   return treeCache.get(showHidden ? "1" : "0", () => buildTreeUncached(showHidden));
 }
 

--- a/src/lib/ui/page-type-icons.tsx
+++ b/src/lib/ui/page-type-icons.tsx
@@ -108,3 +108,33 @@ export function artifactPathToTreePath(path: string): string {
   next = next.replace(/\.md$/, "");
   return next;
 }
+
+/**
+ * Resolve an agent-authored artifact path to the full, `data/`-rooted tree path
+ * the sidebar + `/room/<path>` URL scheme expect.
+ *
+ * Agents run with cwd `DATA_DIR/<cabinetPath>` (see conversation-runner's
+ * `baseCwd`), so the artifact paths they report are RELATIVE TO that cwd —
+ * e.g. `github/contributors.md` for a task whose `cabinetPath` is
+ * `hilas-home/cabinet-data/dev`. Tree nodes are rooted at `data/`, so the
+ * cwd-relative path must be re-rooted to
+ * `hilas-home/cabinet-data/dev/github/contributors` before it can address the
+ * tree. Without this the first segment is mistaken for a top-level room
+ * (`/room/github/...`) and the page 404s to a "create page" prompt.
+ *
+ * Idempotent and defensive:
+ *   - normalizes via {@link artifactPathToTreePath} (strips `data/`, `.md`, …)
+ *   - no-ops when `cabinetPath` is missing or the root cabinet (`.`)
+ *   - never double-prefixes a path that is already cabinet-rooted
+ */
+export function resolveArtifactTreePath(
+  path: string,
+  cabinetPath?: string | null
+): string {
+  const treePath = artifactPathToTreePath(path);
+  if (!treePath) return treePath;
+  const base = (cabinetPath ?? "").trim().replace(/^\/+|\/+$/g, "");
+  if (!base || base === ".") return treePath;
+  if (treePath === base || treePath.startsWith(`${base}/`)) return treePath;
+  return `${base}/${treePath}`;
+}

--- a/src/stores/tree-store.ts
+++ b/src/stores/tree-store.ts
@@ -28,7 +28,9 @@ interface TreeState {
    *  sidebar (tint + dot) until the user opens them. */
   recentlyChanged: Set<string>;
 
-  loadTree: () => Promise<void>;
+  /** Reload the file tree. Pass `{ fresh: true }` to bypass the server's
+   *  short-TTL cache — needed right after an agent task writes files. */
+  loadTree: (opts?: { fresh?: boolean }) => Promise<void>;
   selectPage: (path: string | null) => void;
   /** Expand all ancestor paths, select the leaf, and bump focusTick. */
   focusPath: (path: string) => void;
@@ -114,7 +116,7 @@ export const useTreeStore = create<TreeState>((set, get) => ({
   focusTick: 0,
   recentlyChanged: new Set<string>(),
 
-  loadTree: async () => {
+  loadTree: async (opts) => {
     const { showHiddenFiles, nodes: existing } = get();
     // Paint instantly from cache on first load, then revalidate in the
     // background. Keeps the sidebar from flashing empty on refresh.
@@ -127,7 +129,7 @@ export const useTreeStore = create<TreeState>((set, get) => ({
       }
     }
     try {
-      const nodes = await fetchTree(showHiddenFiles);
+      const nodes = await fetchTree(showHiddenFiles, opts?.fresh ?? false);
       set({ nodes, loading: false });
       saveCachedTree(nodes, showHiddenFiles);
     } catch {

--- a/test/resolve-artifact-tree-path.test.ts
+++ b/test/resolve-artifact-tree-path.test.ts
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  resolveArtifactTreePath,
+  artifactPathToTreePath,
+} from "@/lib/ui/page-type-icons";
+
+// Regression: agents run with cwd DATA_DIR/<cabinetPath>, so the artifact
+// paths they report are relative to that cwd. Tree nodes / the /room/<path>
+// URL scheme are rooted at data/, so the cwd must be prepended — otherwise the
+// first segment is mistaken for a top-level room and the page 404s to a
+// "create page" prompt (the reported bug).
+
+const CWD = "hilas-home/cabinet-data/Development/dev";
+
+test("re-roots a cwd-relative artifact path under the task's cabinetPath", () => {
+  assert.equal(
+    resolveArtifactTreePath("feedback-tracker/github/contributors.md", CWD),
+    "hilas-home/cabinet-data/Development/dev/feedback-tracker/github/contributors"
+  );
+});
+
+test("strips index.md / .md while re-rooting", () => {
+  assert.equal(
+    resolveArtifactTreePath("feedback-tracker/github/index.md", CWD),
+    "hilas-home/cabinet-data/Development/dev/feedback-tracker/github"
+  );
+});
+
+test("strips a leading data/ prefix before re-rooting", () => {
+  assert.equal(
+    resolveArtifactTreePath("data/notes/today.md", CWD),
+    "hilas-home/cabinet-data/Development/dev/notes/today"
+  );
+});
+
+test("is idempotent — never double-prefixes an already cabinet-rooted path", () => {
+  const full = `${CWD}/feedback-tracker/github/contributors`;
+  assert.equal(resolveArtifactTreePath(full, CWD), full);
+  // ...and applying it twice is stable.
+  assert.equal(
+    resolveArtifactTreePath(resolveArtifactTreePath(full, CWD), CWD),
+    full
+  );
+});
+
+test("no-ops when cabinetPath is absent, empty, or the root cabinet", () => {
+  const rel = "notes/today.md";
+  const tree = artifactPathToTreePath(rel);
+  assert.equal(resolveArtifactTreePath(rel), tree);
+  assert.equal(resolveArtifactTreePath(rel, ""), tree);
+  assert.equal(resolveArtifactTreePath(rel, undefined), tree);
+  assert.equal(resolveArtifactTreePath(rel, "."), tree);
+});
+
+test("tolerates surrounding slashes on the cabinetPath", () => {
+  assert.equal(
+    resolveArtifactTreePath("a/b.md", "/room-x/"),
+    "room-x/a/b"
+  );
+});
+
+test("empty artifact path stays empty", () => {
+  assert.equal(resolveArtifactTreePath("", CWD), "");
+});


### PR DESCRIPTION
## Problem

Clicking an artifact from a finished task (e.g. **contributors** → `feedback-tracker/github/contributors.md`) navigated to `/room/feedback-tracker/github/contributors` and showed *"This folder doesn't have an index.md yet — Create page"*. The new files also didn't show up in the sidebar until a manual refresh, and never got the "new file" highlight.

## Root cause

Agents run with cwd `DATA_DIR/<cabinetPath>` (conversation-runner `baseCwd`), so the artifact paths they report are **relative to that cwd** — `feedback-tracker/github/contributors.md` for a task whose `cabinetPath` is `hilas-home/cabinet-data/Development/dev`. But the sidebar tree (`buildTree` walks all of `DATA_DIR`) and the `/room/<path>` URL scheme are rooted at `data/`.

Every artifact surface called `artifactPathToTreePath()`, which strips `data/`/`.md` but **never prepends the cwd**. So the first segment got mistaken for a top-level room (404 → create-page prompt), and the sidebar's `markChanged` highlight compared cwd-relative paths against data-rooted tree nodes (never matched).

## Changes

- **New `resolveArtifactTreePath(path, cabinetPath)`** (`src/lib/ui/page-type-icons.tsx`) — re-roots a cwd-relative artifact path to the full `data/`-rooted tree path. Idempotent, never double-prefixes, no-ops for root/empty.
- **Routed every artifact-navigation surface through it:** task chat artifact list + in-chat artifact rows, sidebar Recent-Tasks files, agent result/live views, the shared `openArtifactPath` helper, and the file-sync hook (now reads `event.cabinetPath` off the SSE stream).
- **Auto-appear in the sidebar:** `loadTree({ fresh: true })` → `/api/tree?fresh=1` → `buildTree(showHidden, fresh)` busts the 5s tree cache (agents write straight to disk, bypassing the create/move/rename routes that normally invalidate it).
- **Stronger "new/changed" affordance:** those rows now render in fuller, medium-weight text on top of the existing emerald tint + dot until opened.

## Testing

- `tsc --noEmit` clean; lint clean (only pre-existing warnings).
- New `test/resolve-artifact-tree-path.test.ts` (7 cases) + route-scheme/page-move suites pass.
- Verified live: opening the task and clicking the **contributors** artifact now lands on `…/dev/feedback-tracker/github/contributors` and renders the full page (heading + 30-contributor table) instead of the create-page prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cache-busting support to refresh the file tree on-demand, displaying newly created or updated pages immediately without cache delays
  * Enhanced artifact path resolution to correctly handle task working directory contexts across conversation and artifact views

* **Bug Fixes**
  * Fixed artifact navigation and sidebar highlighting to properly resolve paths relative to task working directories in all conversation components
  * Improved visual styling of recently changed tree nodes for better visibility

* **Tests**
  * Added test suite for artifact path resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->