### PR TITLE
fix(editor+artifacts): guard external artifact paths + harden the render path

### DIFF
--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -378,6 +378,11 @@ export function KBEditor() {
     // pure waste — every extension runs a full schema pass twice per
     // navigation. Skip until the real content arrives.
     if (isLoading && content === "") return;
+    // Don't commit an empty render for a path whose fetch hasn't reported
+    // success yet. If a cached paint or transient state lands content=""
+    // before loadStatus flips to "ok" (isLoading already false), recording it
+    // as the rendered key would hide the loading overlay over a blank page.
+    if (content === "" && loadStatus !== "ok") return;
     // Dedupe identical (path, content) renders — e.g. cached paint followed
     // by a fresh fetch that returned the same markdown.
     // assetBase is in the key so a cached paint (assetBase null -> path
@@ -389,18 +394,48 @@ export function KBEditor() {
 
     const setContent = async () => {
       isLoadingRef.current = true;
-      // assetBase (parent dir for standalone .md pages) resolves relative
-      // image refs; currentPath is only correct for directory pages.
-      const html = await markdownToHtml(content, assetBase ?? currentPath);
-      editor.commands.setContent(html);
-      setRendered({ key, path: currentPath });
-      setTimeout(() => {
-        isLoadingRef.current = false;
-      }, 50);
+      try {
+        // assetBase (parent dir for standalone .md pages) resolves relative
+        // image refs; currentPath is only correct for directory pages.
+        const html = await markdownToHtml(content, assetBase ?? currentPath);
+        editor.commands.setContent(html);
+        setRendered({ key, path: currentPath });
+        // Surface a known-bad state instead of silently rendering blank: the
+        // store has content but ProseMirror parsed it down to nothing —
+        // almost always a schema/extension mismatch (unknown element,
+        // malformed table, …). Log so it's debuggable.
+        if (content && editor.isEmpty) {
+          console.warn(
+            "[KBEditor] rendered empty document despite non-empty markdown",
+            { path: currentPath, contentLength: content.length }
+          );
+        }
+      } catch (err) {
+        // Leave `rendered` unset (it's only set on success above) so the next
+        // state tick retries instead of being blocked by a stale key.
+        console.error("[KBEditor] failed to render markdown", err, {
+          path: currentPath,
+          contentLength: content.length,
+        });
+      } finally {
+        setTimeout(() => {
+          isLoadingRef.current = false;
+        }, 50);
+      }
     };
 
     setContent();
-  }, [editor, content, currentPath, assetBase, isLoading, rendered]);
+  }, [editor, content, currentPath, assetBase, isLoading, loadStatus, rendered]);
+
+  // Source mode snapshots the markdown when toggled on but doesn't follow
+  // store updates — navigating to a new page with source mode open used to
+  // leave the textarea showing the previous page. Re-sync whenever the store
+  // content changes for this path and the user hasn't started editing.
+  useEffect(() => {
+    if (!sourceMode) return;
+    if (useEditorStore.getState().isDirty) return;
+    setSourceText((prev) => (prev === content ? prev : content));
+  }, [sourceMode, content, currentPath]);
 
   // Section anchors (PRD §11): scroll to `#heading` on load and on hashchange.
   // Heading ids come from the HeadingAnchors decoration, applied after content

--- a/src/components/sidebar/recent-tasks.tsx
+++ b/src/components/sidebar/recent-tasks.tsx
@@ -8,9 +8,11 @@ import { useTreeStore } from "@/stores/tree-store";
 import { useEditorStore } from "@/stores/editor-store";
 import {
   resolveArtifactTreePath,
+  isExternalArtifactPath,
   inferPageTypeFromPath,
   pageTypeIcon,
 } from "@/lib/ui/page-type-icons";
+import { notifyExternalArtifact } from "@/lib/navigation/open-artifact-path";
 import { dedupFetch } from "@/lib/api/dedup-fetch";
 import { conversationMetaToTaskMeta } from "@/lib/agents/conversation-to-task-view";
 import { subscribeConversationEvents } from "@/lib/agents/conversation-events-client";
@@ -384,6 +386,10 @@ export function RecentTasks({
                       key={path}
                       type="button"
                       onClick={() => {
+                        if (isExternalArtifactPath(path)) {
+                          notifyExternalArtifact(path);
+                          return;
+                        }
                         const treePath = resolveArtifactTreePath(
                           path,
                           task.cabinetPath

--- a/src/components/tasks/conversation/artifacts-list.tsx
+++ b/src/components/tasks/conversation/artifacts-list.tsx
@@ -7,10 +7,12 @@ import { useEditorStore } from "@/stores/editor-store";
 import { useTreeStore } from "@/stores/tree-store";
 import {
   resolveArtifactTreePath,
+  isExternalArtifactPath,
   inferPageTypeFromPath,
   pageTypeColor,
   pageTypeIcon,
 } from "@/lib/ui/page-type-icons";
+import { notifyExternalArtifact } from "@/lib/navigation/open-artifact-path";
 import { usePageMeta } from "@/hooks/use-page-meta";
 import { cn } from "@/lib/utils";
 import type { Turn } from "@/types/tasks";
@@ -90,6 +92,13 @@ export function ArtifactsList({
             key={path}
             type="button"
             onClick={() => {
+              if (isExternalArtifactPath(path)) {
+                // Artifact lives outside DATA_DIR (e.g. an agent wrote to
+                // Claude Code's auto-memory dir). The page API would 404 and
+                // the editor would render blank — surface the path instead.
+                notifyExternalArtifact(path);
+                return;
+              }
               const from = returnContext ?? useAppStore.getState().section;
               focusPath(treePath);
               pushSection({ type: "page", cabinetPath: from.cabinetPath }, from);

--- a/src/components/tasks/conversation/turn-block.tsx
+++ b/src/components/tasks/conversation/turn-block.tsx
@@ -4,10 +4,12 @@ import { useEffect, useState, useSyncExternalStore } from "react";
 import { ChevronRight, Pause, Sparkles, User } from "lucide-react";
 import {
   resolveArtifactTreePath,
+  isExternalArtifactPath,
   inferPageTypeFromPath,
   pageTypeColor,
   pageTypeIcon,
 } from "@/lib/ui/page-type-icons";
+import { notifyExternalArtifact } from "@/lib/navigation/open-artifact-path";
 import { useAppStore, type SelectedSection } from "@/stores/app-store";
 import { useEditorStore } from "@/stores/editor-store";
 import { useTreeStore } from "@/stores/tree-store";
@@ -154,6 +156,10 @@ function KbArtifactRow({
     <button
       type="button"
       onClick={() => {
+        if (isExternalArtifactPath(path)) {
+          notifyExternalArtifact(path);
+          return;
+        }
         const from = returnContext ?? useAppStore.getState().section;
         const treePath = resolveArtifactTreePath(path, cabinetPath ?? from.cabinetPath);
         focusPath(treePath);

--- a/src/lib/navigation/open-artifact-path.ts
+++ b/src/lib/navigation/open-artifact-path.ts
@@ -2,7 +2,10 @@ import { useAppStore, type SelectedSection } from "@/stores/app-store";
 import { useEditorStore } from "@/stores/editor-store";
 import { useTreeStore } from "@/stores/tree-store";
 import { findNodeByPath } from "@/lib/cabinets/tree";
-import { resolveArtifactTreePath } from "@/lib/ui/page-type-icons";
+import {
+  resolveArtifactTreePath,
+  isExternalArtifactPath,
+} from "@/lib/ui/page-type-icons";
 
 const NON_TEXT_ARTIFACT_EXTENSIONS = [
   ".pdf",
@@ -38,10 +41,29 @@ function shouldLoadArtifactContent(treePath: string): boolean {
   return true;
 }
 
+/**
+ * Surface an "outside cabinet" toast for an artifact the page API can't open
+ * (it lives outside DATA_DIR). Shared by every artifact-navigation surface so
+ * a click lands on a clear message instead of a blank editor.
+ */
+export function notifyExternalArtifact(path: string): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent("cabinet:toast", {
+      detail: { kind: "info", message: `Outside cabinet — ${path}` },
+    })
+  );
+}
+
 export async function openArtifactPath(
   path: string,
   section: SelectedSection
 ): Promise<void> {
+  if (isExternalArtifactPath(path)) {
+    notifyExternalArtifact(path);
+    return;
+  }
+
   const { setSection } = useAppStore.getState();
   const { focusPath, loadTree } = useTreeStore.getState();
   const { loadPage } = useEditorStore.getState();

--- a/src/lib/ui/page-type-icons.tsx
+++ b/src/lib/ui/page-type-icons.tsx
@@ -126,6 +126,8 @@ export function artifactPathToTreePath(path: string): string {
  *   - normalizes via {@link artifactPathToTreePath} (strips `data/`, `.md`, …)
  *   - no-ops when `cabinetPath` is missing or the root cabinet (`.`)
  *   - never double-prefixes a path that is already cabinet-rooted
+ *   - never prefixes an external (absolute-system) path — see
+ *     {@link isExternalArtifactPath}
  */
 export function resolveArtifactTreePath(
   path: string,
@@ -133,8 +135,57 @@ export function resolveArtifactTreePath(
 ): string {
   const treePath = artifactPathToTreePath(path);
   if (!treePath) return treePath;
+  // External (absolute-system) paths live outside DATA_DIR; the page API
+  // can't read them, so grafting a cabinet prefix on would just produce a
+  // bogus tree path. Callers should short-circuit navigation via
+  // isExternalArtifactPath; this is a backstop so resolution never lies.
+  if (isExternalArtifactPath(path)) return treePath;
   const base = (cabinetPath ?? "").trim().replace(/^\/+|\/+$/g, "");
   if (!base || base === ".") return treePath;
   if (treePath === base || treePath.startsWith(`${base}/`)) return treePath;
   return `${base}/${treePath}`;
+}
+
+/**
+ * macOS/Linux system-root segments that an artifact path under DATA_DIR could
+ * never legitimately start with. Used to detect absolute filesystem paths an
+ * agent recorded as artifacts (e.g. files it wrote to Claude Code's auto-memory
+ * dir at `/Users/.../.claude/projects/.../memory/`). The page API's
+ * path-traversal guard refuses anything outside DATA_DIR, so these would
+ * silently 404 if we tried to render them through the editor.
+ */
+const EXTERNAL_PATH_ROOTS = new Set([
+  "Users",
+  "home",
+  "private",
+  "tmp",
+  "var",
+  "etc",
+  "opt",
+  "bin",
+  "sbin",
+  "lib",
+  "usr",
+  "dev",
+  "Volumes",
+  "Library",
+  "Applications",
+  "System",
+]);
+
+/**
+ * True when an artifact path points outside the cabinet's DATA_DIR. Such paths
+ * can't be rendered through the page API — callers should either disable
+ * navigation or surface a clear "outside cabinet" message instead of letting
+ * the editor render blank.
+ */
+export function isExternalArtifactPath(path: string): boolean {
+  if (!path) return false;
+  const trimmed = path.trim();
+  // Windows drive prefixes (C:/, D:\, …) are unambiguously absolute.
+  if (/^[a-zA-Z]:[\\/]/.test(trimmed)) return true;
+  const noSlashes = trimmed.replace(/^\/+/, "");
+  if (noSlashes.startsWith("data/")) return false;
+  const firstSeg = noSlashes.split("/", 1)[0] ?? "";
+  return EXTERNAL_PATH_ROOTS.has(firstSeg);
 }

--- a/test/resolve-artifact-tree-path.test.ts
+++ b/test/resolve-artifact-tree-path.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   resolveArtifactTreePath,
   artifactPathToTreePath,
+  isExternalArtifactPath,
 } from "@/lib/ui/page-type-icons";
 
 // Regression: agents run with cwd DATA_DIR/<cabinetPath>, so the artifact
@@ -62,4 +63,42 @@ test("tolerates surrounding slashes on the cabinetPath", () => {
 
 test("empty artifact path stays empty", () => {
   assert.equal(resolveArtifactTreePath("", CWD), "");
+});
+
+// --- isExternalArtifactPath + the resolver's external backstop -------------
+// An agent can record an artifact outside DATA_DIR (e.g. Claude Code's
+// auto-memory at /Users/.../.claude/...). Those can't render through the page
+// API, so callers short-circuit on isExternalArtifactPath, and the resolver
+// must never graft a cabinet prefix onto them.
+
+test("flags absolute system paths as external", () => {
+  for (const p of [
+    "/Users/me/.claude/projects/x/memory/note.md",
+    "/tmp/scratch.md",
+    "/var/log/x.md",
+    "/etc/hosts",
+    "/home/me/notes.md",
+    "C:/Users/me/file.md",
+    "D:\\work\\file.md",
+  ]) {
+    assert.equal(isExternalArtifactPath(p), true, p);
+  }
+});
+
+test("does NOT flag in-cabinet / data-rooted paths as external", () => {
+  for (const p of [
+    "feedback-tracker/github/contributors.md",
+    "data/notes/today.md",
+    "kb/reports/foo.md",
+    "",
+  ]) {
+    assert.equal(isExternalArtifactPath(p), false, p);
+  }
+});
+
+test("resolver never prefixes an external path with the cabinet", () => {
+  assert.equal(
+    resolveArtifactTreePath("/Users/me/.claude/memory/note.md", CWD),
+    "Users/me/.claude/memory/note"
+  );
 });


### PR DESCRIPTION
Follow-up to #133. Ports the still-relevant **defense-in-depth** from @alpha8eta's #113 — the artifact-path prefix fix that #113 and #133 shared already landed in #133, so this PR carries only the extra robustness that #133 didn't include. With this merged, **#113 is fully superseded.**

## 1. External artifact paths → clear toast instead of a blank page

An agent can record an artifact **outside** `DATA_DIR` (e.g. Claude Code's auto-memory at `/Users/.../.claude/projects/.../memory/`, `/tmp`, `/var`, or a Windows `C:\…` path). The page API's path-traversal guard refuses anything outside `DATA_DIR`, so clicking such an artifact used to 404 → blank editor.

- New `isExternalArtifactPath()` + `EXTERNAL_PATH_ROOTS` (`page-type-icons.tsx`).
- Every artifact-navigation surface (`artifacts-list`, `turn-block`, `recent-tasks`, `openArtifactPath`) short-circuits with an **"Outside cabinet — &lt;path&gt;"** toast via the shared `notifyExternalArtifact` helper.
- `resolveArtifactTreePath` refuses to graft a cabinet prefix onto an external path (backstop, so resolution never lies even if a caller forgets to check).

## 2. Editor render-path hardening

- **Don't commit an empty render** for a path whose fetch hasn't reported `loadStatus === "ok"` — a transient `content=""` (cached paint / state echo) could otherwise hide the loading overlay over a blank page.
- **try/catch/finally** around `markdownToHtml` + `setContent`: a failed render now logs and leaves `rendered` unset so the next tick retries, instead of locking a stale key; `isLoadingRef` always resets.
- **Warn** when content is non-empty but ProseMirror parsed it to an empty doc (almost always a schema/extension mismatch) — surfaces a debuggable signal instead of a silent blank.
- **Source-mode re-sync**: navigating to a new page with source mode open no longer leaves the textarea showing the previous page.

(Adapted to current `main` — the editor render effect was refactored to a single `rendered` state object since #113's base.)

## Testing
- `tsc --noEmit` clean; lint clean (0 errors).
- `test/resolve-artifact-tree-path.test.ts` extended with `isExternalArtifactPath` + external-backstop cases (18 assertions pass).
- Verified in-app: a normal KB page still renders after the editor-effect changes (no regression).

Credit: @alpha8eta (#113).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection and notification for artifacts outside the system, with early exit to prevent internal navigation.

* **Bug Fixes**
  * Fixed editor loading overlay prematurely hiding when content is empty.
  * Fixed source-mode textarea to avoid displaying stale content from previous pages.

* **Tests**
  * Added tests for external artifact path detection and resolver behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->