### PR TITLE
fix(artifacts): detect external paths by absoluteness, not a system-dir denylist

### DIFF
--- a/src/lib/ui/page-type-icons.tsx
+++ b/src/lib/ui/page-type-icons.tsx
@@ -147,45 +147,34 @@ export function resolveArtifactTreePath(
 }
 
 /**
- * macOS/Linux system-root segments that an artifact path under DATA_DIR could
- * never legitimately start with. Used to detect absolute filesystem paths an
- * agent recorded as artifacts (e.g. files it wrote to Claude Code's auto-memory
- * dir at `/Users/.../.claude/projects/.../memory/`). The page API's
- * path-traversal guard refuses anything outside DATA_DIR, so these would
- * silently 404 if we tried to render them through the editor.
- */
-const EXTERNAL_PATH_ROOTS = new Set([
-  "Users",
-  "home",
-  "private",
-  "tmp",
-  "var",
-  "etc",
-  "opt",
-  "bin",
-  "sbin",
-  "lib",
-  "usr",
-  "dev",
-  "Volumes",
-  "Library",
-  "Applications",
-  "System",
-]);
-
-/**
- * True when an artifact path points outside the cabinet's DATA_DIR. Such paths
- * can't be rendered through the page API — callers should either disable
- * navigation or surface a clear "outside cabinet" message instead of letting
- * the editor render blank.
+ * True when an artifact path points outside the cabinet's DATA_DIR — i.e. it's
+ * an *absolute* filesystem path rather than a cabinet-relative one. Such paths
+ * (e.g. files an agent wrote to Claude Code's auto-memory at
+ * `/Users/.../.claude/projects/.../memory/`) can't be read through the page
+ * API, whose path-traversal guard refuses anything outside DATA_DIR — so
+ * callers should surface an "outside cabinet" message instead of letting the
+ * editor render blank.
+ *
+ * This tests the *logical* property "is this absolute?", not a denylist of
+ * system directory names. The forms that are unambiguously absolute:
+ *   - POSIX-absolute (`/…`), except the `/data` cabinet-root alias
+ *   - home-relative (`~/…`)
+ *   - Windows drive (`C:\…`, `C:/…`) or UNC (`\\host\share`)
+ * Anything else is cabinet-relative and therefore internal — even when its
+ * first segment happens to be a name like `var`, `lib`, or `dev` (which a
+ * denylist would wrongly flag, breaking a real in-cabinet folder).
  */
 export function isExternalArtifactPath(path: string): boolean {
-  if (!path) return false;
-  const trimmed = path.trim();
-  // Windows drive prefixes (C:/, D:\, …) are unambiguously absolute.
-  if (/^[a-zA-Z]:[\\/]/.test(trimmed)) return true;
-  const noSlashes = trimmed.replace(/^\/+/, "");
-  if (noSlashes.startsWith("data/")) return false;
-  const firstSeg = noSlashes.split("/", 1)[0] ?? "";
-  return EXTERNAL_PATH_ROOTS.has(firstSeg);
+  const p = path?.trim();
+  if (!p) return false;
+  // Home-relative and Windows drive / UNC paths are unambiguously absolute.
+  if (p.startsWith("~")) return true;
+  if (/^[a-zA-Z]:[\\/]/.test(p) || p.startsWith("\\\\")) return true;
+  // POSIX-absolute. `/data` (and `/data/…`) is the cabinet-root alias and is
+  // internal; any other absolute path points outside DATA_DIR.
+  if (p.startsWith("/")) {
+    const rooted = p.replace(/^\/+/, "");
+    return rooted !== "data" && !rooted.startsWith("data/");
+  }
+  return false;
 }

--- a/test/resolve-artifact-tree-path.test.ts
+++ b/test/resolve-artifact-tree-path.test.ts
@@ -89,11 +89,34 @@ test("does NOT flag in-cabinet / data-rooted paths as external", () => {
   for (const p of [
     "feedback-tracker/github/contributors.md",
     "data/notes/today.md",
+    "/data/notes/today.md",
+    "/data",
     "kb/reports/foo.md",
     "",
   ]) {
     assert.equal(isExternalArtifactPath(p), false, p);
   }
+});
+
+test("does NOT flag relative paths whose first segment looks like a system dir", () => {
+  // Regression guard: the prior denylist heuristic stripped leading slashes
+  // before matching, so it wrongly flagged these *relative* paths. They're
+  // ordinary cabinet folders (this repo even ships a `dev` cabinet).
+  for (const p of [
+    "dev/notes.md",
+    "var/today.md",
+    "lib/x.md",
+    "home/y.md",
+    "Library/z.md",
+    "Users/w.md",
+  ]) {
+    assert.equal(isExternalArtifactPath(p), false, p);
+  }
+});
+
+test("flags home-relative (~) paths as external", () => {
+  assert.equal(isExternalArtifactPath("~/scratch.md"), true);
+  assert.equal(isExternalArtifactPath("~/.claude/memory/note.md"), true);
 });
 
 test("resolver never prefixes an external path with the cabinet", () => {


### PR DESCRIPTION
Refines the `isExternalArtifactPath` heuristic added in #134.

## Problem

The `EXTERNAL_PATH_ROOTS` denylist (`Users`, `home`, `var`, `lib`, `dev`, …) was:
- **Brittle** — any system dir not in the list slips through.
- **Actively wrong** — `isExternalArtifactPath` stripped leading slashes *before* matching, so it fired on cabinet-**relative** paths whose first segment happened to match. `dev/notes.md`, `var/x.md`, `lib/y.md` would all be flagged "outside cabinet". This repo ships a **`dev`** cabinet, so a relative artifact under it would refuse to open. A false-positive here breaks a *working* click — worse than the blank page the guard prevents.

## Fix

Test the logical property we actually mean — **"is this an absolute path?"**:
- POSIX-absolute (`/…`), except the `/data` cabinet-root alias
- home-relative (`~/…`)
- Windows drive (`C:\`, `C:/`) or UNC (`\\host\share`)

Anything else is cabinet-relative → internal, regardless of its first segment's name. No directory-name enumeration.

## Testing
- `tsc` + lint clean.
- `test/resolve-artifact-tree-path.test.ts` (12 cases): added regression coverage that relative paths with system-like first segments (`dev/`, `var/`, `lib/`, `home/`, `Library/`, `Users/`) stay **internal**; `~/…` is external; `/data/…` and bare `/data` stay internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved external artifact path classification using absolute-path detection instead of a directory-based allowlist, affecting how the system identifies paths outside the storage cabinet.

* **Tests**
  * Expanded test coverage to validate correct classification of internal, data-rooted, and external artifact paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->