### PR TITLE
test: run co-located src tests in npm test + fix 4 stale assertions

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "eslint src server electron scripts test eslint.config.mjs next.config.ts",
     "skills:sync": "tsx scripts/skills-sync.ts",
     "test:unit": "tsx --test test/update-system.test.ts",
-    "test": "tsx --test test/*.test.ts",
+    "test": "tsx --test $(find test src -name '*.test.ts')",
     "i18n:extract": "node scripts/i18n-extract.mjs",
     "i18n:check": "node scripts/i18n-extract.mjs --check",
     "i18n:report": "node scripts/i18n-find-hardcoded.mjs",

--- a/src/lib/agents/conversation-runner-continue.test.ts
+++ b/src/lib/agents/conversation-runner-continue.test.ts
@@ -122,7 +122,7 @@ test("continueConversationRun in resume mode sends only the follow-up to the ada
 
   assert.equal(captures.length, 1, "adapter was invoked once");
   assert.equal(captures[0].sessionIdSeen, "sess-before");
-  assert.match(captures[0].promptSeen, /```cabinet block/);
+  assert.match(captures[0].promptSeen, /```cabinet``` fenced block/);
   assert.match(captures[0].promptSeen, /User follow-up:\nthe new follow-up/);
   assert.ok(
     !captures[0].promptSeen.includes("Turn 1 reply."),
@@ -178,7 +178,10 @@ test("continueConversationRun in replay mode includes prior turns + full agent c
     "replay mode includes history header"
   );
   assert.match(captures[0].promptSeen, /T1 reply\./);
-  assert.match(captures[0].promptSeen, /You are Cabinet's General agent/);
+  // The replay prompt carries the agent's identity/system context. With no
+  // persona file on disk for "general" in the test env, that surfaces as the
+  // not-found fallback line — either way it names the agent.
+  assert.match(captures[0].promptSeen, /Cabinet agent `general`/);
   assert.match(captures[0].promptSeen, /User follow-up:\nthe follow-up/);
 
   agentAdapterRegistry.unregisterExternal("mock_continue");

--- a/src/lib/agents/conversation-store-turns.test.ts
+++ b/src/lib/agents/conversation-store-turns.test.ts
@@ -66,16 +66,23 @@ test("readConversationTurns synthesizes turn 1 from prompt + transcript on a sin
   assert.match(turns[1].content, /I created the poem/);
 });
 
-test("readConversationTurns returns only user turn 1 when the conversation is still running", async () => {
+test("readConversationTurns fabricates a pending agent turn while running with no output yet", async () => {
   const meta = await store.createConversation({
     agentSlug: "general",
     title: "In flight",
     trigger: "manual",
     prompt: "User request:\ndo something",
   });
+  // createConversation defaults to status "running". With no transcript bytes
+  // yet, readTurnOne deliberately fabricates an empty *pending* agent turn so
+  // the UI shows a typing indicator (not a blank gap) during adapter
+  // cold-start, rather than returning the user turn alone.
   const turns = await store.readConversationTurns(meta.id);
-  assert.equal(turns.length, 1);
+  assert.equal(turns.length, 2, "user turn + fabricated pending agent placeholder");
   assert.equal(turns[0].role, "user");
+  assert.equal(turns[1].role, "agent");
+  assert.equal(turns[1].pending, true);
+  assert.equal(turns[1].content, "");
 });
 
 test("appendUserTurn + appendAgentTurn build up multi-turn state and aggregate tokens", async () => {

--- a/src/lib/agents/provider-settings.test.ts
+++ b/src/lib/agents/provider-settings.test.ts
@@ -56,13 +56,20 @@ test("normalizeProviderSettings falls back to the first enabled provider when ne
       },
     },
     () => {
+      // Disable every OTHER registered provider so the only enabled one is our
+      // injected test provider. Deterministic regardless of which built-ins
+      // ship in the registry (e.g. gemini-cli) — the prior hard-coded
+      // [claude-code, codex-cli] list broke once more built-ins were added.
+      const others = [...providerRegistry.providers.keys()].filter(
+        (id) => id !== "test-only-provider"
+      );
       const settings = normalizeProviderSettings({
         defaultProvider: "missing-provider",
-        disabledProviderIds: ["claude-code", "codex-cli"],
+        disabledProviderIds: others,
       });
 
       assert.equal(settings.defaultProvider, "test-only-provider");
-      assert.deepEqual(settings.disabledProviderIds, ["claude-code", "codex-cli"]);
+      assert.deepEqual(settings.disabledProviderIds, others);
     }
   );
 


### PR DESCRIPTION
## Why

While verifying #124 I found a freshly-created conversation returned 2 turns where a test expected 1. It turned out **not** to be a product bug — it was a *stale test that never runs in CI*.

`npm test` only globs `test/*.test.ts`, so **25 co-located `src/**/*.test.ts` files (141 tests) never execute**. Running them revealed **4** that had silently rotted as the code evolved (all assertion drift, zero product bugs).

## Changes

**Widen the test glob** so co-located tests run going forward:
```diff
- "test": "tsx --test test/*.test.ts",
+ "test": "tsx --test $(find test src -name '*.test.ts')",
```
(`sh` has no globstar and Node 20's `--test` doesn't expand glob patterns, so shell command-substitution is the portable form. `npm test` now runs **308 tests**, up from 167.)

**Fix the 4 stale assertions** to match current intended behavior:

| Test | Fix |
|---|---|
| `readConversationTurns … still running` | now asserts `[user, pending-agent]` — `readTurnOne` deliberately fabricates an empty *pending* agent turn so the UI shows a typing indicator during adapter cold-start |
| `continueConversationRun … resume` | prompt reworded → `/```cabinet``` fenced block/` |
| `continueConversationRun … replay` | agent-identity line is now the persona not-found fallback → `/Cabinet agent \`general\`/` |
| `normalizeProviderSettings … first enabled` | disable **all** other registered providers so the fallback is deterministic regardless of which built-ins ship (`gemini-cli` was added, breaking the hard-coded `[claude-code, codex-cli]` assumption) |

## Testing
- `npm test` → **308 tests, 0 fail** (was 167 before the glob widened; the 4 previously-rotting tests now pass).
- `tsc --noEmit` clean; eslint clean on the edited files.

## Note / follow-up
Running `npm test` on PRs still needs a CI workflow — the repo currently has none merged (only `release.yml` / `electron-release.yml`); PR #25 ("Add CI workflow for pull requests") would wire it up. With this PR, that workflow would cover the full 308-test suite instead of ~half of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test discovery to scan multiple directories for test files
  * Enhanced test assertions for conversation handling and agent provider functionality to improve test reliability and coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->