### PR TITLE
fix(daemon): authenticate scheduler triggers against the KB_PASSWORD gate

### DIFF
--- a/server/cabinet-daemon.ts
+++ b/server/cabinet-daemon.ts
@@ -43,6 +43,7 @@ import chokidar from "chokidar";
 import matter from "gray-matter";
 import { getDb, closeDb } from "./db";
 import { DATA_DIR, isHiddenEntry } from "../src/lib/storage/path-utils";
+import { hashKbToken, KB_AUTH_COOKIE } from "../src/lib/auth/kb-auth";
 import { discoverCabinetPathsSync } from "../src/lib/cabinets/discovery";
 import { resolveCabinetDir } from "../src/lib/cabinets/server-paths";
 import {
@@ -1195,10 +1196,48 @@ const scheduledJobs = new Map<string, ReturnType<typeof cron.schedule>>();
 const scheduledHeartbeats = new Map<string, ReturnType<typeof cron.schedule>>();
 let scheduleReloadTimer: NodeJS.Timeout | null = null;
 
+// The app gates every /api/* route behind KB_PASSWORD (src/proxy.ts). Next
+// auto-loads .env so the app has it, but the daemon does not — and the
+// production `start:daemon` path doesn't go through scripts/dev-daemon.mjs — so
+// resolve it here: prefer the process env, then fall back to reading .env from
+// the working directory (same file the app reads). Cached: like the app, a
+// changed password takes effect on restart.
+let cachedKbPassword: string | null = null;
+function resolveKbPassword(): string {
+  if (cachedKbPassword !== null) return cachedKbPassword;
+  let pw = process.env.KB_PASSWORD ?? "";
+  if (!pw) {
+    try {
+      const envRaw = fs.readFileSync(path.join(process.cwd(), ".env"), "utf-8");
+      for (const line of envRaw.split(/\r?\n/)) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith("#")) continue;
+        const eq = trimmed.indexOf("=");
+        if (eq === -1 || trimmed.slice(0, eq).trim() !== "KB_PASSWORD") continue;
+        pw = trimmed.slice(eq + 1).trim().replace(/^["']|["']$/g, "");
+        break;
+      }
+    } catch {
+      // No .env / unreadable — auth gate is presumably disabled.
+    }
+  }
+  cachedKbPassword = pw;
+  return pw;
+}
+
+// When the app's auth gate is active, server-to-server calls must carry the
+// same `kb-auth` cookie a logged-in browser would. Without this every
+// scheduled job and heartbeat trigger 401s silently and never runs.
+async function authCookieHeader(): Promise<Record<string, string>> {
+  const password = resolveKbPassword();
+  if (!password) return {};
+  return { Cookie: `${KB_AUTH_COOKIE}=${await hashKbToken(password)}` };
+}
+
 async function putJson(url: string, body: Record<string, unknown>): Promise<void> {
   const response = await fetch(url, {
     method: "PUT",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...(await authCookieHeader()) },
     body: JSON.stringify(body),
   });
 

--- a/src/lib/auth/kb-auth.ts
+++ b/src/lib/auth/kb-auth.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared KB_PASSWORD auth primitives.
+ *
+ * The app's auth gate (src/proxy.ts) protects every `/api/*` route when
+ * `KB_PASSWORD` is set, requiring a `kb-auth` cookie whose value is
+ * SHA-256(password + salt). The scheduler daemon (server/cabinet-daemon.ts)
+ * makes internal server-to-server calls to those same routes and must present
+ * the identical cookie, so both sides derive the value from this one module to
+ * prevent the hash/salt from drifting between them.
+ */
+
+/** Cookie name checked by the app's auth gate. */
+export const KB_AUTH_COOKIE = "kb-auth";
+
+const KB_AUTH_SALT = "cabinet-salt";
+
+/**
+ * Hex SHA-256 of `password + salt`. Uses Web Crypto (`crypto.subtle`), which is
+ * available in both the Next edge/middleware runtime and Node 20+ (the daemon).
+ */
+export async function hashKbToken(password: string): Promise<string> {
+  const data = new TextEncoder().encode(password + KB_AUTH_SALT);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,12 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-
-async function hashToken(password: string): Promise<string> {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(password + "cabinet-salt");
-  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
-}
+import { hashKbToken, KB_AUTH_COOKIE } from "@/lib/auth/kb-auth";
 
 export async function proxy(req: NextRequest) {
   const password = process.env.KB_PASSWORD || "";
@@ -29,8 +22,8 @@ export async function proxy(req: NextRequest) {
   }
 
   // Check auth cookie
-  const token = req.cookies.get("kb-auth")?.value;
-  const expected = await hashToken(password);
+  const token = req.cookies.get(KB_AUTH_COOKIE)?.value;
+  const expected = await hashKbToken(password);
 
   if (token !== expected) {
     // API routes return 401

--- a/test/kb-auth.test.ts
+++ b/test/kb-auth.test.ts
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { hashKbToken, KB_AUTH_COOKIE } from "@/lib/auth/kb-auth";
+
+// Independent reference implementation of the gate's expected cookie value.
+// proxy.ts and the daemon must both reproduce exactly this, or scheduled
+// triggers 401.
+function expectedHash(password: string): string {
+  return createHash("sha256")
+    .update(password + "cabinet-salt")
+    .digest("hex");
+}
+
+test("cookie name is kb-auth", () => {
+  assert.equal(KB_AUTH_COOKIE, "kb-auth");
+});
+
+test("hashKbToken matches SHA-256(password + salt)", async () => {
+  for (const pw of ["hunter2", "p@ss word!", "", "🔑-unicode"]) {
+    assert.equal(await hashKbToken(pw), expectedHash(pw));
+  }
+});
+
+test("different passwords produce different hashes", async () => {
+  assert.notEqual(await hashKbToken("a"), await hashKbToken("b"));
+});
+
+test("hash is stable across calls", async () => {
+  assert.equal(await hashKbToken("same"), await hashKbToken("same"));
+});


### PR DESCRIPTION
## Problem

When `KB_PASSWORD` is set, `src/proxy.ts` requires a valid `kb-auth` cookie on every `/api/*` route. The scheduler daemon's server-to-server calls (`putJson` → `/api/agents/.../jobs` and `/api/agents/personas/...`) send **no cookie**, so once the auth gate is enabled **every scheduled job and heartbeat trigger returns 401 and silently never runs**.

It's an easy failure to miss because:
- Manual **"Run now"** from the browser keeps working (the browser carries the cookie).
- `/health` still reports `status: ok` with `scheduledJobs > 0`.
- The only signal is `console.error("Failed to trigger ...")`.

In our deployment this silently disabled all cron routines for days after `KB_PASSWORD` was turned on.

## Fix

The daemon now attaches the same `kb-auth` cookie a logged-in browser would:

- New `src/lib/auth/kb-auth.ts` holds the shared `hashKbToken` + `KB_AUTH_COOKIE`, so the verifier (`proxy.ts`) and the caller (the daemon) can't drift on hash/salt. `proxy.ts` is refactored onto it (no behavior change).
- The daemon resolves `KB_PASSWORD` from its env, falling back to reading `.env` from the working dir — Next auto-loads `.env` for the app, but the daemon doesn't, and the production `start:daemon` path bypasses `scripts/dev-daemon.mjs`.

**No behavior change when `KB_PASSWORD` is unset** (auth disabled) — no cookie is sent.

## Test

`test/kb-auth.test.ts` pins the hash against an independent SHA-256 reference so the daemon's cookie always matches what the gate expects.

## Verification

Applied to a live instance: previously 100% of scheduled triggers 401'd; after the fix, a `0 */4` job + an hourly job + all heartbeats fired at the cron boundary with **zero 401s** and produced real runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Internal scheduler and heartbeat operations now properly authenticate using the application's password-based gate, consistent with user authentication.

* **Tests**
  * Added test coverage for authentication token hashing and cookie validation.

* **Refactor**
  * Extracted shared authentication utilities for improved consistency across modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->