### PR TITLE
feat(daemon): expose scheduler trigger health on /health

### DIFF
--- a/server/cabinet-daemon.ts
+++ b/server/cabinet-daemon.ts
@@ -1196,6 +1196,31 @@ const scheduledJobs = new Map<string, ReturnType<typeof cron.schedule>>();
 const scheduledHeartbeats = new Map<string, ReturnType<typeof cron.schedule>>();
 let scheduleReloadTimer: NodeJS.Timeout | null = null;
 
+// Scheduler observability, surfaced on /health. A scheduler that fires but
+// whose every trigger fails (e.g. 401 from the app auth gate) is otherwise
+// invisible: scheduledJobs stays > 0 and the daemon looks healthy while no
+// job actually runs. These process-lifetime counters make that detectable
+// without scraping logs.
+const schedulerStats = {
+  lastTriggerAt: null as string | null,
+  lastSuccessfulTriggerAt: null as string | null,
+  lastFailedTriggerAt: null as string | null,
+  triggerFailures: 0,
+  lastTriggerError: null as string | null,
+};
+function recordTriggerAttempt(scheduledAt: string): void {
+  schedulerStats.lastTriggerAt = scheduledAt;
+}
+function recordTriggerSuccess(scheduledAt: string): void {
+  schedulerStats.lastSuccessfulTriggerAt = scheduledAt;
+}
+function recordTriggerFailure(error: unknown): void {
+  schedulerStats.triggerFailures += 1;
+  schedulerStats.lastFailedTriggerAt = new Date().toISOString();
+  schedulerStats.lastTriggerError =
+    error instanceof Error ? error.message : String(error);
+}
+
 // The app gates every /api/* route behind KB_PASSWORD (src/proxy.ts). Next
 // auto-loads .env so the app has it, but the daemon does not — and the
 // production `start:daemon` path doesn't go through scripts/dev-daemon.mjs — so
@@ -1266,6 +1291,7 @@ function scheduleJob(job: JobConfig): void {
   const task = cron.schedule(job.schedule, () => {
     const scheduledAt = new Date(Math.round(Date.now() / 60000) * 60000).toISOString();
     console.log(`Triggering scheduled job ${key} @ ${scheduledAt}`);
+    recordTriggerAttempt(scheduledAt);
     // Disable a one-shot after it has fired — on BOTH success and failure. A
     // one-off cron (`m h dom mon *`) would otherwise re-match a year later; a
     // failed run must not leave it armed for that rollover.
@@ -1294,7 +1320,9 @@ function scheduleJob(job: JobConfig): void {
       cabinetPath: job.cabinetPath,
       scheduledAt,
     })
+      .then(() => recordTriggerSuccess(scheduledAt))
       .catch((error) => {
+        recordTriggerFailure(error);
         console.error(`Failed to trigger scheduled job ${key}:`, error);
       })
       .finally(() => {
@@ -1319,14 +1347,18 @@ function scheduleHeartbeat(slug: string, cronExpr: string, cabinetPath: string):
   const task = cron.schedule(cronExpr, () => {
     const scheduledAt = new Date(Math.round(Date.now() / 60000) * 60000).toISOString();
     console.log(`Triggering heartbeat ${key} @ ${scheduledAt}`);
+    recordTriggerAttempt(scheduledAt);
     void putJson(`${getAppOrigin()}/api/agents/personas/${slug}`, {
       action: "run",
       source: "scheduler",
       cabinetPath,
       scheduledAt,
-    }).catch((error) => {
-      console.error(`Failed to trigger heartbeat ${key}:`, error);
-    });
+    })
+      .then(() => recordTriggerSuccess(scheduledAt))
+      .catch((error) => {
+        recordTriggerFailure(error);
+        console.error(`Failed to trigger heartbeat ${key}:`, error);
+      });
   });
 
   scheduledHeartbeats.set(key, task);
@@ -1884,6 +1916,11 @@ const server = http.createServer(async (req, res) => {
         scheduledJobs: scheduledJobs.size,
         scheduledHeartbeats: scheduledHeartbeats.size,
         subscribers: subscribers.length,
+        lastTriggerAt: schedulerStats.lastTriggerAt,
+        lastSuccessfulTriggerAt: schedulerStats.lastSuccessfulTriggerAt,
+        lastFailedTriggerAt: schedulerStats.lastFailedTriggerAt,
+        triggerFailures: schedulerStats.triggerFailures,
+        lastTriggerError: schedulerStats.lastTriggerError,
       })
     );
     return;

--- a/server/cabinet-daemon.ts
+++ b/server/cabinet-daemon.ts
@@ -43,6 +43,7 @@ import chokidar from "chokidar";
 import matter from "gray-matter";
 import { getDb, closeDb } from "./db";
 import { DATA_DIR, isHiddenEntry } from "../src/lib/storage/path-utils";
+import { hashKbToken, KB_AUTH_COOKIE } from "../src/lib/auth/kb-auth";
 import { discoverCabinetPathsSync } from "../src/lib/cabinets/discovery";
 import { resolveCabinetDir } from "../src/lib/cabinets/server-paths";
 import {
@@ -1195,10 +1196,48 @@ const scheduledJobs = new Map<string, ReturnType<typeof cron.schedule>>();
 const scheduledHeartbeats = new Map<string, ReturnType<typeof cron.schedule>>();
 let scheduleReloadTimer: NodeJS.Timeout | null = null;
 
+// The app gates every /api/* route behind KB_PASSWORD (src/proxy.ts). Next
+// auto-loads .env so the app has it, but the daemon does not — and the
+// production `start:daemon` path doesn't go through scripts/dev-daemon.mjs — so
+// resolve it here: prefer the process env, then fall back to reading .env from
+// the working directory (same file the app reads). Cached: like the app, a
+// changed password takes effect on restart.
+let cachedKbPassword: string | null = null;
+function resolveKbPassword(): string {
+  if (cachedKbPassword !== null) return cachedKbPassword;
+  let pw = process.env.KB_PASSWORD ?? "";
+  if (!pw) {
+    try {
+      const envRaw = fs.readFileSync(path.join(process.cwd(), ".env"), "utf-8");
+      for (const line of envRaw.split(/\r?\n/)) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith("#")) continue;
+        const eq = trimmed.indexOf("=");
+        if (eq === -1 || trimmed.slice(0, eq).trim() !== "KB_PASSWORD") continue;
+        pw = trimmed.slice(eq + 1).trim().replace(/^["']|["']$/g, "");
+        break;
+      }
+    } catch {
+      // No .env / unreadable — auth gate is presumably disabled.
+    }
+  }
+  cachedKbPassword = pw;
+  return pw;
+}
+
+// When the app's auth gate is active, server-to-server calls must carry the
+// same `kb-auth` cookie a logged-in browser would. Without this every
+// scheduled job and heartbeat trigger 401s silently and never runs.
+async function authCookieHeader(): Promise<Record<string, string>> {
+  const password = resolveKbPassword();
+  if (!password) return {};
+  return { Cookie: `${KB_AUTH_COOKIE}=${await hashKbToken(password)}` };
+}
+
 async function putJson(url: string, body: Record<string, unknown>): Promise<void> {
   const response = await fetch(url, {
     method: "PUT",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...(await authCookieHeader()) },
     body: JSON.stringify(body),
   });
 

--- a/src/lib/auth/kb-auth.ts
+++ b/src/lib/auth/kb-auth.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared KB_PASSWORD auth primitives.
+ *
+ * The app's auth gate (src/proxy.ts) protects every `/api/*` route when
+ * `KB_PASSWORD` is set, requiring a `kb-auth` cookie whose value is
+ * SHA-256(password + salt). The scheduler daemon (server/cabinet-daemon.ts)
+ * makes internal server-to-server calls to those same routes and must present
+ * the identical cookie, so both sides derive the value from this one module to
+ * prevent the hash/salt from drifting between them.
+ */
+
+/** Cookie name checked by the app's auth gate. */
+export const KB_AUTH_COOKIE = "kb-auth";
+
+const KB_AUTH_SALT = "cabinet-salt";
+
+/**
+ * Hex SHA-256 of `password + salt`. Uses Web Crypto (`crypto.subtle`), which is
+ * available in both the Next edge/middleware runtime and Node 20+ (the daemon).
+ */
+export async function hashKbToken(password: string): Promise<string> {
+  const data = new TextEncoder().encode(password + KB_AUTH_SALT);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,12 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-
-async function hashToken(password: string): Promise<string> {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(password + "cabinet-salt");
-  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
-}
+import { hashKbToken, KB_AUTH_COOKIE } from "@/lib/auth/kb-auth";
 
 export async function proxy(req: NextRequest) {
   const password = process.env.KB_PASSWORD || "";
@@ -29,8 +22,8 @@ export async function proxy(req: NextRequest) {
   }
 
   // Check auth cookie
-  const token = req.cookies.get("kb-auth")?.value;
-  const expected = await hashToken(password);
+  const token = req.cookies.get(KB_AUTH_COOKIE)?.value;
+  const expected = await hashKbToken(password);
 
   if (token !== expected) {
     // API routes return 401

--- a/test/kb-auth.test.ts
+++ b/test/kb-auth.test.ts
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { hashKbToken, KB_AUTH_COOKIE } from "@/lib/auth/kb-auth";
+
+// Independent reference implementation of the gate's expected cookie value.
+// proxy.ts and the daemon must both reproduce exactly this, or scheduled
+// triggers 401.
+function expectedHash(password: string): string {
+  return createHash("sha256")
+    .update(password + "cabinet-salt")
+    .digest("hex");
+}
+
+test("cookie name is kb-auth", () => {
+  assert.equal(KB_AUTH_COOKIE, "kb-auth");
+});
+
+test("hashKbToken matches SHA-256(password + salt)", async () => {
+  for (const pw of ["hunter2", "p@ss word!", "", "🔑-unicode"]) {
+    assert.equal(await hashKbToken(pw), expectedHash(pw));
+  }
+});
+
+test("different passwords produce different hashes", async () => {
+  assert.notEqual(await hashKbToken("a"), await hashKbToken("b"));
+});
+
+test("hash is stable across calls", async () => {
+  assert.equal(await hashKbToken("same"), await hashKbToken("same"));
+});


### PR DESCRIPTION
## Stacked on #137 — review/merge that first

> This branch contains #137's commit plus one more. GitHub will reduce the diff to just the observability commit once #137 merges into `main`. **Review commit `feat(daemon): expose scheduler trigger health on /health` here; merge after #137.**

## Problem

A scheduler that fires on time but whose every trigger fails (the 401 gate bug in #137, a downed app, a wrong origin) is invisible today: `scheduledJobs` stays > 0 and `/health` reports `status: ok` while no job actually runs. The failures only land in `console.error`, which is easy to lose when the daemon isn't closely supervised.

## Change

Track process-lifetime trigger stats and surface them on `/health`:

| field | meaning |
|---|---|
| `lastTriggerAt` | last time any job/heartbeat cron fired |
| `lastSuccessfulTriggerAt` | last trigger the app accepted |
| `lastFailedTriggerAt` | last trigger that errored |
| `triggerFailures` | count of failed triggers |
| `lastTriggerError` | message of the most recent failure |

This turns "silently not running for days" into a single `/health` glance: `lastTriggerAt` advancing while `lastSuccessfulTriggerAt` is stale and `triggerFailures` climbing pinpoints a delivery failure vs a stalled timer.

No new dependencies; counters are in-memory and reset on restart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daemon now authenticates its own internal API calls to ensure secure communication.
  * Health endpoint now includes scheduler observability metrics (attempts, successes, failures, and last error information).

* **Tests**
  * Added comprehensive authentication test suite validating token generation and hash consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->