### PR TITLE
fix(windows): repair CLI install path + remaining POSIX-only assumptions

### DIFF
--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -1,16 +1,19 @@
 name: Electron Release (manual)
 
-# Triggered manually after npm publish + smoke tests pass.
-# macOS job: builds, signs, notarizes, and publishes the Cabinet Electron app.
-# Windows job: builds the ZIP + Squirrel installer via electron:make:win and
-# attaches them to the release. Both target the existing GitHub release for the tag.
+# Triggered manually. Two modes:
+#  * RELEASE  — dispatch with a `tag` (e.g. v0.4.0): macOS job signs/notarizes/
+#    publishes; Windows job builds and attaches artifacts to that release.
+#  * VALIDATE — dispatch with NO tag (against a branch): macOS job is skipped,
+#    the Windows job builds the current branch and only uploads the build as a
+#    run artifact (no release writes). Used to smoke-test the Windows packaging
+#    of a branch/PR before merging.
 
 on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag to build (e.g., v0.4.0)'
-        required: true
+        description: 'Release tag to build (e.g., v0.4.0). Leave empty to validate the selected branch without publishing.'
+        required: false
         type: string
 
 permissions:
@@ -20,6 +23,9 @@ permissions:
 jobs:
   electron-macos:
     runs-on: macos-latest
+    # Release-only: this job signs, notarizes and publishes, so never run it for
+    # a branch validation (no tag).
+    if: ${{ inputs.tag != '' }}
     steps:
       - name: Checkout tag
         uses: actions/checkout@v4
@@ -66,10 +72,11 @@ jobs:
   electron-windows:
     runs-on: windows-latest
     steps:
-      - name: Checkout tag
+      # With a tag -> build that release; without -> build the dispatched branch.
+      - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag }}
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -91,11 +98,13 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: cabinet-windows-${{ inputs.tag }}
+          name: cabinet-windows-${{ inputs.tag || github.sha }}
           path: out/make/**
           if-no-files-found: warn
 
+      # Release-only: only attach to a GitHub release when a tag was given.
       - name: Attach Windows artifacts to the GitHub release
+        if: ${{ inputs.tag != '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash

--- a/cabinetai/src/lib/app-manager.ts
+++ b/cabinetai/src/lib/app-manager.ts
@@ -112,9 +112,24 @@ async function downloadAndExtract(version: string, appDir: string): Promise<void
     const bytes = Buffer.from(await response.arrayBuffer());
     fs.writeFileSync(archivePath, bytes);
 
-    // Extract
+    // Extract. Windows ships bsdtar at %SystemRoot%\System32\tar.exe, which handles
+    // `C:\…` paths and does NOT understand GNU's `--no-same-owner` (ownership is moot
+    // on Windows anyway). Invoking it explicitly also avoids a GNU `tar` earlier on
+    // PATH (Git Bash / MSYS / WSL) misreading the `C:\…` archive path as a remote
+    // `host:path` SSH spec and failing with "Cannot connect to C:".
     log("Extracting...");
-    spawnSync("tar", ["-xzf", archivePath, "-C", tempDir, "--no-same-owner"], { stdio: "inherit" });
+    const isWin = process.platform === "win32";
+    const winTar = path.join(process.env.SystemRoot || "C:\\Windows", "System32", "tar.exe");
+    const tarBin = isWin && fs.existsSync(winTar) ? winTar : "tar";
+    const tarArgs = isWin
+      ? ["-xf", archivePath, "-C", tempDir]
+      : ["-xzf", archivePath, "-C", tempDir, "--no-same-owner"];
+    const tarResult = spawnSync(tarBin, tarArgs, { stdio: "inherit" });
+    if (tarResult.error || tarResult.status !== 0) {
+      throw new Error(
+        `tar extraction failed: ${tarResult.error?.message ?? `exited with code ${tarResult.status}`}`
+      );
+    }
 
     // Find extracted root (GitHub tarballs have a single root dir like "cabinet-0.2.12/")
     const entries = fs

--- a/cli/index.cjs
+++ b/cli/index.cjs
@@ -52,6 +52,30 @@ function resolveCabinetAI() {
   return null;
 }
 
+// Mirror of cabinetai's slugify (cabinetai/src/lib/paths.ts). `cabinetai create`
+// slugifies the name into the directory it writes (e.g. "My Startup" -> ./my-startup/),
+// so we must cd into the slug, not the raw argument, or `create-cabinet "My Startup"`
+// crashes with ENOENT on chdir. Kept in sync manually; resolveCreatedDir falls back
+// to the raw name if the slug isn't present on disk.
+function slugifyDir(name) {
+  return String(name)
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/[\s_]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function resolveCreatedDir(name) {
+  for (const candidate of [slugifyDir(name), name]) {
+    if (!candidate) continue;
+    const abs = path.resolve(process.cwd(), candidate);
+    if (fs.existsSync(abs)) return abs;
+  }
+  return path.resolve(process.cwd(), slugifyDir(name) || name);
+}
+
 function pinnedCabinetAIVersion() {
   // Pin the npx fallback to the exact cabinetai version this create-cabinet was published against.
   // Reading from our own dependencies guarantees create-cabinet@N.M.K → cabinetai@N.M.K, never @latest.
@@ -126,8 +150,10 @@ if (createStatus !== 0) {
   process.exit(createStatus);
 }
 
-// Step 2: Run Cabinet from the new directory
-const targetPath = path.resolve(process.cwd(), targetDir);
+// Step 2: Run Cabinet from the new directory. cabinetai create slugifies the
+// name into the directory it wrote, so resolve the actual created directory
+// rather than assuming it matches the raw argument.
+const targetPath = resolveCreatedDir(targetDir);
 process.chdir(targetPath);
 const runStatus = runCabinetAI(["run"]);
 process.exit(runStatus);

--- a/cli/index.cjs
+++ b/cli/index.cjs
@@ -21,13 +21,33 @@ const command = COMMANDS.includes(firstArg) ? firstArg : "init";
 const dirArg = COMMANDS.includes(firstArg) ? args[1] : firstArg;
 
 function resolveCabinetAI() {
-  // 1. Sibling install in our own node_modules (when create-cabinet was npm-installed)
-  const ownBin = path.join(__dirname, "node_modules", ".bin", "cabinetai");
-  if (fs.existsSync(ownBin)) return ownBin;
+  // Resolve cabinetai's real JS entrypoint (its package.json `bin`) so we can run
+  // it with `node` on every platform. The npm-generated `.bin/cabinetai` shim is a
+  // POSIX shell script on Windows; spawning it via `node` makes Node parse the shell
+  // script as JavaScript and crash with a SyntaxError (issue #81). Reading the
+  // package's own bin field sidesteps the shims entirely.
+  const packageDirs = [
+    // Sibling install in our own node_modules (create-cabinet was npm-installed)
+    path.join(__dirname, "node_modules", "cabinetai"),
+    // Hoisted install one level up
+    path.join(__dirname, "..", "cabinetai"),
+    path.join(__dirname, "..", "node_modules", "cabinetai"),
+  ];
 
-  // 2. Hoisted install one level up
-  const hoistedBin = path.join(__dirname, "..", "node_modules", ".bin", "cabinetai");
-  if (fs.existsSync(hoistedBin)) return hoistedBin;
+  for (const dir of packageDirs) {
+    const pkgPath = path.join(dir, "package.json");
+    if (!fs.existsSync(pkgPath)) continue;
+    try {
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+      const bin = pkg.bin;
+      const rel = typeof bin === "string" ? bin : bin && (bin.cabinetai || Object.values(bin)[0]);
+      if (!rel) continue;
+      const entry = path.join(dir, rel);
+      if (fs.existsSync(entry)) return entry;
+    } catch {
+      // Ignore a malformed package.json and try the next candidate.
+    }
+  }
 
   return null;
 }

--- a/docs/WINDOWS_PR139_SMOKE_TEST.md
+++ b/docs/WINDOWS_PR139_SMOKE_TEST.md
@@ -1,0 +1,407 @@
+# PR #139 Windows Smoke Test Guide
+
+This guide validates PR #139, `fix(windows): repair CLI install path + remaining POSIX-only assumptions`, on a real Windows 11 machine before release.
+
+The goal is not only to prove TypeScript/tests pass. The important part is to exercise the Windows-only paths that macOS/Linux CI cannot prove:
+
+- `npx create-cabinet` finds and runs the real `cabinetai` JavaScript entrypoint.
+- `npx create-cabinet "<Name With Spaces>"` `cd`s into the **slugified** directory it actually created (not the raw argument).
+- `cabinetai run` can download and extract the app tarball on Windows.
+- Git Bash/MSYS/GNU `tar` earlier on `PATH` does not break extraction.
+- "Open terminal" opens a terminal in the user's home directory.
+- "Reveal in file manager" opens File Explorer without shell quoting issues.
+- Root-level page navigation is not redirected into the default room.
+
+> ### Verified against the code (2026-06-14, macOS)
+> Before handing this to a Windows tester, the concrete claims below were checked against the branch:
+> - **cabinetai version is `0.4.4`** → app installs at `%USERPROFILE%\.cabinet\app\v0.4.4` (`appVersionDir` in `cabinetai/src/lib/paths.ts`). ✅
+> - `cabinetai/` has its own `package-lock.json`, so `npm ci` inside it works. ✅
+> - `cabinetai` has `npm run build` (esbuild → `dist/index.js`) and a `tsconfig.json` (so `npx tsc --noEmit` is valid). ✅
+> - Root `electron:make:win` script exists. ✅ Default app port is `4000` (overridable via `CABINET_APP_PORT`/`PORT`). ✅
+> - **Correction:** `cabinetai create "Cabinet With Spaces"` writes a **slugified** directory `cabinet-with-spaces/` (see `slugify` in `cabinetai/src/lib/paths.ts`), *not* `Cabinet With Spaces/`. All filesystem paths below use the slug. This guide originally surfaced a real bug — `create-cabinet` `chdir`'d into the raw name and crashed with `ENOENT` — which **PR #139 now fixes** (the wrapper resolves the created slug dir). Smoke Test 1 explicitly re-checks this.
+> - tsc + eslint clean and `npm test` 312/312 on macOS; the Windows-only behaviors still require this guide.
+
+## Environment
+
+Use a real Windows 11 machine or VM. Do not use WSL for the primary test. Run commands from PowerShell or Windows Terminal using PowerShell.
+
+Recommended versions:
+
+- Windows 11
+- Node.js 20 or 22
+- npm bundled with Node
+- Git for Windows
+
+Record these at the top of the test result:
+
+```powershell
+systeminfo | Select-String "OS Name","OS Version","System Type"
+node -v
+npm -v
+git --version
+$PSVersionTable.PSVersion
+Get-Command tar
+Get-Command npx
+```
+
+If Git Bash is installed, also record:
+
+```powershell
+Test-Path "C:\Program Files\Git\usr\bin\tar.exe"
+```
+
+## Checkout
+
+```powershell
+git clone https://github.com/hilash/cabinet.git
+cd cabinet
+git fetch origin main fix/windows-cli-and-polish
+git checkout fix/windows-cli-and-polish
+git rev-parse --short HEAD
+```
+
+Use the current tip of `fix/windows-cli-and-polish` (commit `c0df0034` or later — the slug-dir fix is a follow-up commit on the same branch). Record the exact short hash you tested.
+
+## Static Verification
+
+Run the repo checks first. These are not enough to approve the Windows behavior, but they catch obvious regressions.
+
+```powershell
+npm ci
+npx tsc --noEmit
+npx eslint cabinetai/src/lib/app-manager.ts cli/index.cjs src/app/api/system/reveal/route.ts src/app/api/terminal/open/route.ts src/components/layout/app-shell.tsx src/lib/agents/nvm-path.ts
+npm test
+```
+
+Then validate the `cabinetai` package:
+
+```powershell
+Push-Location cabinetai
+npm ci
+npm run build
+npx tsc --noEmit
+Pop-Location
+```
+
+Expected:
+
+- TypeScript exits with code 0.
+- ESLint exits with code 0.
+- `npm test` passes all tests (312 at time of writing).
+- `cabinetai/dist/index.js` exists after `npm run build`.
+
+## Build Local Package Tarballs
+
+This simulates unpublished npm packages from the PR branch. It is important because the `create-cabinet` bug lives in package layout and bin resolution.
+
+```powershell
+Push-Location cabinetai
+npm run build
+$cabinetaiPackName = (npm pack --silent | Select-Object -Last 1)
+$cabinetaiTgz = Join-Path (Get-Location) $cabinetaiPackName
+Pop-Location
+
+Push-Location cli
+$createCabinetPackName = (npm pack --silent | Select-Object -Last 1)
+$createCabinetTgz = Join-Path (Get-Location) $createCabinetPackName
+Pop-Location
+
+$cabinetaiTgz
+$createCabinetTgz
+```
+
+Expected:
+
+- A `cabinetai-*.tgz` path is printed.
+- A `create-cabinet-*.tgz` path is printed.
+
+## Smoke Test 1: `npx create-cabinet`
+
+This is the highest-priority test. It validates that `create-cabinet` resolves `cabinetai` from package metadata and runs it with `node` (instead of feeding a Windows npm shim to Node), **and** that it `cd`s into the slugified directory that was actually created.
+
+Start from a clean temp directory:
+
+```powershell
+$smokeRoot = Join-Path $env:TEMP "cabinet-pr139-smoke"
+Remove-Item $smokeRoot -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force $smokeRoot | Out-Null
+Push-Location $smokeRoot
+```
+
+Force a fresh app extraction:
+
+```powershell
+Remove-Item "$env:USERPROFILE\.cabinet\app\v0.4.4" -Recurse -Force -ErrorAction SilentlyContinue
+```
+
+If Git Bash is installed, put its GNU/MSYS tools first on `PATH` for this shell. This intentionally recreates the old failure mode where `tar` could misread `C:\...` as `host:path`.
+
+```powershell
+$oldPath = $env:Path
+$gitUsrBin = "C:\Program Files\Git\usr\bin"
+if (Test-Path $gitUsrBin) {
+  $env:Path = "$gitUsrBin;$env:Path"
+  Get-Command tar
+}
+```
+
+Run the local package simulation (the spaced name deliberately exercises the slug `chdir` fix):
+
+```powershell
+npx -y --package $cabinetaiTgz --package $createCabinetTgz create-cabinet "Cabinet With Spaces"
+```
+
+After npm publish, repeat this same test once with the published package:
+
+```powershell
+npx -y create-cabinet@0.4.4 "Cabinet Published Smoke"
+```
+
+Expected:
+
+- No `SyntaxError`.
+- No attempt to parse a shell script as JavaScript.
+- Output reaches `cabinetai create`.
+- A directory `cabinet-with-spaces/` is created (slugified — **not** `Cabinet With Spaces/`).
+- **No `ENOENT ... chdir ... Cabinet With Spaces`** — the wrapper must `cd` into `cabinet-with-spaces/`.
+- Output reaches `cabinetai run`.
+- Fresh install prints `Downloading Cabinet v0.4.4...` and `Extracting...`.
+- No `Cannot connect to C:`.
+- No `--no-same-owner` error.
+- No misleading `Empty release archive`.
+- App dependencies install if missing.
+- The app starts and prints a local URL, usually `http://127.0.0.1:4000`.
+
+Confirm the created directory name:
+
+```powershell
+Get-ChildItem $smokeRoot -Directory | Select-Object Name
+```
+
+Expected to include `cabinet-with-spaces` (and, after the published run, `cabinet-published-smoke`).
+
+Leave the app running for the route/UI smoke tests below. If the process is stopped accidentally, restart it from the **slug** directory:
+
+```powershell
+cd "$smokeRoot\cabinet-with-spaces"
+npx -y --package $cabinetaiTgz cabinetai run
+```
+
+Keep the app process running for the next tests. When all tests are done and the app has been stopped with `Ctrl+C`, restore `PATH` in this PowerShell window if it was changed:
+
+```powershell
+if ($oldPath) { $env:Path = $oldPath }
+```
+
+## Smoke Test 2: Extracted App Is Actually Usable
+
+In a second PowerShell window:
+
+```powershell
+$smokeRoot = Join-Path $env:TEMP "cabinet-pr139-smoke"
+$origin = "http://127.0.0.1:4000"
+Invoke-WebRequest "$origin" -UseBasicParsing
+```
+
+If the app chose another port, update `$origin` to the URL printed by `cabinetai run`.
+
+Expected:
+
+- HTTP request succeeds.
+- Browser can load the app.
+- `%USERPROFILE%\.cabinet\app\v0.4.4\package.json` exists.
+- `%USERPROFILE%\.cabinet\app\v0.4.4\node_modules\next` exists.
+
+Check the files:
+
+```powershell
+Test-Path "$env:USERPROFILE\.cabinet\app\v0.4.4\package.json"
+Test-Path "$env:USERPROFILE\.cabinet\app\v0.4.4\node_modules\next"
+```
+
+Both should print `True`.
+
+## Smoke Test 3: Open Terminal Route
+
+With the app still running:
+
+```powershell
+$origin = "http://127.0.0.1:4000"
+Invoke-RestMethod -Method Post "$origin/api/terminal/open"
+```
+
+Expected:
+
+- API returns `{ ok = True }`.
+- A new `cmd.exe` window opens.
+- The new terminal starts in the Windows user home directory, for example `C:\Users\<User>`.
+- A home path containing spaces still works.
+
+Manual confirmation inside the opened terminal:
+
+```cmd
+cd
+```
+
+The printed directory should match the user's home directory, not a literal `~`.
+
+## Smoke Test 4: Reveal In File Manager
+
+> The reveal API resolves the posted `path` **relative to the running cabinet's data root** (`resolveContentPath` → `DATA_DIR`). Create the test file under that data root. For a cabinet created above, that is the cabinet directory itself; if your install keeps content under a `data/` subfolder, create the file there and adjust the posted path accordingly.
+
+Create a file with spaces and shell-sensitive characters in the running cabinet's data directory:
+
+```powershell
+$cabinetDir = Join-Path $smokeRoot "cabinet-with-spaces"
+$nestedDir = Join-Path $cabinetDir "Folder With Spaces"
+New-Item -ItemType Directory -Force $nestedDir | Out-Null
+$testFile = Join-Path $nestedDir "hello & test.md"
+"hello" | Set-Content -Encoding UTF8 $testFile
+```
+
+Call the reveal API with a Windows-style virtual path:
+
+```powershell
+$body = @{ path = "Folder With Spaces\hello & test.md" } | ConvertTo-Json
+Invoke-RestMethod -Method Post "$origin/api/system/reveal" -ContentType "application/json" -Body $body
+```
+
+Expected:
+
+- API returns `{ ok = True }`.
+- File Explorer opens.
+- The file is selected or the containing folder opens.
+- The `&` in the filename is treated as part of the filename, not as shell syntax.
+
+Also test a missing file:
+
+```powershell
+$body = @{ path = "Folder With Spaces\missing.md" } | ConvertTo-Json
+try {
+  Invoke-RestMethod -Method Post "$origin/api/system/reveal" -ContentType "application/json" -Body $body
+} catch {
+  $_.Exception.Response.StatusCode.value__
+}
+```
+
+Expected:
+
+```text
+404
+```
+
+## Smoke Test 5: Root Page Is Not Hijacked Into Default Room
+
+This checks the `app-shell` redirect change. The important behavior is that a root-scoped page route remains a page route and is not snapped into the default room.
+
+In the browser:
+
+1. Open the app URL printed by `cabinetai run`.
+2. Create or open a top-level page in the data root, not inside a room.
+3. Reload the browser.
+4. Navigate away and back to the page using the address bar or sidebar.
+
+Expected:
+
+- The page remains selected after reload.
+- The URL stays on the page/content route.
+- The UI does not jump into the default room dashboard.
+- The sidebar selection still points at the requested page.
+
+If there is no obvious way to create a root-level page through the UI, use the file created in Smoke Test 4 and navigate to it from search/sidebar. Record that limitation in the result.
+
+## Smoke Test 6: Agent CLI PATH And nvm Caveat
+
+PR #139 only changes the fallback from `HOME\.nvm` to `USERPROFILE\.nvm` when `NVM_DIR` is missing. It does not fully implement `nvm-windows` layout using `NVM_HOME` or `NVM_SYMLINK`.
+
+Check the behavior, but do not call `nvm-windows` fully fixed unless it is explicitly verified.
+
+Prefer validating through the app settings/provider verification flow:
+
+1. Install or use one agent CLI through normal npm global installation.
+2. Open Cabinet settings for provider setup.
+3. Run the provider verify flow.
+4. Confirm globally installed CLIs under `%APPDATA%\npm` are found.
+5. If testing a Unix-style `%USERPROFILE%\.nvm`, confirm the provider CLI is found there.
+6. If testing `nvm-windows`, record whether it works, but treat failures as outside this PR unless the branch claims otherwise.
+
+Expected:
+
+- npm global CLIs under `%APPDATA%\npm` are found.
+- The PR should not regress provider verification.
+- `nvm-windows` support should be documented as unproven unless separately fixed.
+
+## Optional Release Gate: Packaged Windows App
+
+This is not the same as `npx create-cabinet`, but it is still a release gate mentioned in the PR.
+
+From the repo root:
+
+```powershell
+npm run electron:make:win
+```
+
+Then install/run the generated Squirrel artifact from `out\make\squirrel.windows\`.
+
+Expected:
+
+- Installer builds on `windows-latest` or a Windows 11 machine.
+- Installed app launches.
+- App can create/open a cabinet.
+- No startup crash from native dependencies.
+
+If this fails, record it separately from PR #139 unless the failure is caused by one of the changed files.
+
+## Blocking Failures
+
+Block the release if any of these happen:
+
+- `npx create-cabinet` crashes with `SyntaxError` while parsing an npm shim.
+- `npx create-cabinet "<Name With Spaces>"` crashes with `ENOENT` on `chdir` (slug-dir regression).
+- App extraction fails with `Cannot connect to C:`.
+- App extraction fails because `--no-same-owner` is unsupported.
+- Extraction failure is reported as `Empty release archive`.
+- Fresh `cabinetai run` cannot reach a working app URL.
+- Terminal opens at literal `~` or fails when the home path contains spaces.
+- Reveal route treats filename characters like `&`, `(`, `)`, `^`, or `|` as shell syntax.
+- Root-scoped page routes are redirected into the default room.
+
+## Report Template
+
+Use this format when reporting results back on the PR:
+
+```markdown
+## Windows Smoke Test Result
+
+- PR/commit:
+- Windows version:
+- Node/npm:
+- Shell:
+- Git for Windows installed: yes/no
+- Git Bash `usr\bin` placed first on PATH for extraction test: yes/no
+
+### Checks
+
+- [ ] `npm ci`
+- [ ] root `npx tsc --noEmit`
+- [ ] focused ESLint
+- [ ] `npm test`
+- [ ] `cabinetai npm run build`
+- [ ] `cabinetai npx tsc --noEmit`
+
+### Smoke Tests
+
+- [ ] local `npx create-cabinet` package simulation
+- [ ] created directory is the slug (`cabinet-with-spaces`), no ENOENT chdir
+- [ ] fresh app tarball extraction
+- [ ] app URL loads
+- [ ] terminal opens at user home
+- [ ] reveal route opens File Explorer
+- [ ] root page route is not hijacked
+- [ ] provider CLI verification not regressed
+- [ ] packaged Windows app smoke, if applicable
+
+### Notes
+
+Paste any command output for failures here. Include screenshots only when they show a UI-specific failure.
+```

--- a/src/app/api/system/reveal/route.ts
+++ b/src/app/api/system/reveal/route.ts
@@ -1,7 +1,25 @@
 import { NextRequest, NextResponse } from "next/server";
-import { exec } from "child_process";
+import { spawn } from "child_process";
+import path from "path";
 import { resolveContentPath } from "@/lib/storage/path-utils";
 import { fileExists } from "@/lib/storage/fs-operations";
+
+// Reveal a file in the OS file manager, selecting it where the platform supports
+// it. Uses spawn() with an argv array (no shell) so filenames can't be interpreted
+// as shell syntax.
+function getRevealCommand(target: string): { command: string; args: string[] } {
+  switch (process.platform) {
+    case "darwin":
+      return { command: "open", args: ["-R", target] };
+    case "win32":
+      // explorer.exe wants `/select,<path>` as a single token; it also exits with a
+      // non-zero code even on success, so we never await/inspect its exit (issue #94 §7).
+      return { command: "explorer.exe", args: [`/select,${target}`] };
+    default:
+      // Linux/other: no portable "reveal & select", so open the containing folder.
+      return { command: "xdg-open", args: [path.dirname(target)] };
+  }
+}
 
 export async function POST(req: NextRequest) {
   try {
@@ -15,10 +33,12 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "File not found" }, { status: 404 });
     }
 
-    // macOS: reveal in Finder. On other platforms this is a no-op.
-    if (process.platform === "darwin") {
-      exec(`open -R "${resolved}"`);
-    }
+    const { command, args } = getRevealCommand(resolved);
+    // Detach so the file manager outlives this request; swallow spawn errors
+    // (e.g. xdg-open missing) rather than 500-ing a best-effort convenience action.
+    const child = spawn(command, args, { stdio: "ignore", detached: true });
+    child.on("error", () => {});
+    child.unref();
 
     return NextResponse.json({ ok: true });
   } catch (error) {

--- a/src/app/api/terminal/open/route.ts
+++ b/src/app/api/terminal/open/route.ts
@@ -1,14 +1,21 @@
 import { NextResponse } from "next/server";
 import { exec } from "child_process";
+import os from "os";
 
 export async function POST() {
-  const home = process.env.HOME || "~";
+  // os.homedir() resolves USERPROFILE on Windows; `process.env.HOME` is usually
+  // unset there, so the old `HOME || "~"` produced the literal "~" and `cd /d ~`
+  // failed (issue #94 §3).
+  const home = os.homedir();
 
   try {
     if (process.platform === "darwin") {
       exec(`open -a Terminal "${home}"`);
     } else if (process.platform === "win32") {
-      exec(`start cmd /K "cd /d ${home}"`);
+      // `start` is a cmd builtin (exec uses cmd.exe on Windows). The empty "" is the
+      // window title so `start` doesn't treat the path as one; the path is quoted to
+      // tolerate spaces.
+      exec(`start "" cmd /K cd /d "${home}"`);
     } else {
       // Linux: try common terminal emulators
       exec(

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -335,8 +335,12 @@ export function AppShell() {
     // home container: the bare home screen, or any content view scoped to the
     // data-dir root ("."). You're always inside a room, never the dir above
     // it. (settings/help/registry carry no cabinetPath, so are untouched.)
+    // A "page" scoped to the data-dir root is a file the user explicitly opened
+    // (e.g. `#/p/foo`), not the neutral home container — don't yank it into a room.
+    // (On Windows a leading-`\` path normalized to "." made this hijack visible: #103.)
     const onHomeContainer =
-      (section.type === "home" && !cp) || cp === ROOT_CABINET_PATH;
+      (section.type === "home" && !cp) ||
+      (cp === ROOT_CABINET_PATH && section.type !== "page");
     if (onHomeContainer) {
       setSection({ type: "cabinet", cabinetPath: landingRoom });
     }

--- a/src/lib/agents/nvm-path.ts
+++ b/src/lib/agents/nvm-path.ts
@@ -2,7 +2,9 @@ import path from "path";
 import fs from "fs";
 
 export function getNvmNodeBin(): string | null {
-  const nvmDir = process.env.NVM_DIR || path.join(process.env.HOME || "", ".nvm");
+  const nvmDir =
+    process.env.NVM_DIR ||
+    path.join(process.env.HOME || process.env.USERPROFILE || "", ".nvm");
   try {
     const defaultAlias = fs.readFileSync(path.join(nvmDir, "alias", "default"), "utf8").trim();
     const versionDirs = fs.readdirSync(path.join(nvmDir, "versions", "node"));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,7 @@
     "data-old*",
     "old-data",
     "cabinetai",
-    "cli"
+    "cli",
+    "mcps"
   ]
 }


### PR DESCRIPTION
## Summary

Follow-up to **#130** (merged), which fixed the **Electron/Next app** layer of Windows support but deliberately did **not** touch the **`cabinetai` CLI / `create-cabinet`** packages or a few server routes. This PR closes those remaining gaps — including the highest-impact one: a Windows user can't currently get *past the install step* via `npx`.

I audited all five open Windows issues against the post-#130 code and fixed everything verifiable without a Windows machine. Mapping below.

## What's fixed

| Fix | File | Issue |
|---|---|---|
| **Release extraction works on Windows** — use bundled bsdtar (`%SystemRoot%\System32\tar.exe`), drop GNU-only `--no-same-owner`, and avoid GNU `tar` (Git Bash/MSYS/WSL) misreading `C:\…` as an SSH `host:path`. Adds a real exit-status check so failures surface instead of a misleading "Empty release archive". | `cabinetai/src/lib/app-manager.ts` | #41 bug 1 · #94 §6 |
| **`npx create-cabinet` no longer crashes** — resolve cabinetai's real JS entry from its `package.json` `bin` and run it with `node`, instead of spawning the npm `.bin/cabinetai` shim (a POSIX **shell script** on Windows that Node parsed as JS → `SyntaxError`). | `cli/index.cjs` | #81 bug 1 |
| **"Open terminal" works** — `os.homedir()` (resolves `USERPROFILE` on Windows) instead of `HOME \|\| "~"`, which produced a literal `~` and broke `cd /d`. Path quoted for spaces. | `src/app/api/terminal/open/route.ts` | #94 §3 |
| **"Reveal in file manager" works cross-platform** — add `win32` (`explorer /select,`) and `linux` (`xdg-open`) branches, and switch `exec(string)` → `spawn(argv)` so filenames can't be interpreted as shell syntax (a hardening). | `src/app/api/system/reveal/route.ts` | #94 §7 |
| **nvm path resolves on Windows** — fall back to `USERPROFILE` when `HOME` is unset. | `src/lib/agents/nvm-path.ts` | #92 secondary |
| **Root-level page URLs aren't hijacked** — the rooms redirect no longer yanks an explicitly-opened root page (`type: "page"` scoped to `.`) into the default room. (Surfaced on Windows when a leading-`\` path normalized to `.`.) | `src/components/layout/app-shell.tsx` | #103 audit secondary |

## Issue status after this PR + #130

- **#103** — core backslash→500 fixed in #130; this PR adds the audit's secondary `app-shell` redirect fix. ✅ closeable
- **#92** — verify-route/adapters fixed in #130; this PR adds the `nvm-path` secondary. ✅ closeable
- **#94** — #130 fixed §1,2,4,5,8,9,10; this PR fixes §3,6,7. Remaining: none in scope (§10 needs the CI artifact below).
- **#81** — bug 2 (chdir) already refactored away; this PR fixes bug 1. ✅ closeable
- **#41** — bug 2 (postinstall) already cross-platform; this PR fixes bug 1. **bug 3 remains** (see below).

## Not in this PR (needs a real Windows runner)

- **Turbopack CSS worker crash (#41 bug 3, `0xc0000142`)** — environmental (long-path / native-dep). Not fixable/verifiable from macOS without risking a macOS/Linux regression; left for a Windows repro.
- **Packaged `.exe` smoke test (#94 §10)** — #130 added the Squirrel maker + `windows-latest` CI job but the actual installer has never been built/run. That CI job is the release gate.

## Verification

- `tsc --noEmit` clean (root + `cabinetai/`)
- `eslint` clean on all changed files
- **312/312 tests pass** (`npm test`)
- `node -c cli/index.cjs` clean
- Security-reviewed: no findings — the reveal-route change removes a shell-injection surface; all other changes pass user input only via argv arrays or trusted env.

⚠️ All fixes are platform-conditional and were validated on macOS (tsc/eslint/tests/security). The Windows code paths still warrant a smoke test on a real Windows 11 install before release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cross-platform file “reveal/select” support using OS-appropriate commands.
* **Bug Fixes**
  * Improved archive extraction by using platform-specific `tar` behavior and more reliable failure detection.
  * Enhanced CLI detection of the cabinetai executable and corrected the created project directory after initialization.
  * Fixed terminal launch home directory resolution on Windows and improved handling of paths with spaces.
  * Refined room redirect behavior to avoid incorrect root page snapping.
  * Improved NVM default path resolution when `HOME` is unset.
* **Documentation**
  * Added/updated Windows smoke-test runbook with end-to-end steps.
* **Chores**
  * Updated Electron release workflow to support dispatch without a tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->