### PR TITLE
fix(auth): PBKDF2 + per-install salt + login rate-limiting (closes #11)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,19 @@
-# Optional: set a password to protect the UI (leave empty for no auth)
+# Optional: set a password to protect the UI (leave empty for no auth).
+# The auth cookie is PBKDF2(password, per-install salt). Changing the password
+# (or salt/iterations) logs everyone out once.
 KB_PASSWORD=
+
+# Auth hardening (all optional):
+# CABINET_AUTH_SALT — per-install salt for the auth token. Auto-generated into
+#   .cabinet.env on first run; set it here only to pin a specific value.
+#   Changing or clearing it forces a one-time re-login.
+# CABINET_LOGIN_PBKDF2_ITERS — KDF cost (default 600000). Lower only for
+#   constrained hardware; values below ~300000 are discouraged.
+# Login rate limiting (per-process, in-memory):
+# CABINET_LOGIN_MAX_ATTEMPTS=10      # failed attempts per client before lockout
+# CABINET_LOGIN_WINDOW_MS=900000     # counting window (15 min)
+# CABINET_LOGIN_LOCKOUT_MS=900000    # lockout duration once tripped (15 min)
+# CABINET_LOGIN_GLOBAL_MAX=60        # global failed-attempt ceiling per window
 
 # Optional: domain for the app
 DOMAIN=localhost

--- a/README.md
+++ b/README.md
@@ -239,7 +239,10 @@ cp .env.example .env.local
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `KB_PASSWORD` | _(empty)_ | Password to protect the UI. Leave empty for no auth. |
+| `KB_PASSWORD` | _(empty)_ | Password to protect the UI. Leave empty for no auth. The auth cookie is PBKDF2(password, per-install salt) with login rate-limiting; changing the password logs everyone out once. |
+| `CABINET_AUTH_SALT` | _(auto)_ | Per-install auth salt, auto-generated into `.cabinet.env` on first run. Set only to pin a value; changing it forces a one-time re-login. |
+| `CABINET_LOGIN_PBKDF2_ITERS` | `600000` | PBKDF2 iteration count for the auth token. Lower only for constrained hardware. |
+| `CABINET_LOGIN_MAX_ATTEMPTS` / `_WINDOW_MS` / `_LOCKOUT_MS` / `CABINET_LOGIN_GLOBAL_MAX` | `10` / `900000` / `900000` / `60` | Login rate-limit tuning (per-client + global failed-attempt buckets). |
 | `DOMAIN` | `localhost` | Domain for the app. |
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -245,6 +245,15 @@ cp .env.example .env.local
 | `CABINET_LOGIN_MAX_ATTEMPTS` / `_WINDOW_MS` / `_LOCKOUT_MS` / `CABINET_LOGIN_GLOBAL_MAX` | `10` / `900000` / `900000` / `60` | Login rate-limit tuning (per-client + global failed-attempt buckets). |
 | `DOMAIN` | `localhost` | Domain for the app. |
 
+### Authentication
+
+Setting `KB_PASSWORD` turns on a single password gate for the whole UI/API
+(leave it empty for no auth). The session cookie is `PBKDF2-HMAC-SHA256` over a
+per-install salt that's auto-generated into `.cabinet.env` on first run, the
+login endpoint is rate-limited against brute force, and the gate verifies in
+constant time. Changing the password (or salt/iterations) logs everyone out
+once. Full details, threat model, and tuning: **[docs/AUTH.md](docs/AUTH.md)**.
+
 ## Commands
 
 ```bash

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -1,0 +1,146 @@
+# Authentication & access control
+
+Cabinet ships with a single, optional password gate for the whole UI/API. It is
+**off by default** (no login) and turns on the moment you set `KB_PASSWORD`.
+
+This document describes the auth model after the issue #11 hardening
+(PBKDF2 + per-install salt + login rate-limiting). For the user-facing env
+reference, see the table in the main [README](../README.md#configuration).
+
+---
+
+## TL;DR
+
+- Set `KB_PASSWORD` → the whole app requires login. Leave it empty → no auth.
+- The session cookie (`kb-auth`) is `PBKDF2-HMAC-SHA256(password, per-install salt)`,
+  not a fast plain hash.
+- A per-install random salt is generated once into `.cabinet.env`.
+- The login endpoint is rate-limited (per-client + a global ceiling) to stop
+  brute force.
+- Changing the password, salt, or iteration count logs everyone out once.
+
+## How it works
+
+### The gate
+
+`src/proxy.ts` is the Next.js **proxy** (the renamed-in-Next-16 middleware; it is
+auto-detected at `src/proxy.ts` and runs on the Node.js runtime). On every
+request, when auth is enabled, it requires a valid `kb-auth` cookie:
+
+- Allowed without a cookie: `/login`, `/api/auth/login`, `/api/auth/check`,
+  `/api/health*`, and Next static assets.
+- Missing/invalid cookie → API routes get `401`, page routes redirect to
+  `/login`.
+- Verification is **constant-time**, and the expected token is **memoized** per
+  process, so the gate stays O(1) per request (PBKDF2 runs once per process, not
+  per request).
+
+### The token
+
+The `kb-auth` cookie value is:
+
+```
+PBKDF2-HMAC-SHA256(password, salt, iterations)  →  256-bit, lowercase hex
+```
+
+- **Slow KDF (PBKDF2)** — default **600,000** iterations. This is the
+  defense-in-depth that makes *offline* password recovery from a leaked cookie
+  expensive.
+- **Per-install salt** — a random 32-byte value, distinct per deployment, so a
+  leaked cookie can't be attacked with precomputed/cross-install tables.
+- One shared module, `src/lib/auth/kb-auth.ts`, is the single source of truth
+  for the derivation; the gate, the login route, and the check route all use it
+  so they can never drift.
+
+Cookie attributes are unchanged: `HttpOnly`, `SameSite=Lax`, `Path=/`, 30-day
+`Max-Age`, and `Secure` in production unless `KB_ALLOW_HTTP=1`.
+
+### Login + rate limiting
+
+`POST /api/auth/login` (`src/app/api/auth/login/route.ts`):
+
+- Derives the candidate token with PBKDF2 and **constant-time compares** it to
+  the expected token — so each guess costs one PBKDF2 (there is no fast
+  plaintext comparison).
+- Is rate-limited (`src/lib/auth/login-rate-limit.ts`) with **two buckets**:
+  - a **global** failed-attempt bucket — the real, unspoofable guarantee, and
+  - a **best-effort per-client** bucket keyed on `X-Forwarded-For`. This is
+    additive friction only; forwarded headers are not trusted as a security
+    boundary on direct LAN/Tailscale access.
+- Over the limit → `429` + `Retry-After` (JSON) or a `303` to `/login?error=rate`
+  (native form post). Only **failed** attempts consume budget; a success resets
+  that client's bucket.
+
+The buckets live in memory in the Next.js process and reset on restart.
+
+## Configuration
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `KB_PASSWORD` | _(empty)_ | Enable auth by setting it. Empty = no auth. |
+| `CABINET_AUTH_SALT` | _(auto)_ | Per-install salt. Auto-generated into `.cabinet.env` on first run; set it only to pin a value. |
+| `CABINET_LOGIN_PBKDF2_ITERS` | `600000` | KDF cost. Lower only for constrained hardware; below ~300000 is discouraged. |
+| `CABINET_LOGIN_MAX_ATTEMPTS` | `10` | Failed attempts per client before lockout. |
+| `CABINET_LOGIN_WINDOW_MS` | `900000` | Counting window (15 min). |
+| `CABINET_LOGIN_LOCKOUT_MS` | `900000` | Lockout duration once tripped (15 min). |
+| `CABINET_LOGIN_GLOBAL_MAX` | `60` | Global failed-attempt ceiling per window. |
+| `KB_ALLOW_HTTP` | _(unset)_ | Set to `1` to drop the `Secure` cookie flag in production (e.g. plain-HTTP LAN). |
+
+### The per-install salt
+
+On first boot with this version, `src/instrumentation.ts` generates a random
+`CABINET_AUTH_SALT` and stores it in `.cabinet.env` (atomic write, `0600`,
+gitignored). It is read back into `process.env` on every boot. If generation
+ever fails, the code falls back to a legacy fixed salt so the gate, login, and
+check stay mutually consistent (just without per-install uniqueness).
+
+`.cabinet.env` is editable from **Settings → Integrations**, where the salt
+appears as a masked entry. Changing or clearing it forces a one-time re-login.
+
+## Upgrading / migration
+
+Switching from the old `SHA-256(password + "cabinet-salt")` scheme to PBKDF2
+changes the token value, so **all existing `kb-auth` cookies become invalid** —
+everyone (including you) re-logs-in once. The cookie name and attributes are
+unchanged; there is no data migration.
+
+## Threat model notes
+
+- **Online brute force** (the practical risk, especially now that Cabinet can be
+  reached over LAN / Tailscale / VPN) is stopped primarily by **rate limiting**.
+- **PBKDF2 + per-install salt** is defense-in-depth: it slows *offline* password
+  recovery if a cookie/verifier leaks. It does **not** revoke a leaked bearer
+  cookie — rotating the password (or salt) invalidates all cookies.
+- The single shared `KB_PASSWORD` model is unchanged: there are no per-user
+  accounts, and login is not CSRF-tokened (login CSRF is not a meaningful
+  escalation for a single shared secret).
+- **Scope:** the scheduler daemon's server-to-server calls are handled
+  separately (see PR #137) and must mint the cookie via this same
+  `src/lib/auth/kb-auth.ts` module.
+
+## Testing it
+
+Unit tests (run with `npm test`):
+
+- `src/lib/auth/kb-auth.test.ts` — PBKDF2 against an independent `node:crypto`
+  reference, iteration parsing, constant-time compare, memoization.
+- `src/lib/auth/login-rate-limit.test.ts` — lockout, success reset, global
+  bucket tripping when client keys rotate.
+- `test/proxy.test.ts`, `src/app/api/auth/login/route.test.ts` — gate behavior
+  and the login form/JSON flows (including the 429 / `?error=rate` paths).
+
+Manual end-to-end:
+
+```bash
+# Start with auth on (low thresholds make the lockout quick to observe).
+# Put these in .env, then `npm run dev:all`:
+#   KB_PASSWORD=your-test-password
+#   CABINET_LOGIN_MAX_ATTEMPTS=3
+#   CABINET_LOGIN_LOCKOUT_MS=15000
+```
+
+1. A fresh `CABINET_AUTH_SALT` appears in `.cabinet.env` (and persists across restarts).
+2. Visiting any page unauthenticated redirects to `/login`; `/api/*` returns `401`.
+3. The correct password logs in (sets the `kb-auth` cookie) and the gate passes.
+4. Several wrong passwords trip the lockout (`429` / `?error=rate` + `Retry-After`);
+   the correct password is refused while locked, then works again after the lockout window.

--- a/src/app/api/auth/check/route.ts
+++ b/src/app/api/auth/check/route.ts
@@ -1,26 +1,20 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
-
-const KB_PASSWORD = process.env.KB_PASSWORD || "";
-const AUTH_ENABLED = KB_PASSWORD.length > 0;
-
-async function hashToken(password: string): Promise<string> {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(password + "cabinet-salt");
-  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
-}
+import {
+  KB_AUTH_COOKIE,
+  expectedToken,
+  isAuthEnabled,
+  timingSafeEqualHex,
+} from "@/lib/auth/kb-auth";
 
 export async function GET() {
-  if (!AUTH_ENABLED) {
+  if (!isAuthEnabled()) {
     return NextResponse.json({ authenticated: true, authEnabled: false });
   }
 
   const cookieStore = await cookies();
-  const token = cookieStore.get("kb-auth")?.value;
-  const expected = await hashToken(KB_PASSWORD);
-  const authenticated = token === expected;
+  const token = cookieStore.get(KB_AUTH_COOKIE)?.value ?? "";
+  const authenticated = timingSafeEqualHex(token, await expectedToken());
 
   return NextResponse.json({ authenticated, authEnabled: true });
 }

--- a/src/app/api/auth/login/route.test.ts
+++ b/src/app/api/auth/login/route.test.ts
@@ -1,15 +1,23 @@
-import test, { before } from "node:test";
+import test, { before, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import { NextRequest } from "next/server";
+import { resetLoginRateLimit } from "@/lib/auth/login-rate-limit";
 
-// KB_PASSWORD is read at module load, so set it before importing the handler.
 type Route = typeof import("./route");
 let route: Route;
 
 before(async () => {
   process.env.KB_PASSWORD = "s3cret";
+  // Keep PBKDF2 cheap so the many derivations in these tests stay fast.
+  process.env.CABINET_LOGIN_PBKDF2_ITERS = "1";
+  // Small lockout threshold so the rate-limit test doesn't need many rounds.
+  process.env.CABINET_LOGIN_MAX_ATTEMPTS = "3";
+  process.env.CABINET_LOGIN_LOCKOUT_MS = "60000";
   route = await import("./route");
 });
+
+// Isolate rate-limit state (global + per-client buckets) between cases.
+beforeEach(() => resetLoginRateLimit());
 
 const URL = "http://127.0.0.1:4000/api/auth/login";
 
@@ -21,10 +29,10 @@ function formReq(password: string, headers: Record<string, string> = {}): NextRe
   });
 }
 
-function jsonReq(password: string): NextRequest {
+function jsonReq(password: string, headers: Record<string, string> = {}): NextRequest {
   return new NextRequest(URL, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", ...headers },
     body: JSON.stringify({ password }),
   });
 }
@@ -64,4 +72,40 @@ test("JSON login: correct → ok + cookie; wrong → 401", async () => {
 
   const bad = await route.POST(jsonReq("nope"));
   assert.equal(bad.status, 401);
+});
+
+test("JSON login: locks out after N failed attempts (429 + Retry-After)", async () => {
+  const xff = { "x-forwarded-for": "203.0.113.7" };
+  // MAX_ATTEMPTS=3 → first 3 wrong return 401, then the client is locked.
+  for (let i = 0; i < 3; i++) {
+    const res = await route.POST(jsonReq("nope", xff));
+    assert.equal(res.status, 401, `attempt ${i + 1} should be 401`);
+  }
+  const locked = await route.POST(jsonReq("nope", xff));
+  assert.equal(locked.status, 429);
+  assert.ok(Number(locked.headers.get("retry-after")) > 0, "Retry-After set");
+
+  // Even the CORRECT password is refused while locked out.
+  const lockedCorrect = await route.POST(jsonReq("s3cret", xff));
+  assert.equal(lockedCorrect.status, 429);
+});
+
+test("form login: over-limit → 303 /login?error=rate with Retry-After", async () => {
+  const xff = { "x-forwarded-for": "203.0.113.8" };
+  for (let i = 0; i < 3; i++) await route.POST(formReq("nope", xff));
+  const res = await route.POST(formReq("nope", xff));
+  assert.equal(res.status, 303);
+  assert.equal(res.headers.get("location"), "/login?error=rate");
+  assert.ok(Number(res.headers.get("retry-after")) > 0, "Retry-After set");
+});
+
+test("a successful login resets the client's failure budget", async () => {
+  const xff = { "x-forwarded-for": "203.0.113.9" };
+  await route.POST(jsonReq("nope", xff)); // 1 failure
+  await route.POST(jsonReq("nope", xff)); // 2 failures
+  const good = await route.POST(jsonReq("s3cret", xff));
+  assert.equal(good.status, 200, "correct password still allowed (under limit)");
+  // Budget reset → two more failures don't immediately lock.
+  const after = await route.POST(jsonReq("nope", xff));
+  assert.equal(after.status, 401, "counter reset after success, not locked");
 });

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,15 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
-
-const KB_PASSWORD = process.env.KB_PASSWORD || "";
-const AUTH_ENABLED = KB_PASSWORD.length > 0;
-
-async function hashToken(password: string): Promise<string> {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(password + "cabinet-salt");
-  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
-}
+import {
+  KB_AUTH_COOKIE,
+  deriveAuthToken,
+  expectedToken,
+  getAuthSalt,
+  isAuthEnabled,
+  timingSafeEqualHex,
+} from "@/lib/auth/kb-auth";
+import {
+  clientKeyFromForwardedFor,
+  getLoginRateLimitStatus,
+  recordFailedLogin,
+  resetLoginFailures,
+} from "@/lib/auth/login-rate-limit";
 
 // Native form posts expect a redirect. Emit a RELATIVE Location: the browser
 // resolves it against the address-bar origin, so it lands back on whatever host
@@ -21,11 +24,39 @@ function seeOther(path: string): NextResponse {
   return new NextResponse(null, { status: 303, headers: { Location: path } });
 }
 
+function tooManyAttempts(isForm: boolean, retryAfterSec: number): NextResponse {
+  if (isForm) {
+    const res = seeOther("/login?error=rate");
+    res.headers.set("Retry-After", String(retryAfterSec));
+    return res;
+  }
+  return NextResponse.json(
+    { error: "Too many attempts", retryAfter: retryAfterSec },
+    { status: 429, headers: { "Retry-After": String(retryAfterSec) } },
+  );
+}
+
 export async function POST(req: NextRequest) {
   // Native form posts arrive with Content-Type: application/x-www-form-urlencoded
   // and expect a redirect; JS fetch posts JSON and expects a JSON reply.
   const contentType = req.headers.get("content-type") || "";
   const isForm = contentType.includes("application/x-www-form-urlencoded");
+
+  // Auth disabled — accept without parsing the body or deriving anything.
+  if (!isAuthEnabled()) {
+    return isForm ? seeOther("/") : NextResponse.json({ ok: true });
+  }
+
+  // Best-effort per-client key from the first X-Forwarded-For hop (spoofable on
+  // direct access — the global bucket inside the limiter is the real guarantee).
+  const clientKey = clientKeyFromForwardedFor(req.headers.get("x-forwarded-for"));
+
+  // Already locked out → reject cheaply, before parsing the body or running
+  // PBKDF2, so a flood of over-limit requests stays inexpensive.
+  const pre = getLoginRateLimitStatus(clientKey);
+  if (pre.limited) {
+    return tooManyAttempts(isForm, pre.retryAfterSec);
+  }
 
   let password = "";
   if (isForm) {
@@ -36,23 +67,26 @@ export async function POST(req: NextRequest) {
     password = body.password || "";
   }
 
-  if (!AUTH_ENABLED) {
-    return isForm ? seeOther("/") : NextResponse.json({ ok: true });
-  }
+  // Derive the candidate token (slow PBKDF2 — intentional per-attempt cost) and
+  // compare constant-time against the expected (memoized) token. Replaces the
+  // old plaintext `password !== KB_PASSWORD`, so each guess is expensive and the
+  // comparison leaks no timing about how many chars matched.
+  const candidate = await deriveAuthToken(password, getAuthSalt());
+  const ok = timingSafeEqualHex(candidate, await expectedToken());
 
-  if (password !== KB_PASSWORD) {
+  if (!ok) {
+    recordFailedLogin(clientKey);
     return isForm
       ? seeOther("/login?error=1")
       : NextResponse.json({ error: "Invalid password" }, { status: 401 });
   }
 
-  // 303 + Set-Cookie + Location → the browser commits the cookie and follows
-  // the redirect to "/" with it attached (no client JS needed; sidesteps the
-  // mobile-Safari race between cookie commit and client navigation). The cookie
-  // is set on the response itself so it rides whichever response shape we send.
-  const token = await hashToken(password);
+  // Success: clear this client's failure budget, then mint the cookie (reuse the
+  // derived token) and 303 to "/" (form) so the browser commits the cookie
+  // before navigating.
+  resetLoginFailures(clientKey);
   const res = isForm ? seeOther("/") : NextResponse.json({ ok: true });
-  res.cookies.set("kb-auth", token, {
+  res.cookies.set(KB_AUTH_COOKIE, candidate, {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production" && process.env.KB_ALLOW_HTTP !== "1",
     sameSite: "lax",

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,16 +1,21 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useSearchParams } from "next/navigation";
 
+function errorFromParam(code: string | null): string {
+  if (code === "1") return "Wrong password";
+  if (code === "rate") return "Too many attempts. Try again later.";
+  return "";
+}
+
 export default function LoginPage() {
-  const [password, setPassword] = useState("");
-  const [error, setError] = useState("");
-  const [loading, setLoading] = useState(false);
   const searchParams = useSearchParams();
-  useEffect(() => {
-    if (searchParams.get("error") === "1") setError("Wrong password");
-  }, [searchParams]);
+  const [password, setPassword] = useState("");
+  // Native form posts redirect to /login?error=… as a full navigation, so this
+  // initializer runs fresh on each mount; the JS submit handler overrides below.
+  const [error, setError] = useState(() => errorFromParam(searchParams.get("error")));
+  const [loading, setLoading] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -36,6 +41,8 @@ export default function LoginPage() {
         // and bounces back to /login).
         window.location.assign("/");
         return;
+      } else if (res.status === 429) {
+        setError("Too many attempts. Try again later.");
       } else {
         setError("Wrong password");
       }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -25,6 +25,16 @@ export async function register(): Promise<void> {
   } catch (err) {
     console.error("instrumentation: loadCabinetEnv failed", err);
   }
+  // Generate a per-install auth salt on first run (persisted to .cabinet.env)
+  // so the kb-auth token is PBKDF2(password, per-install-salt). Best-effort:
+  // on failure the auth path falls back to the legacy fixed salt. Must run
+  // after loadCabinetEnv so an existing salt isn't regenerated.
+  try {
+    const { ensureAuthSalt } = await import("./lib/auth/kb-auth-salt.node");
+    ensureAuthSalt();
+  } catch (err) {
+    console.error("instrumentation: ensureAuthSalt failed", err);
+  }
   try {
     const { ensureGlobalAgents } = await import("./lib/agents/library-manager");
     await ensureGlobalAgents();

--- a/src/lib/auth/kb-auth-salt.node.ts
+++ b/src/lib/auth/kb-auth-salt.node.ts
@@ -1,0 +1,21 @@
+/**
+ * Node-only: ensure a per-install auth salt exists.
+ *
+ * On first run (no CABINET_AUTH_SALT yet) this generates a random 32-byte hex
+ * salt and persists it to `.cabinet.env` via `upsertCabinetEnv` (atomic 0600
+ * write + gitignore guard + live `process.env` update). Idempotent: a non-empty
+ * value is left untouched. Best-effort — on any failure the auth path falls back
+ * to the legacy fixed salt (see getAuthSalt), so a write error never blocks boot.
+ *
+ * This file imports node:crypto + the filesystem-backed env store, so it must
+ * NOT be imported from the portable `kb-auth.ts`. Call it once at server boot
+ * (src/instrumentation.ts), after `.cabinet.env` is loaded into process.env.
+ */
+import crypto from "node:crypto";
+import { upsertCabinetEnv } from "@/lib/runtime/cabinet-env";
+
+export function ensureAuthSalt(): void {
+  if (process.env.CABINET_AUTH_SALT?.trim()) return;
+  const salt = crypto.randomBytes(32).toString("hex");
+  upsertCabinetEnv("CABINET_AUTH_SALT", salt);
+}

--- a/src/lib/auth/kb-auth.test.ts
+++ b/src/lib/auth/kb-auth.test.ts
@@ -1,0 +1,119 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { pbkdf2Sync } from "node:crypto";
+import {
+  deriveAuthToken,
+  expectedToken,
+  getAuthSalt,
+  getKbPassword,
+  getPbkdf2Iterations,
+  isAuthEnabled,
+  timingSafeEqualHex,
+} from "./kb-auth";
+
+// Independent reference: node's pbkdf2Sync must agree with the module's
+// Web-Crypto derivation, byte-for-byte. Catches any drift in algorithm, salt
+// encoding, output length, or hex formatting.
+function ref(pw: string, salt: string, iters: number): string {
+  return pbkdf2Sync(
+    Buffer.from(pw, "utf8"),
+    Buffer.from(salt, "utf8"),
+    iters,
+    32,
+    "sha256",
+  ).toString("hex");
+}
+
+test("deriveAuthToken == PBKDF2-HMAC-SHA256 reference (algo/encoding/length)", async () => {
+  for (const [pw, salt, iters] of [
+    ["password", "cabinet-salt", 1],
+    ["hunter2", "abc123", 7],
+    ["", "s", 3],
+    ["🔑-unicode", "🧂", 4],
+  ] as const) {
+    const got = await deriveAuthToken(pw, salt, iters);
+    assert.equal(got, ref(pw, salt, iters), `${pw}/${salt}/${iters}`);
+    assert.equal(got.length, 64, "256-bit token = 64 hex chars");
+  }
+});
+
+test("getPbkdf2Iterations: default, override, invalid", () => {
+  const prev = process.env.CABINET_LOGIN_PBKDF2_ITERS;
+  try {
+    delete process.env.CABINET_LOGIN_PBKDF2_ITERS;
+    assert.equal(getPbkdf2Iterations(), 600_000);
+    process.env.CABINET_LOGIN_PBKDF2_ITERS = "5";
+    assert.equal(getPbkdf2Iterations(), 5);
+    for (const bad of ["0", "-3", "abc", ""]) {
+      process.env.CABINET_LOGIN_PBKDF2_ITERS = bad;
+      assert.equal(getPbkdf2Iterations(), 600_000, `bad: ${JSON.stringify(bad)}`);
+    }
+  } finally {
+    if (prev === undefined) delete process.env.CABINET_LOGIN_PBKDF2_ITERS;
+    else process.env.CABINET_LOGIN_PBKDF2_ITERS = prev;
+  }
+});
+
+test("timingSafeEqualHex: equal, off-by-one, length mismatch", () => {
+  const a = "a".repeat(64);
+  assert.equal(timingSafeEqualHex(a, a), true);
+  assert.equal(timingSafeEqualHex(a, "a".repeat(63) + "b"), false);
+  assert.equal(timingSafeEqualHex(a, "a".repeat(63)), false);
+  assert.equal(timingSafeEqualHex("", ""), true);
+});
+
+test("getAuthSalt: legacy fallback + trim", () => {
+  const prev = process.env.CABINET_AUTH_SALT;
+  try {
+    delete process.env.CABINET_AUTH_SALT;
+    assert.equal(getAuthSalt(), "cabinet-salt");
+    process.env.CABINET_AUTH_SALT = "  deadbeef  ";
+    assert.equal(getAuthSalt(), "deadbeef");
+  } finally {
+    if (prev === undefined) delete process.env.CABINET_AUTH_SALT;
+    else process.env.CABINET_AUTH_SALT = prev;
+  }
+});
+
+test("isAuthEnabled / getKbPassword read env at call time", () => {
+  const prev = process.env.KB_PASSWORD;
+  try {
+    delete process.env.KB_PASSWORD;
+    assert.equal(isAuthEnabled(), false);
+    process.env.KB_PASSWORD = "x";
+    assert.equal(isAuthEnabled(), true);
+    assert.equal(getKbPassword(), "x");
+  } finally {
+    if (prev === undefined) delete process.env.KB_PASSWORD;
+    else process.env.KB_PASSWORD = prev;
+  }
+});
+
+test("expectedToken memoizes and re-keys when env changes", async () => {
+  const prev = {
+    pw: process.env.KB_PASSWORD,
+    it: process.env.CABINET_LOGIN_PBKDF2_ITERS,
+    salt: process.env.CABINET_AUTH_SALT,
+  };
+  try {
+    process.env.CABINET_LOGIN_PBKDF2_ITERS = "2";
+    delete process.env.CABINET_AUTH_SALT;
+    process.env.KB_PASSWORD = "alpha";
+    const t1 = await expectedToken();
+    assert.equal(t1, await expectedToken(), "stable across calls");
+    assert.equal(t1, await deriveAuthToken("alpha", "cabinet-salt", 2));
+    process.env.KB_PASSWORD = "beta";
+    const t2 = await expectedToken();
+    assert.notEqual(t2, t1, "re-keys when the password changes");
+    assert.equal(t2, await deriveAuthToken("beta", "cabinet-salt", 2));
+  } finally {
+    for (const [k, v] of [
+      ["KB_PASSWORD", prev.pw],
+      ["CABINET_LOGIN_PBKDF2_ITERS", prev.it],
+      ["CABINET_AUTH_SALT", prev.salt],
+    ] as const) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+});

--- a/src/lib/auth/kb-auth.ts
+++ b/src/lib/auth/kb-auth.ts
@@ -1,0 +1,132 @@
+/**
+ * Shared KB_PASSWORD auth primitives -- the single source of truth for the
+ * `kb-auth` cookie value, used by the gate (src/proxy.ts), the login route
+ * (mint), and the check route (status). Keeping the derivation in one module
+ * stops the three from drifting on algorithm / salt / iterations; any drift
+ * means the cookie a logged-in browser holds stops matching what the gate
+ * expects, i.e. silent 401s.
+ *
+ * Web Crypto + guarded env reads only -- NO node-only imports (`node:crypto`,
+ * `fs`, `path`, ...) so the module stays portable and importable from any
+ * runtime/test. The Node-only salt *generation* lives in `kb-auth-salt.node.ts`.
+ */
+
+/** Cookie name checked by the gate and set on login. */
+export const KB_AUTH_COOKIE = "kb-auth";
+
+/** Legacy fixed salt. Used only as a fallback when CABINET_AUTH_SALT is unset,
+ *  so all three consumers stay self-consistent even if salt generation failed. */
+const LEGACY_SALT = "cabinet-salt";
+
+/** Default PBKDF2 iterations -- OWASP 2023 floor for PBKDF2-HMAC-SHA256.
+ *  Tunable via CABINET_LOGIN_PBKDF2_ITERS; values below ~300k are for emergency
+ *  low-power hardware only. The value is baked into the token, so changing it
+ *  invalidates existing cookies (one-time re-login). */
+const DEFAULT_PBKDF2_ITERATIONS = 600_000;
+
+/** Read an env var without a hard dependency on the Node `process` global, so
+ *  this module never throws if it is ever evaluated outside Node. */
+function readEnv(name: string): string | undefined {
+  const env = (
+    globalThis as typeof globalThis & {
+      process?: { env?: Record<string, string | undefined> };
+    }
+  ).process?.env;
+  return env?.[name];
+}
+
+/** The configured password, read at CALL time (never cached at module load) so
+ *  Settings-driven env changes and tests that mutate process.env are honored. */
+export function getKbPassword(): string {
+  return readEnv("KB_PASSWORD") ?? "";
+}
+
+/** Auth is enabled exactly when a non-empty KB_PASSWORD is set. */
+export function isAuthEnabled(): boolean {
+  return getKbPassword().length > 0;
+}
+
+/** Per-install salt (random hex, persisted to .cabinet.env) or the legacy
+ *  fallback. Read at call time. */
+export function getAuthSalt(): string {
+  return readEnv("CABINET_AUTH_SALT")?.trim() || LEGACY_SALT;
+}
+
+/** PBKDF2 iteration count: a finite positive override, else the default. */
+export function getPbkdf2Iterations(): number {
+  const n = Number.parseInt(readEnv("CABINET_LOGIN_PBKDF2_ITERS") ?? "", 10);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_PBKDF2_ITERATIONS;
+}
+
+const HEX_BYTE = Array.from({ length: 256 }, (_, b) =>
+  b.toString(16).padStart(2, "0"),
+);
+function toHex(bytes: Uint8Array): string {
+  let out = "";
+  for (const b of bytes) out += HEX_BYTE[b];
+  return out;
+}
+
+/**
+ * PBKDF2-HMAC-SHA256(password, salt) -> 256-bit token as lowercase hex.
+ * `salt` is hashed as its UTF-8 bytes (per-install random hex, or the legacy
+ * fixed salt string). Slow by design: each call costs `iterations` of PBKDF2.
+ */
+export async function deriveAuthToken(
+  password: string,
+  salt: string,
+  iterations: number = getPbkdf2Iterations(),
+): Promise<string> {
+  const enc = new TextEncoder();
+  const keyMaterial = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(password),
+    "PBKDF2",
+    false,
+    ["deriveBits"],
+  );
+  const bits = await crypto.subtle.deriveBits(
+    { name: "PBKDF2", hash: "SHA-256", salt: enc.encode(salt), iterations },
+    keyMaterial,
+    256,
+  );
+  return toHex(new Uint8Array(bits));
+}
+
+/**
+ * The token a valid `kb-auth` cookie must equal. Memoized per process, keyed on
+ * (iterations, salt, password), so:
+ *   - the GATE pays PBKDF2 once per process, not per request (O(1) verify), and
+ *   - a password/salt/iteration change (restart, or env mutation in tests)
+ *     recomputes instead of returning a stale value.
+ */
+let memo: { key: string; promise: Promise<string> } | null = null;
+export function expectedToken(): Promise<string> {
+  const password = getKbPassword();
+  const salt = getAuthSalt();
+  const iterations = getPbkdf2Iterations();
+  const key = JSON.stringify([iterations, salt, password]);
+  if (memo && memo.key === key) return memo.promise;
+  const promise = deriveAuthToken(password, salt, iterations).catch((err) => {
+    // Don't cache a rejection -- let the next call retry.
+    if (memo && memo.key === key) memo = null;
+    throw err;
+  });
+  memo = { key, promise };
+  return promise;
+}
+
+/**
+ * Constant-time comparison of two hex strings. Pure JS (keeps this module
+ * node-free; `node:crypto.timingSafeEqual` would not). Returns false on length
+ * mismatch; otherwise XOR-accumulates over the full length without an
+ * early-out, so timing does not reveal the matching prefix length.
+ */
+export function timingSafeEqualHex(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}

--- a/src/lib/auth/login-rate-limit.test.ts
+++ b/src/lib/auth/login-rate-limit.test.ts
@@ -1,0 +1,52 @@
+import test, { beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  clientKeyFromForwardedFor,
+  getLoginRateLimitStatus,
+  recordFailedLogin,
+  resetLoginFailures,
+  resetLoginRateLimit,
+} from "./login-rate-limit";
+
+beforeEach(() => {
+  resetLoginRateLimit();
+  process.env.CABINET_LOGIN_MAX_ATTEMPTS = "3";
+  process.env.CABINET_LOGIN_GLOBAL_MAX = "100";
+  process.env.CABINET_LOGIN_WINDOW_MS = "60000";
+  process.env.CABINET_LOGIN_LOCKOUT_MS = "60000";
+});
+
+test("clientKeyFromForwardedFor: first hop, trimmed, or 'unknown'", () => {
+  assert.equal(clientKeyFromForwardedFor("1.2.3.4, 5.6.7.8"), "1.2.3.4");
+  assert.equal(clientKeyFromForwardedFor("  9.9.9.9 "), "9.9.9.9");
+  assert.equal(clientKeyFromForwardedFor(null), "unknown");
+  assert.equal(clientKeyFromForwardedFor(""), "unknown");
+});
+
+test("locks a client after MAX failed attempts", () => {
+  const k = "client-a";
+  assert.equal(getLoginRateLimitStatus(k).limited, false);
+  for (let i = 0; i < 3; i++) recordFailedLogin(k);
+  const s = getLoginRateLimitStatus(k);
+  assert.equal(s.limited, true);
+  assert.ok(s.retryAfterSec > 0, "Retry-After is positive when locked");
+});
+
+test("a success reset clears the client's failure budget", () => {
+  const k = "client-b";
+  recordFailedLogin(k);
+  recordFailedLogin(k); // 2 < 3 → not locked
+  assert.equal(getLoginRateLimitStatus(k).limited, false);
+  resetLoginFailures(k);
+  recordFailedLogin(k);
+  recordFailedLogin(k); // 2 again → still under the limit
+  assert.equal(getLoginRateLimitStatus(k).limited, false, "counter rewound on reset");
+});
+
+test("global bucket trips even when client keys rotate (spoof-resistant)", () => {
+  process.env.CABINET_LOGIN_GLOBAL_MAX = "5";
+  process.env.CABINET_LOGIN_MAX_ATTEMPTS = "1000"; // per-client never locks here
+  for (let i = 0; i < 5; i++) recordFailedLogin(`rotating-${i}`);
+  // A brand-new client key is still limited because the global bucket is locked.
+  assert.equal(getLoginRateLimitStatus("fresh-client").limited, true);
+});

--- a/src/lib/auth/login-rate-limit.ts
+++ b/src/lib/auth/login-rate-limit.ts
@@ -1,0 +1,127 @@
+/**
+ * In-memory, per-process login rate limiting for POST /api/auth/login.
+ *
+ * Two buckets, with honest trust boundaries:
+ *   - GLOBAL failed-attempt bucket — the real anti-brute-force guarantee. It is
+ *     unspoofable (not derived from any request-controlled value), so it holds
+ *     even when an attacker rotates/forges client identifiers.
+ *   - per-CLIENT bucket keyed on the first `x-forwarded-for` hop (or "unknown").
+ *     Best-effort friction only: Cabinet can't prove forwarded headers are
+ *     trustworthy on direct LAN/Tailscale access, so this must never be treated
+ *     as spoof-proof. It exists so one noisy client doesn't consume the whole
+ *     global budget, and to give that client clearer feedback.
+ *
+ * A request is limited if EITHER bucket is locked. Only FAILED attempts consume
+ * budget; a successful login resets that client's bucket (the global budget
+ * expires on its own window). State is per-process and resets on restart —
+ * acceptable because the login route only runs in the Next.js process.
+ *
+ * Tunable via env (all positive integers): CABINET_LOGIN_WINDOW_MS,
+ * CABINET_LOGIN_MAX_ATTEMPTS, CABINET_LOGIN_LOCKOUT_MS, CABINET_LOGIN_GLOBAL_MAX.
+ */
+
+function readIntEnv(name: string, fallback: number): number {
+  const env = (
+    globalThis as typeof globalThis & {
+      process?: { env?: Record<string, string | undefined> };
+    }
+  ).process?.env;
+  const n = Number.parseInt(env?.[name] ?? "", 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+const windowMs = () => readIntEnv("CABINET_LOGIN_WINDOW_MS", 15 * 60_000);
+const maxAttempts = () => readIntEnv("CABINET_LOGIN_MAX_ATTEMPTS", 10);
+const lockoutMs = () => readIntEnv("CABINET_LOGIN_LOCKOUT_MS", 15 * 60_000);
+const globalMax = () => readIntEnv("CABINET_LOGIN_GLOBAL_MAX", 60);
+
+const GLOBAL_KEY = "__global__";
+
+interface Bucket {
+  /** Failed attempts in the current window. */
+  count: number;
+  /** When the counting window resets (ms epoch). */
+  windowResetAt: number;
+  /** Locked until this time (ms epoch); 0 = not locked. */
+  lockedUntil: number;
+}
+
+const buckets = new Map<string, Bucket>();
+
+export interface RateLimitStatus {
+  limited: boolean;
+  retryAfterSec: number;
+}
+
+/** Derive a best-effort client key from the X-Forwarded-For header. NOT a
+ *  security boundary (the header is spoofable on direct access) — see module doc. */
+export function clientKeyFromForwardedFor(xff: string | null | undefined): string {
+  const first = xff?.split(",")[0]?.trim();
+  return first ? first : "unknown";
+}
+
+function getBucket(key: string, now: number): Bucket {
+  let b = buckets.get(key);
+  if (!b) {
+    b = { count: 0, windowResetAt: now + windowMs(), lockedUntil: 0 };
+    buckets.set(key, b);
+  }
+  // Reset the counting window once it has elapsed and the bucket isn't locked.
+  if (now > b.windowResetAt && now >= b.lockedUntil) {
+    b.count = 0;
+    b.windowResetAt = now + windowMs();
+  }
+  return b;
+}
+
+function retryAfter(b: Bucket, now: number): number {
+  return b.lockedUntil > now ? Math.ceil((b.lockedUntil - now) / 1000) : 0;
+}
+
+/** Drop fully-expired per-client buckets to bound memory. Cheap; the map is tiny. */
+function prune(now: number): void {
+  for (const [key, b] of buckets) {
+    if (key === GLOBAL_KEY) continue;
+    if (now > b.windowResetAt && now >= b.lockedUntil) buckets.delete(key);
+  }
+}
+
+function combined(clientKey: string, now: number): RateLimitStatus {
+  const sec = Math.max(
+    retryAfter(getBucket(GLOBAL_KEY, now), now),
+    retryAfter(getBucket(clientKey, now), now),
+  );
+  return { limited: sec > 0, retryAfterSec: sec };
+}
+
+/** Read-only pre-check: is this client currently locked out? */
+export function getLoginRateLimitStatus(clientKey: string): RateLimitStatus {
+  return combined(clientKey, Date.now());
+}
+
+/** Record one failed attempt against the global + client buckets and return the
+ *  resulting status (so the caller can 429 immediately when this trips the lock). */
+export function recordFailedLogin(clientKey: string): RateLimitStatus {
+  const now = Date.now();
+  for (const [key, max] of [
+    [GLOBAL_KEY, globalMax()] as const,
+    [clientKey, maxAttempts()] as const,
+  ]) {
+    const b = getBucket(key, now);
+    b.count += 1;
+    if (b.count >= max) b.lockedUntil = now + lockoutMs();
+  }
+  prune(now);
+  return combined(clientKey, now);
+}
+
+/** Clear a client's failed-attempt bucket after an allowed successful login.
+ *  Does NOT touch the global bucket (which expires on its own window). */
+export function resetLoginFailures(clientKey: string): void {
+  buckets.delete(clientKey);
+}
+
+/** Test/admin helper: wipe all rate-limit state. */
+export function resetLoginRateLimit(): void {
+  buckets.clear();
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,18 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
-
-async function hashToken(password: string): Promise<string> {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(password + "cabinet-salt");
-  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
-}
+import {
+  KB_AUTH_COOKIE,
+  expectedToken,
+  isAuthEnabled,
+  timingSafeEqualHex,
+} from "@/lib/auth/kb-auth";
 
 export async function proxy(req: NextRequest) {
-  const password = process.env.KB_PASSWORD || "";
-
   // Auth disabled — no password set
-  if (!password) {
+  if (!isAuthEnabled()) {
     return NextResponse.next();
   }
 
@@ -28,11 +24,12 @@ export async function proxy(req: NextRequest) {
     return NextResponse.next();
   }
 
-  // Check auth cookie
-  const token = req.cookies.get("kb-auth")?.value;
-  const expected = await hashToken(password);
+  // Check auth cookie (constant-time; expected token is memoized so this is
+  // O(1) per request — PBKDF2 runs once per process, not per request).
+  const token = req.cookies.get(KB_AUTH_COOKIE)?.value ?? "";
+  const expected = await expectedToken();
 
-  if (token !== expected) {
+  if (!timingSafeEqualHex(token, expected)) {
     // API routes return 401
     if (pathname.startsWith("/api/")) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -2,6 +2,10 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { NextRequest } from "next/server";
 import { proxy } from "@/proxy";
+import { deriveAuthToken, getAuthSalt } from "@/lib/auth/kb-auth";
+
+// Keep PBKDF2 cheap for tests — the shared module reads this at call time.
+process.env.CABINET_LOGIN_PBKDF2_ITERS = "1";
 
 function makeReq(pathname: string, cookies: Record<string, string> = {}) {
   const url = new URL(pathname, "http://localhost:4000");
@@ -11,15 +15,6 @@ function makeReq(pathname: string, cookies: Record<string, string> = {}) {
   return new NextRequest(url, {
     headers: cookieHeader ? { cookie: cookieHeader } : undefined,
   });
-}
-
-async function hashToken(password: string): Promise<string> {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(password + "cabinet-salt");
-  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
-  return Array.from(new Uint8Array(hashBuffer))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
 }
 
 test("proxy passes through every path when KB_PASSWORD is unset", async () => {
@@ -86,7 +81,7 @@ test("proxy admits authenticated requests when locked", async () => {
   const prev = process.env.KB_PASSWORD;
   process.env.KB_PASSWORD = "secret";
   try {
-    const token = await hashToken("secret");
+    const token = await deriveAuthToken("secret", getAuthSalt());
     const res = await proxy(makeReq("/some-page", { "kb-auth": token }));
     assert.equal(res.status, 200);
   } finally {


### PR DESCRIPTION
Closes #11.

## Problem
The `kb-auth` cookie was `SHA-256(password + "cabinet-salt")` — a **fast** hash with a **hardcoded, repo-visible salt**, **deterministic / never rotated**, and the login endpoint had **no rate limiting**. PR #112 (LAN/Tailscale/VPN/mobile access) exposed that endpoint to whole networks, making online brute-force practical.

## Fix (keeps the simple derived-token model)
- **One shared module** `src/lib/auth/kb-auth.ts` (Web-Crypto only, no node imports): **PBKDF2-HMAC-SHA256** (default **600k** iters, env-tunable) over a **per-install salt**; `expectedToken()` **memoized** per `(iterations, salt, password)` so the gate stays **O(1) per request** (PBKDF2 runs once per process); pure-JS **constant-time** `timingSafeEqualHex`; env read at **call time** (no stale module-load constants).
- **Per-install salt** auto-generated on first boot into `.cabinet.env` (`kb-auth-salt.node.ts` → `ensureAuthSalt()` in `instrumentation.ts`); legacy `"cabinet-salt"` fallback keeps all consumers consistent if generation ever fails.
- **Login rate-limiting** (`login-rate-limit.ts`): an always-enforced **global** failed-attempt bucket (the real guarantee) + a best-effort **per-client** bucket from `X-Forwarded-For` (additive friction, *not* treated as spoof-proof). Over-limit → **429 + `Retry-After`** (JSON) / **303 `?error=rate`** (form). Login now **derives + constant-time compares** (replacing plaintext `!==`), so each guess costs one PBKDF2.
- **De-dupe**: `proxy.ts` (gate), `login`, and `check` all use the shared module — no more 3 drifting copies.
- Login page surfaces a "too many attempts" message; initial error derived from the URL via a lazy `useState` initializer (no set-state-in-effect).

## Scope / coordination
Daemon server-to-server auth (open PR #137) is **intentionally out of scope**; #137 should adopt this module's `deriveAuthToken`/`expectedToken` rather than re-deriving SHA-256, or its scheduled jobs will 401 under the new scheme. Agree on export names before the second of the two merges.

## Migration
SHA-256 → PBKDF2 changes the token value → **existing `kb-auth` cookies become invalid → one-time re-login** for everyone (incl. the operator). Cookie name + flags (`httpOnly`, `secure`+`KB_ALLOW_HTTP`, `sameSite:lax`, 30d) unchanged. No DB/file migration beyond one new `.cabinet.env` key.

## Tests
- `kb-auth`: PBKDF2 vs an **independent `node:crypto` reference**, iteration parsing, constant-time compare, `expectedToken` memo/re-key.
- `login-rate-limit`: lockout-after-N, success resets the client bucket, **global bucket trips even when client keys rotate**.
- Updated `proxy` + login route tests (mint via `deriveAuthToken`; 429/`?error=rate` + `Retry-After`; spoofed-host still no open redirect).
- Full suite **325/325**; `tsc` + eslint clean. (Co-located `src/**/*.test.ts` run in CI via the widened glob from #136.)

## Remaining manual check (opt-in; not done here)
Live e2e requires setting `KB_PASSWORD` and restarting the dev server (which locks the instance + forces re-login), so it's left for the maintainer: confirm `.cabinet.env` gets a fresh `CABINET_AUTH_SALT` once; correct login sets the cookie + gate passes; ~11 rapid wrong attempts → lockout then recovery; an old SHA-256 cookie is rejected once.

Tunables documented in `.env.example` / `README.md`: `CABINET_AUTH_SALT`, `CABINET_LOGIN_PBKDF2_ITERS`, `CABINET_LOGIN_MAX_ATTEMPTS` / `_WINDOW_MS` / `_LOCKOUT_MS` / `CABINET_LOGIN_GLOBAL_MAX`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable login rate limiting with per-client and global attempt thresholds, plus lockout duration and `Retry-After` handling for over-limit requests.

* **Documentation**
  * Updated `.env.example` and README with new authentication hardening options, including per-install auth salt (`CABINET_AUTH_SALT`) and PBKDF2 iteration cost (`CABINET_LOGIN_PBKDF2_ITERS`), along with expanded login/lockout behavior details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->