### PR TITLE
fix(daemon): authenticate scheduler triggers against the KB_PASSWORD gate

### DIFF
--- a/server/cabinet-daemon.ts
+++ b/server/cabinet-daemon.ts
@@ -72,6 +72,7 @@ import {
   getTokenFromAuthorizationHeader,
   isDaemonTokenValid,
 } from "../src/lib/agents/daemon-auth";
+import { authCookieHeader } from "../src/lib/auth/kb-auth";
 import {
   normalizeJobConfig,
   normalizeJobId,
@@ -1195,10 +1196,50 @@ const scheduledJobs = new Map<string, ReturnType<typeof cron.schedule>>();
 const scheduledHeartbeats = new Map<string, ReturnType<typeof cron.schedule>>();
 let scheduleReloadTimer: NodeJS.Timeout | null = null;
 
+// The app gates every /api/* route behind KB_PASSWORD (src/proxy.ts). Next
+// auto-loads `.env` so the app sees the password, but the daemon does not -- and
+// the production `start:daemon` path bypasses scripts/dev-daemon.mjs (which
+// loads it in dev). So if KB_PASSWORD isn't already in the environment, read it
+// from `.env` in the working dir (the same file the app reads) into
+// process.env. From there the shared kb-auth module is the single source of
+// truth for deriving the cookie; the per-install CABINET_AUTH_SALT it needs is
+// already in process.env via loadCabinetEnv() at boot. Resolved once: like the
+// app, a changed password/salt takes effect on the next restart.
+let kbPasswordResolved = false;
+function ensureKbPasswordFromDotEnv(): void {
+  if (kbPasswordResolved) return;
+  kbPasswordResolved = true;
+  if (process.env.KB_PASSWORD) return; // already set (dev path or real env)
+  try {
+    const envRaw = fs.readFileSync(path.join(process.cwd(), ".env"), "utf-8");
+    for (const line of envRaw.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const eq = trimmed.indexOf("=");
+      if (eq === -1 || trimmed.slice(0, eq).trim() !== "KB_PASSWORD") continue;
+      const value = trimmed
+        .slice(eq + 1)
+        .trim()
+        .replace(/^["']|["']$/g, "");
+      if (value) process.env.KB_PASSWORD = value;
+      break;
+    }
+  } catch {
+    // No .env / unreadable -- auth gate is presumably disabled.
+  }
+}
+
 async function putJson(url: string, body: Record<string, unknown>): Promise<void> {
+  // Attach the same `kb-auth` cookie a logged-in browser carries, so these
+  // server-to-server triggers pass the gate instead of silently 401ing. No-op
+  // when auth is disabled (authCookieHeader() returns {}).
+  ensureKbPasswordFromDotEnv();
   const response = await fetch(url, {
     method: "PUT",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      ...(await authCookieHeader()),
+    },
     body: JSON.stringify(body),
   });
 

--- a/src/lib/auth/kb-auth.test.ts
+++ b/src/lib/auth/kb-auth.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { pbkdf2Sync } from "node:crypto";
 import {
+  authCookieHeader,
   deriveAuthToken,
   expectedToken,
   getAuthSalt,
@@ -86,6 +87,38 @@ test("isAuthEnabled / getKbPassword read env at call time", () => {
   } finally {
     if (prev === undefined) delete process.env.KB_PASSWORD;
     else process.env.KB_PASSWORD = prev;
+  }
+});
+
+test("authCookieHeader: {} when auth off, valid kb-auth cookie when on", async () => {
+  const prev = {
+    pw: process.env.KB_PASSWORD,
+    it: process.env.CABINET_LOGIN_PBKDF2_ITERS,
+    salt: process.env.CABINET_AUTH_SALT,
+  };
+  try {
+    process.env.CABINET_LOGIN_PBKDF2_ITERS = "2";
+    process.env.CABINET_AUTH_SALT = "feedface";
+    // Auth disabled -> no cookie, so the daemon's S2S calls behave as before.
+    delete process.env.KB_PASSWORD;
+    assert.deepEqual(await authCookieHeader(), {});
+    process.env.KB_PASSWORD = "";
+    assert.deepEqual(await authCookieHeader(), {});
+    // Auth enabled -> exactly the cookie the gate (expectedToken) expects.
+    process.env.KB_PASSWORD = "s3cret";
+    const header = await authCookieHeader();
+    assert.deepEqual(Object.keys(header), ["Cookie"]);
+    assert.equal(header.Cookie, `kb-auth=${await expectedToken()}`);
+    assert.equal(header.Cookie, `kb-auth=${await deriveAuthToken("s3cret", "feedface", 2)}`);
+  } finally {
+    for (const [k, v] of [
+      ["KB_PASSWORD", prev.pw],
+      ["CABINET_LOGIN_PBKDF2_ITERS", prev.it],
+      ["CABINET_AUTH_SALT", prev.salt],
+    ] as const) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
   }
 });
 

--- a/src/lib/auth/kb-auth.ts
+++ b/src/lib/auth/kb-auth.ts
@@ -117,6 +117,23 @@ export function expectedToken(): Promise<string> {
 }
 
 /**
+ * The `Cookie` header a trusted server-to-server caller (the scheduler daemon,
+ * server/cabinet-daemon.ts) must attach so its own `/api/*` requests pass the
+ * gate in src/proxy.ts -- otherwise every scheduled job + heartbeat trigger
+ * 401s silently once KB_PASSWORD is set. Returns an empty object when auth is
+ * disabled, so callers can spread it unconditionally and send nothing.
+ *
+ * Uses the memoized expectedToken(), so PBKDF2 is paid once per process even
+ * though every trigger calls this. The CALLER must make KB_PASSWORD and (when
+ * generated) CABINET_AUTH_SALT visible in process.env first -- this module only
+ * reads env, it never loads .env / .cabinet.env.
+ */
+export async function authCookieHeader(): Promise<Record<string, string>> {
+  if (!isAuthEnabled()) return {};
+  return { Cookie: `${KB_AUTH_COOKIE}=${await expectedToken()}` };
+}
+
+/**
  * Constant-time comparison of two hex strings. Pure JS (keeps this module
  * node-free; `node:crypto.timingSafeEqual` would not). Returns false on length
  * mismatch; otherwise XOR-accumulates over the full length without an

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { NextRequest } from "next/server";
 import { proxy } from "@/proxy";
-import { deriveAuthToken, getAuthSalt } from "@/lib/auth/kb-auth";
+import { authCookieHeader, deriveAuthToken, getAuthSalt } from "@/lib/auth/kb-auth";
 
 // Keep PBKDF2 cheap for tests — the shared module reads this at call time.
 process.env.CABINET_LOGIN_PBKDF2_ITERS = "1";
@@ -87,5 +87,34 @@ test("proxy admits authenticated requests when locked", async () => {
   } finally {
     if (prev !== undefined) process.env.KB_PASSWORD = prev;
     else delete process.env.KB_PASSWORD;
+  }
+});
+
+// End-to-end guard for the scheduler-daemon bug: the cookie the daemon attaches
+// (authCookieHeader) must satisfy the SAME gate (proxy) on an /api/* route, or
+// every scheduled job + heartbeat 401s silently once KB_PASSWORD is set. Both
+// sides derive from the shared kb-auth module; this pins them together through
+// the real proxy, across a non-default per-install salt.
+test("daemon's authCookieHeader passes the proxy gate on /api/* when locked", async () => {
+  const prev = {
+    pw: process.env.KB_PASSWORD,
+    salt: process.env.CABINET_AUTH_SALT,
+  };
+  process.env.KB_PASSWORD = "s3cret";
+  process.env.CABINET_AUTH_SALT = "feedface";
+  try {
+    const header = await authCookieHeader();
+    const eq = header.Cookie.indexOf("=");
+    const cookies = { [header.Cookie.slice(0, eq)]: header.Cookie.slice(eq + 1) };
+    const res = await proxy(makeReq("/api/pages", cookies));
+    assert.equal(res.status, 200, "gate must admit the daemon's cookie");
+  } finally {
+    for (const [k, v] of [
+      ["KB_PASSWORD", prev.pw],
+      ["CABINET_AUTH_SALT", prev.salt],
+    ] as const) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
   }
 });


### PR DESCRIPTION
## Problem

When `KB_PASSWORD` is set, `src/proxy.ts` requires a valid `kb-auth` cookie on every `/api/*` route. The scheduler daemon's server-to-server calls (`putJson` → job/persona triggers) send **no cookie**, so once the auth gate is enabled **every scheduled job and heartbeat trigger 401s silently and never runs**.

It's easy to miss: manual **"Run now"** from the browser keeps working (the browser carries the cookie), `/health` still reports `status: ok`, and the only signal is a `console.error("Failed to trigger ...")`.

This is the bug originally reported in **#137**.

## Why a new PR (supersedes #137)

#137 was opened against the old auth model and predated **#140** (PBKDF2 + per-install salt + login rate-limiting). As written it re-introduced fast, unsalted `SHA-256(password + "cabinet-salt")` in its own `src/lib/auth/kb-auth.ts` and re-refactored `src/proxy.ts` — both now **conflict** with main and would have regressed #140's hardening. #140's own commit message called this out: *"Daemon S2S auth (PR #137) intentionally out of scope; #137 should adopt this module."*

This PR keeps #137's correct core idea (daemon attaches the gate cookie) and rebuilds it on the merged PBKDF2 module.

## Fix

- **`authCookieHeader()`** added to `src/lib/auth/kb-auth.ts` — the single source of truth for the daemon's cookie. Returns `{}` when auth is off, else `{ Cookie: "kb-auth=<token>" }` using the **memoized `expectedToken()`**, so PBKDF2 is paid once per process, not per trigger. Caller (daemon) ↔ verifier (`proxy.ts`) can't drift on hash/salt/iterations.
- **`server/cabinet-daemon.ts`** — `putJson()` spreads `...(await authCookieHeader())` into its headers; all trigger sites (jobs, one-shot disable, heartbeats) funnel through it. `ensureKbPasswordFromDotEnv()` resolves `KB_PASSWORD` from `.env` when it isn't already in the environment — the production `start:daemon` path bypasses `scripts/dev-daemon.mjs` (which loads `.env` in dev). The per-install `CABINET_AUTH_SALT` is already loaded via the existing `loadCabinetEnv()` at boot.

**No behavior change when `KB_PASSWORD` is unset** — `authCookieHeader()` returns `{}`, so no cookie is sent.

## Tests

- `src/lib/auth/kb-auth.test.ts` — unit test for `authCookieHeader` (off → `{}`, on → cookie matching `expectedToken`/`deriveAuthToken`).
- `test/proxy.test.ts` — **end-to-end guard**: drives the daemon's cookie through the *real* `proxy()` gate on `/api/pages` across a non-default per-install salt, so the two sides stay pinned together. This is exactly the failure #137 hit.

Full suite **327/327**; `tsc --noEmit` and `eslint` clean.

## Note

Any auth env must be identical in both processes. Salt is fine (both load `.cabinet.env`); password has the `.env` fallback above. If someone overrides `CABINET_LOGIN_PBKDF2_ITERS` in `.env` only (not real env / `.cabinet.env`), the prod daemon won't see it → token drift. Default-vs-default (600k) is fine.

Closes #137.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed authentication handling for scheduled and triggered jobs, ensuring they work correctly in all deployment configurations.

* **Tests**
  * Added tests to verify proper authentication behavior for internal server-to-server communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->