### PR TITLE
fix: copy standalone static assets after build (postbuild hook)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev:all": "concurrently -k -n app,daemon \"npm:dev\" \"npm:dev:daemon\"",
     "debug:chrome": "bash scripts/launch-chrome-debug.sh",
     "build": "next build",
+    "postbuild": "node scripts/copy-standalone-assets.mjs",
     "electron:prep": "node scripts/prepare-electron-package.mjs",
     "release:manifest": "node scripts/generate-release-manifest.mjs",
     "start": "concurrently -k -n app,daemon \"npm:start:next\" \"npm:start:daemon\"",

--- a/scripts/copy-standalone-assets.mjs
+++ b/scripts/copy-standalone-assets.mjs
@@ -1,0 +1,61 @@
+// Runs automatically after `next build` (postbuild hook).
+//
+// Next.js copies server code to .next/standalone/ but intentionally omits
+// static assets — they are meant to be served by a CDN in typical cloud
+// deployments. When Cabinet is self-hosted and the standalone server handles
+// all traffic directly, the assets must live alongside server.js so that
+// /_next/static/* and /public/* routes resolve correctly. Without this copy
+// the server starts and the API responds, but every page loads blank because
+// the JS/CSS bundles (and public files) return 404.
+//
+// Reference: https://nextjs.org/docs/app/api-reference/config/next-config-js/output#automatically-copying-traced-files
+
+import fs from "fs";
+import path from "path";
+
+const ROOT = process.cwd();
+
+// next.config.ts sets outputFileTracingRoot to the parent of the project dir
+// so the standalone bundle is nested one level deeper than usual.
+const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, "package.json"), "utf8"));
+const projectName = path.basename(ROOT); // "cabinet" in most setups
+const STANDALONE = path.join(ROOT, ".next", "standalone", projectName);
+
+if (!fs.existsSync(STANDALONE)) {
+  // outputFileTracingRoot may have changed the nesting — fall back to the
+  // flat layout (server.js directly in .next/standalone/).
+  const flat = path.join(ROOT, ".next", "standalone");
+  if (fs.existsSync(path.join(flat, "server.js"))) {
+    copyAssets(flat);
+  } else {
+    console.warn(
+      `[cabinet] postbuild: standalone dir not found at ${STANDALONE} or ${flat}. ` +
+        "Static assets were NOT copied — production server may serve blank pages."
+    );
+  }
+} else {
+  copyAssets(STANDALONE);
+}
+
+function copyAssets(standaloneDir) {
+  copyDir(
+    path.join(ROOT, ".next", "static"),
+    path.join(standaloneDir, ".next", "static")
+  );
+  copyDir(path.join(ROOT, "public"), path.join(standaloneDir, "public"));
+  console.log(`[cabinet] Standalone assets copied to ${standaloneDir}`);
+}
+
+function copyDir(src, dest) {
+  if (!fs.existsSync(src)) return;
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDir(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Cabinet's `next.config.ts` sets `output: "standalone"`, but there's no mechanism to copy the static assets that the standalone server needs to serve the UI. This means:

- `next build` succeeds ✓
- Standalone server starts and `/api/*` routes respond ✓  
- **Every page loads blank** — JS/CSS bundles return 404 ✗

This happens because Next.js intentionally excludes `.next/static/` and `public/` from the standalone bundle (they're designed to be served by a CDN in cloud deployments). When Cabinet is self-hosted and the standalone server handles all traffic directly, those assets must live alongside `server.js`.

The existing `start:next` script (`next start`) also emits a warning when `output: standalone` is set:
> `"next start" does not work with "output: standalone" configuration. Use "node .next/standalone/server.js" instead.`

## Fix

Add `scripts/copy-standalone-assets.mjs` and a `postbuild` npm hook so `.next/static/` and `public/` are automatically copied into the standalone output directory after every `next build`. No manual step, no forgetting.

The script handles two layouts:
- **Nested** (when `outputFileTracingRoot` is a parent dir): `.next/standalone/<project-name>/`
- **Flat** (standard): `.next/standalone/`

## Test plan

- [ ] `npm run build` completes and logs `[cabinet] Standalone assets copied to …`
- [ ] `node .next/standalone/<project-name>/server.js` (or flat path) serves the UI without blank pages
- [ ] `.next/standalone/.../next/static/chunks/` contains JS bundles
- [ ] No regression on `npm run dev` (postbuild only runs after `next build`)

## References

- [Next.js standalone output docs](https://nextjs.org/docs/app/api-reference/config/next-config-js/output#automatically-copying-traced-files): *"you will need to copy the public folder … and the .next/static folder … manually"*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced self-hosted deployment support by automatically bundling static assets with standalone builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->