### PR TITLE
fix(agents): coerce inbox timestamp to string in readInbox (Date crash)

### DIFF
--- a/src/lib/agents/persona-manager.ts
+++ b/src/lib/agents/persona-manager.ts
@@ -598,6 +598,19 @@ export async function sendMessage(
   await writeFileContent(path.join(inboxDir, filename), content);
 }
 
+/**
+ * Coerce a frontmatter timestamp to a string. gray-matter (js-yaml) parses an
+ * unquoted ISO-8601 value (e.g. `timestamp: 2026-06-14T13:03:17.498Z`) into a
+ * JS Date, not a string — and a Date survives `|| ""`, so a later
+ * `.localeCompare` throws. Inter-agent messages written without quotes hit
+ * this, 500-ing the persona GET and crashing the heartbeat's inbox read.
+ */
+function toTimestampString(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value instanceof Date) return value.toISOString();
+  return value != null ? String(value) : "";
+}
+
 export async function readInbox(slug: string, cabinetPath?: string): Promise<Array<{ from: string; timestamp: string; message: string; filename: string }>> {
   const inboxDir = path.join(await resolveMessagesDirForSlug(slug, cabinetPath), slug);
   await ensureDirectory(inboxDir);
@@ -610,13 +623,15 @@ export async function readInbox(slug: string, cabinetPath?: string): Promise<Arr
     const { data, content } = matter(raw);
     messages.push({
       from: (data.from as string) || "unknown",
-      timestamp: (data.timestamp as string) || "",
+      timestamp: toTimestampString(data.timestamp),
       message: content.trim(),
       filename: entry.name,
     });
   }
 
-  return messages.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+  return messages.sort((a, b) =>
+    String(b.timestamp).localeCompare(String(a.timestamp))
+  );
 }
 
 export async function clearInbox(slug: string, cabinetPath?: string): Promise<void> {


### PR DESCRIPTION
## Problem

An unquoted ISO-8601 `timestamp:` in an inbox message's YAML frontmatter — exactly what inter-agent `sendMessage` writes, e.g.:

```yaml
---
from: sigma
to: some-agent
timestamp: 2026-06-14T13:03:17.498Z
---
```

is parsed by gray-matter (js-yaml) into a JS **`Date`**, not a string. A `Date` is truthy, so it survives `(data.timestamp as string) || ""` in `readInbox`, and the sort comparator then calls `Date.prototype.localeCompare`, which doesn't exist:

```
TypeError: b.timestamp.localeCompare is not a function
    at readInbox (src/lib/agents/persona-manager.ts)
    at async buildHeartbeatContext (src/lib/agents/heartbeat.ts)
    at async runHeartbeat (...)
    at async GET /api/agents/personas/[slug]
```

Impact for any agent whose inbox contains such a message:
- `GET /api/agents/personas/[slug]` returns **500** → the UI shows **"Couldn't load this agent."**
- The agent's **heartbeat crashes** (`runHeartbeat → buildHeartbeatContext → readInbox`), so it silently stops running.

Agents with empty inboxes never hit it, so it presents as "one specific agent won't load."

## Fix

Coerce the frontmatter timestamp to a string at construction (`Date → toISOString()`), and harden the sort with `String(...)`. This is a **read-side** fix, so it also repairs messages already on disk, no matter how they were written.

## Test plan
- [x] `tsc --noEmit` clean on the changed file
- [x] `eslint` clean on the changed file
- [x] Reproduced live: agent with a `Date`-typed inbox timestamp returned 500; after the fix the same endpoint returns 200 and the inbox parses/sorts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inbox message sorting and timestamp handling to prevent runtime errors and ensure consistent message ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->