### PR TITLE
perf(conversations): skip transcript re-parse for finalized conversations

### DIFF
--- a/src/lib/agents/conversation-store.ts
+++ b/src/lib/agents/conversation-store.ts
@@ -1249,6 +1249,27 @@ async function maybeResolveCompletedConversation(
 ): Promise<ConversationMeta | null> {
   if (!meta) return meta;
 
+  // Fast path: an already-terminal conversation with clean (non-placeholder)
+  // fields needs no repair, so skip the expensive transcript + prompt read and
+  // string-scan below. listConversationMetas() runs this for EVERY conversation
+  // on every call, and getRunningConversationCounts() calls that on every SSE
+  // tick (every 3s per connected client) plus the personas/board polls. Reading
+  // and re-parsing every finalized transcript is O(conversations x file size)
+  // CPU that blocks the event loop once a cabinet accumulates conversations
+  // (observed: a single cabinet with ~600 conversations pegged the server at
+  // 90%+ CPU, with /api/agents/personas taking 37s and the daemon-health proxy
+  // timing out -> false "daemon not responding" banner). The run-completion
+  // finalizeConversation() already extracted summary/artifacts, so re-parsing a
+  // terminal transcript on every poll is redundant.
+  if (
+    meta.status !== "running" &&
+    !isPlaceholderCabinetValue(meta.summary) &&
+    !isPlaceholderCabinetValue(meta.contextSummary) &&
+    !meta.artifactPaths.some((artifactPath) => isPlaceholderCabinetValue(artifactPath))
+  ) {
+    return meta;
+  }
+
   const cabinetPath = meta.cabinetPath;
   const transcript = await readConversationTranscript(meta.id, cabinetPath);
   const prompt = (await fileExists(promptPathFs(meta.id, cabinetPath)))


### PR DESCRIPTION
## Problem

`maybeResolveCompletedConversation()` reads each conversation's full `transcript.txt` + `prompt.md` (often 100KB+) and string-scans them (`transcriptShowsCompletedRun`, `parseCabinetBlock`). `listConversationMetas()` calls it for **every** conversation on every invocation, and `getRunningConversationCounts()` calls `listConversationMetas()` on **every `/api/agents/events` SSE tick (every 3s per connected client)** — plus the personas and board surfaces poll it.

That makes each poll **O(conversations × file size) CPU on the main thread**, so cost grows linearly with a cabinet's conversation count and eventually blocks the event loop.

Observed on a cabinet with ~600 conversations (a few open browser tabs each holding an SSE connection):

- server pegged at **90%+ CPU**, event loop blocked 6–12s at a time
- `/api/agents/personas` → **37s**, `/api/cabinets/overview` → **20–43s**
- `/api/health/daemon` proxy timed out → UI showed a **false "The agent daemon isn't responding" banner** (the daemon itself was healthy, responding in <10ms)
- task composer showed **"No agent available"** because its agent-list fetch never returned before the user clicked Start

A CPU sample of the pegged process showed the hot stack: `fs FileHandle` read → microtask → `StringIndexOf`/`StringSearch`/`memchr`, in a tight loop — i.e. reading + scanning conversation files.

## Fix

Add a fast path at the top of `maybeResolveCompletedConversation()`: an already-terminal conversation (`status !== "running"`) whose `summary` / `contextSummary` / `artifactPaths` are all non-placeholder needs no repair, so return it **without reading the transcript/prompt at all**.

`finalizeConversation()` already extracts summary/artifacts at run completion, so re-parsing a terminal transcript on every poll is redundant. Repair behavior is unchanged for `running` conversations and for any meta with placeholder/incomplete fields (crash-mid-write recovery still works).

## Result

| Endpoint | Before | After |
|---|---|---|
| `/api/agents/personas` | 37 s | **0.06 s** |
| `/api/cabinets/overview` | 20–43 s | **0.008 s** |
| `/api/health` (rapid) | 6–12 s, timeouts | **7–23 ms** |
| idle CPU | 90–106% | **~0%** |

The read+scan now runs only for the handful of actually-running conversations instead of all of them.

## Notes

Complementary follow-ups (not included here): a short-TTL cache on `getRunningConversationCounts()`, and pruning/archiving old `.conversations`, would further bound the per-tick cost — but the read-amplification is the root cause and this removes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized conversation processing efficiency by implementing a faster data retrieval pathway for completed conversations. This reduces unnecessary processing steps and improves response times when accessing conversation history and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->