### PR TITLE
feat(agents): add Claude Fable 5, bump Opus 4.7 → 4.8; clear stale task error

### DIFF
--- a/src/components/tasks/conversation/task-conversation-page.tsx
+++ b/src/components/tasks/conversation/task-conversation-page.tsx
@@ -144,14 +144,21 @@ function applyTerminalPayloadToTask(
   if (typeof raw !== "string") return null;
   const taskStatus = conversationStatusToTaskStatus(raw);
   if (!taskStatus || taskStatus === "running") return null;
-  const errorHint =
-    typeof payload.errorHint === "string"
+  // Only carry an error while the task is actually failed. A transient error
+  // (e.g. a resume/session blip the runner recovers from via replay) emits a
+  // momentary failed event; when the task later resolves to a non-failed
+  // status, clear the stale errorKind/errorHint so the banner doesn't stick.
+  const isFailed = taskStatus === "failed";
+  const errorHint = isFailed
+    ? typeof payload.errorHint === "string"
       ? payload.errorHint
-      : prev.meta.errorHint;
-  const errorKind =
-    typeof payload.errorKind === "string"
+      : prev.meta.errorHint
+    : undefined;
+  const errorKind = isFailed
+    ? typeof payload.errorKind === "string"
       ? payload.errorKind
-      : prev.meta.errorKind;
+      : prev.meta.errorKind
+    : undefined;
   if (
     prev.meta.status === taskStatus &&
     prev.meta.errorHint === errorHint &&

--- a/src/lib/agents/providers/claude-code.ts
+++ b/src/lib/agents/providers/claude-code.ts
@@ -7,8 +7,8 @@ import {
 } from "../provider-cli";
 import { getNvmNodeBin } from "../nvm-path";
 
-// Effort levels per Claude Code docs: Opus 4.7 supports an extra `xhigh`
-// rung (recommended default); Opus 4.6 / Sonnet 4.6 stop at `max`. Setting
+// Effort levels per Claude Code docs: Fable 5 / Opus 4.8 support an extra
+// `xhigh` rung (recommended default); Sonnet 4.6 stops at `max`. Setting
 // an unsupported level falls back to the highest the model accepts, but we
 // surface the right list so the picker doesn't show levels that won't apply.
 const OPUS_THINKING_LEVELS = [
@@ -46,15 +46,21 @@ export const claudeCodeProvider: AgentProvider = {
   ],
   models: [
     {
+      id: "fable",
+      name: "Claude Fable 5",
+      description: "Most powerful model, above Opus, with configurable effort",
+      effortLevels: [...OPUS_THINKING_LEVELS],
+    },
+    {
       id: "opus",
-      name: "Claude Opus 4.7",
-      description: "Most intelligent with configurable effort",
+      name: "Claude Opus 4.8",
+      description: "Most intelligent Opus with configurable effort",
       effortLevels: [...OPUS_THINKING_LEVELS],
     },
     {
       id: "opus[1m]",
-      name: "Claude Opus 4.7 (1M context)",
-      description: "Opus 4.7 with 1M-token context for very long sessions",
+      name: "Claude Opus 4.8 (1M context)",
+      description: "Opus 4.8 with 1M-token context for very long sessions",
       effortLevels: [...OPUS_THINKING_LEVELS],
     },
     {


### PR DESCRIPTION
Salvages the still-needed pieces of #119 (by @alpha8eta). The other two fixes in #119 — the dev-origin allowlist and board-prefix navigation — already landed on main via #112 and #133/#134, so only these two non-conflicting pieces remain:

## 1. `feat(providers)`: add Claude Fable 5, refresh Claude Code labels
The Claude Code provider hardcoded "Opus 4.7" labels against the floating `opus` CLI alias (now Opus 4.8), mislabeling the current model. This adds the `fable` entry (alias verified in `@anthropic-ai/claude-code`'s `sdk-tools.d.ts`: `"sonnet" | "opus" | "haiku" | "fable"`) and bumps the Opus labels (standard + 1M variants) to 4.8.

## 2. `fix(tasks)`: clear stale task error on recovery
`task-conversation-page` now only carries `errorKind`/`errorHint` while the task is actually failed, so a transient resume/session blip the runner recovers from doesn't leave a stale error banner stuck on a now-succeeded task.

Supersedes #119, which will be closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed issue where error messages persisted after task failures were resolved to other outcomes.

## New Features
* Added support for Claude Fable 5 and Claude Opus 4.8 models.
* Added "xhigh" effort level option for Fable 5 and Opus 4.8 models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->