### PR TITLE
feat(daemon): expose scheduler trigger health on /health

### DIFF
--- a/server/cabinet-daemon.ts
+++ b/server/cabinet-daemon.ts
@@ -1196,6 +1196,31 @@ const scheduledJobs = new Map<string, ReturnType<typeof cron.schedule>>();
 const scheduledHeartbeats = new Map<string, ReturnType<typeof cron.schedule>>();
 let scheduleReloadTimer: NodeJS.Timeout | null = null;
 
+// Scheduler observability, surfaced on /health. A scheduler that fires but
+// whose every trigger fails (e.g. a 401 from the app auth gate) is otherwise
+// invisible: scheduledJobs stays > 0 and the daemon looks healthy while no job
+// actually runs. These process-lifetime counters make that detectable without
+// scraping logs.
+const schedulerStats = {
+  lastTriggerAt: null as string | null,
+  lastSuccessfulTriggerAt: null as string | null,
+  lastFailedTriggerAt: null as string | null,
+  triggerFailures: 0,
+  lastTriggerError: null as string | null,
+};
+function recordTriggerAttempt(scheduledAt: string): void {
+  schedulerStats.lastTriggerAt = scheduledAt;
+}
+function recordTriggerSuccess(scheduledAt: string): void {
+  schedulerStats.lastSuccessfulTriggerAt = scheduledAt;
+}
+function recordTriggerFailure(error: unknown): void {
+  schedulerStats.triggerFailures += 1;
+  schedulerStats.lastFailedTriggerAt = new Date().toISOString();
+  schedulerStats.lastTriggerError =
+    error instanceof Error ? error.message : String(error);
+}
+
 // The app gates every /api/* route behind KB_PASSWORD (src/proxy.ts), deriving
 // the cookie from PBKDF2(password, CABINET_AUTH_SALT, CABINET_LOGIN_PBKDF2_ITERS)
 // via the shared kb-auth module. The daemon must derive the IDENTICAL value, so
@@ -1279,6 +1304,7 @@ function scheduleJob(job: JobConfig): void {
   const task = cron.schedule(job.schedule, () => {
     const scheduledAt = new Date(Math.round(Date.now() / 60000) * 60000).toISOString();
     console.log(`Triggering scheduled job ${key} @ ${scheduledAt}`);
+    recordTriggerAttempt(scheduledAt);
     // Disable a one-shot after it has fired — on BOTH success and failure. A
     // one-off cron (`m h dom mon *`) would otherwise re-match a year later; a
     // failed run must not leave it armed for that rollover.
@@ -1307,7 +1333,9 @@ function scheduleJob(job: JobConfig): void {
       cabinetPath: job.cabinetPath,
       scheduledAt,
     })
+      .then(() => recordTriggerSuccess(scheduledAt))
       .catch((error) => {
+        recordTriggerFailure(error);
         console.error(`Failed to trigger scheduled job ${key}:`, error);
       })
       .finally(() => {
@@ -1332,14 +1360,18 @@ function scheduleHeartbeat(slug: string, cronExpr: string, cabinetPath: string):
   const task = cron.schedule(cronExpr, () => {
     const scheduledAt = new Date(Math.round(Date.now() / 60000) * 60000).toISOString();
     console.log(`Triggering heartbeat ${key} @ ${scheduledAt}`);
+    recordTriggerAttempt(scheduledAt);
     void putJson(`${getAppOrigin()}/api/agents/personas/${slug}`, {
       action: "run",
       source: "scheduler",
       cabinetPath,
       scheduledAt,
-    }).catch((error) => {
-      console.error(`Failed to trigger heartbeat ${key}:`, error);
-    });
+    })
+      .then(() => recordTriggerSuccess(scheduledAt))
+      .catch((error) => {
+        recordTriggerFailure(error);
+        console.error(`Failed to trigger heartbeat ${key}:`, error);
+      });
   });
 
   scheduledHeartbeats.set(key, task);
@@ -1897,6 +1929,11 @@ const server = http.createServer(async (req, res) => {
         scheduledJobs: scheduledJobs.size,
         scheduledHeartbeats: scheduledHeartbeats.size,
         subscribers: subscribers.length,
+        lastTriggerAt: schedulerStats.lastTriggerAt,
+        lastSuccessfulTriggerAt: schedulerStats.lastSuccessfulTriggerAt,
+        lastFailedTriggerAt: schedulerStats.lastFailedTriggerAt,
+        triggerFailures: schedulerStats.triggerFailures,
+        lastTriggerError: schedulerStats.lastTriggerError,
       })
     );
     return;


### PR DESCRIPTION
Salvages the observability half of #138 (by @alpha8eta). #138 was stacked on #137, whose auth fix already landed on main as the PBKDF2 `kb-auth` module via #140/#142 — so only the `/health` observability commit remains, rebased cleanly onto current main.

## Problem
A scheduler that fires on time but whose every trigger fails (a 401 from the auth gate, a downed app, a wrong origin) is invisible today: `scheduledJobs` stays > 0 and `/health` reports `status: ok` while no job actually runs. Failures only land in `console.error`.

## Change
Track process-lifetime trigger stats and surface them on `/health`:

| field | meaning |
|---|---|
| `lastTriggerAt` | last time any job/heartbeat cron fired |
| `lastSuccessfulTriggerAt` | last trigger the app accepted |
| `lastFailedTriggerAt` | last trigger that errored |
| `triggerFailures` | count of failed triggers |
| `lastTriggerError` | message of the most recent failure |

`lastTriggerAt` advancing while `lastSuccessfulTriggerAt` is stale and `triggerFailures` climbing pinpoints a delivery failure vs a stalled timer. No new dependencies; counters are in-memory and reset on restart. Single-file change to `server/cabinet-daemon.ts`.

Supersedes #138, which will be closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Health monitoring endpoint now exposes detailed scheduler statistics including trigger history, failure counts, and diagnostic error information for improved system observability and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->