### PR TITLE
fix(channels): hide @mention reply conversations from Tasks panel

### DIFF
--- a/src/components/cabinets/cabinet-utils.ts
+++ b/src/components/cabinets/cabinet-utils.ts
@@ -66,6 +66,7 @@ export const TRIGGER_STYLES: Record<ConversationMeta["trigger"], string> = {
   heartbeat: "bg-pink-500/12 text-pink-400 ring-1 ring-pink-500/20",
   agent: "bg-violet-500/12 text-violet-400 ring-1 ring-violet-500/20",
   telegram: "bg-cyan-500/12 text-cyan-400 ring-1 ring-cyan-500/20",
+  channel: "bg-amber-500/12 text-amber-400 ring-1 ring-amber-500/20",
 };
 
 export const TRIGGER_LABELS: Record<ConversationMeta["trigger"], string> = {
@@ -74,6 +75,7 @@ export const TRIGGER_LABELS: Record<ConversationMeta["trigger"], string> = {
   heartbeat: "Heartbeat",
   agent: "Agent",
   telegram: "Telegram",
+  channel: "Channel",
 };
 
 /* ─── Icon components ─── */

--- a/src/components/tasks/board/list-view.tsx
+++ b/src/components/tasks/board/list-view.tsx
@@ -54,6 +54,10 @@ const TRIGGER_STYLES: Record<
     label: "Telegram",
     className: "bg-muted text-muted-foreground ring-1 ring-border/60",
   },
+  channel: {
+    label: "Channel",
+    className: "bg-muted text-muted-foreground ring-1 ring-border/60",
+  },
 };
 
 function TriggerBadge({ trigger }: { trigger: TaskMeta["trigger"] }) {

--- a/src/lib/agents/conversation-store.ts
+++ b/src/lib/agents/conversation-store.ts
@@ -1750,6 +1750,17 @@ export async function listConversationMetas(
   const metas = groups.flat();
 
   const filtered = metas.filter((meta) => {
+    // Channel @mention replies aren't tasks — hide them from every listing.
+    // Trigger "channel" tags new ones; the title match sweeps up older ones
+    // written as "manual" before the trigger existed (no migration needed).
+    // ponytail: title check is the retroactive fallback; drop it once old
+    // channel-reply conversations have aged out.
+    if (
+      filters.trigger !== "channel" &&
+      (meta.trigger === "channel" || / · reply in #/.test(meta.title))
+    ) {
+      return false;
+    }
     if (filters.agentSlug && meta.agentSlug !== filters.agentSlug) return false;
     if (filters.trigger && meta.trigger !== filters.trigger) return false;
     if (filters.status && meta.status !== filters.status) return false;

--- a/src/lib/agents/heartbeat.ts
+++ b/src/lib/agents/heartbeat.ts
@@ -579,7 +579,9 @@ IMPORTANT: You may think or check files first, but put ONLY your final reply to 
     startConversationRun({
       agentSlug: slug,
       title: `${persona.name} · reply in #${channel}`,
-      trigger: "manual",
+      // Channel @mention replies are transient — not user tasks. Tag them so the
+      // Tasks panel can hide them (see listConversationMetas).
+      trigger: "channel",
       prompt,
       adapterType: persona.adapterType || defaultAdapterTypeForProvider(providerId),
       adapterConfig: persona.adapterConfig,

--- a/src/types/conversations.ts
+++ b/src/types/conversations.ts
@@ -1,6 +1,6 @@
 import type { DispatchedAction, PendingAction } from "./actions";
 
-export type ConversationTrigger = "manual" | "job" | "heartbeat" | "agent" | "telegram";
+export type ConversationTrigger = "manual" | "job" | "heartbeat" | "agent" | "telegram" | "channel";
 export type ConversationSource = "manual" | "editor";
 
 export type ConversationStatus =

--- a/src/types/tasks.ts
+++ b/src/types/tasks.ts
@@ -6,7 +6,7 @@ export type TaskStatus =
   | "failed"
   | "archived";
 
-export type TaskTrigger = "manual" | "job" | "heartbeat" | "agent" | "telegram";
+export type TaskTrigger = "manual" | "job" | "heartbeat" | "agent" | "telegram" | "channel";
 
 export type TurnRole = "user" | "agent";
 


### PR DESCRIPTION
## Problem
PR #157 added agent @mention replies in team channels. Each reply was persisted as a conversation with `trigger: "manual"` — indistinguishable from a real user task — so the Tasks panel filled up with "Editor · reply in #general" entries the user should never see.

## Fix
- Tag channel replies with a new `trigger: "channel"` (`heartbeat.ts`).
- `listConversationMetas()` excludes `trigger === "channel"` from every listing, plus a `· reply in #` title-pattern fallback so the ones already on disk (written as `"manual"` before this change) also disappear — no migration needed.
- Extend the `ConversationTrigger`/`TaskTrigger` unions and the exhaustive trigger style/label maps with `channel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced channel-based conversation triggers with custom styling and visual identification.
  * Channel `@mention` reply conversations are automatically filtered from task list views to reduce clutter.

* **Updates**
  * Enhanced trigger type system to support channel-based conversation workflows and better task organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->