### PR TITLE
Launched Notion in the Integrations Hub catalog and corrected mislead…

### DIFF
--- a/src/app/api/agents/config/mcp-catalog/oauth/login/route.ts
+++ b/src/app/api/agents/config/mcp-catalog/oauth/login/route.ts
@@ -1,0 +1,121 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getCatalogEntry } from "@/lib/agents/mcp-catalog";
+import {
+  startMcpLogin,
+  getMcpLoginStatus,
+  completeMcpLogin,
+  cancelMcpLogin,
+  readServerAuthState,
+} from "@/lib/agents/claude-mcp-login";
+
+/**
+ * `/api/agents/config/mcp-catalog/oauth/login`
+ *
+ * Connect-time OAuth sign-in for HTTP (remote) MCP servers, driven through
+ * Claude Code so the token is cached BEFORE any agent runs — instead of the
+ * broken "sign in on first agent use" loopback (which dies with the task). See
+ * claude-mcp-login.ts.
+ *
+ * POST   { id }                     — start sign-in; returns { sessionId,
+ *                                      authorizeUrl } (or { alreadyAuthenticated }).
+ * POST   { sessionId, callbackUrl } — fallback: submit the pasted callback URL.
+ * GET    ?sessionId                 — poll: pending | success | error | expired.
+ * GET    ?id                        — current auth state for an integration:
+ *                                      { authenticated: boolean }.
+ * DELETE ?sessionId                 — cancel an in-flight sign-in.
+ *
+ * No secrets are handled here; the OAuth token is cached by the CLI.
+ */
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "Invalid JSON body" }, { status: 400 });
+  }
+  const { id, sessionId, callbackUrl } = (body ?? {}) as {
+    id?: unknown;
+    sessionId?: unknown;
+    callbackUrl?: unknown;
+  };
+
+  // Completion branch: forward the pasted callback URL to the live session.
+  if (typeof sessionId === "string" && typeof callbackUrl === "string") {
+    if (!/^https?:\/\/localhost(:\d+)?\/callback/i.test(callbackUrl.trim())) {
+      return NextResponse.json(
+        { ok: false, error: "That doesn't look like a localhost callback URL." },
+        { status: 400 },
+      );
+    }
+    const ok = completeMcpLogin(sessionId, callbackUrl.trim());
+    return ok
+      ? NextResponse.json({ ok: true })
+      : NextResponse.json(
+          { ok: false, error: "No in-progress sign-in for that session." },
+          { status: 404 },
+        );
+  }
+
+  // Start branch.
+  const entry = typeof id === "string" ? getCatalogEntry(id) : undefined;
+  if (!entry) {
+    return NextResponse.json({ ok: false, error: "Unknown integration id" }, { status: 400 });
+  }
+  if (entry.transport !== "http") {
+    return NextResponse.json(
+      { ok: false, error: "This integration doesn't use OAuth sign-in." },
+      { status: 400 },
+    );
+  }
+  try {
+    const res = await startMcpLogin(entry.mcpServerName);
+    return NextResponse.json({ ok: true, ...res });
+  } catch (err) {
+    return NextResponse.json(
+      { ok: false, error: err instanceof Error ? err.message : "Could not start sign-in" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  // `?id=` → report whether the integration's server is already authenticated,
+  // so the connect panel can show a true "signed in" state (registration alone
+  // doesn't mean authenticated).
+  const id = request.nextUrl.searchParams.get("id");
+  if (id) {
+    const entry = getCatalogEntry(id);
+    if (!entry || entry.transport !== "http") {
+      return NextResponse.json({ authenticated: false, applicable: false });
+    }
+    const state = await readServerAuthState(entry.mcpServerName);
+    return NextResponse.json({
+      authenticated: state === "authenticated",
+      applicable: true,
+      state,
+    });
+  }
+
+  const sessionId = request.nextUrl.searchParams.get("sessionId");
+  if (!sessionId) {
+    return NextResponse.json({ error: "Missing sessionId or id" }, { status: 400 });
+  }
+  const status = getMcpLoginStatus(sessionId);
+  if (!status) {
+    return NextResponse.json({ error: "Unknown sign-in session" }, { status: 404 });
+  }
+  return NextResponse.json(status);
+}
+
+export async function DELETE(request: NextRequest): Promise<NextResponse> {
+  const sessionId = request.nextUrl.searchParams.get("sessionId");
+  if (!sessionId) {
+    return NextResponse.json({ error: "Missing sessionId" }, { status: 400 });
+  }
+  cancelMcpLogin(sessionId);
+  return NextResponse.json({ ok: true });
+}

--- a/src/components/integrations/hub/connect-panel.tsx
+++ b/src/components/integrations/hub/connect-panel.tsx
@@ -114,6 +114,20 @@ export function ConnectPanel({
     code?: string;
     error?: string;
   }>({ state: "idle" });
+  // Generic HTTP/OAuth sign-in (Notion, GitHub, Linear, …) driven through
+  // Claude Code at connect-time, so the token is cached before any agent runs.
+  const [oauthLogin, setOauthLogin] = useState<{
+    state: "idle" | "starting" | "pending" | "success" | "error";
+    sessionId?: string;
+    url?: string;
+    error?: string;
+  }>({ state: "idle" });
+  const [callbackPaste, setCallbackPaste] = useState("");
+  // True OAuth auth state (registration alone ≠ authenticated). "unknown" until
+  // the first check resolves, so we don't flash a misleading button.
+  const [authState, setAuthState] = useState<"unknown" | "authenticated" | "needs-auth">(
+    "unknown",
+  );
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const stopPolling = useCallback(() => {
     if (pollRef.current) {
@@ -156,6 +170,31 @@ export function ConnectPanel({
   useEffect(() => {
     void load();
   }, [load]);
+
+  // Resolve true OAuth auth state for HTTP servers (skips non-http / M365, which
+  // have their own flows). Lets the panel show "signed in" vs "needs sign-in".
+  const refreshAuthState = useCallback(async () => {
+    if (isM365) {
+      setAuthState("unknown");
+      return;
+    }
+    try {
+      const res = await fetch(
+        `/api/agents/config/mcp-catalog/oauth/login?id=${encodeURIComponent(item.id)}`,
+        { cache: "no-store" },
+      );
+      const j = await res.json();
+      setAuthState(
+        !j.applicable ? "unknown" : j.authenticated ? "authenticated" : "needs-auth",
+      );
+    } catch {
+      setAuthState("unknown");
+    }
+  }, [isM365, item.id]);
+
+  useEffect(() => {
+    void refreshAuthState();
+  }, [refreshAuthState]);
 
   // If the user already saved their own Entra credentials, open in "work" mode
   // so the fields show (and aren't silently bypassed by the personal default).
@@ -241,6 +280,12 @@ export function ConnectPanel({
   // For M365, the credential fields only show in "work" mode; personal mode is
   // field-free (built-in app + device-code sign-in).
   const showMsCreds = !isM365 || msAccountMode === "work";
+  // Other HTTP/OAuth servers can be signed in at connect-time, but only via
+  // Claude Code (it's the CLI we drive). When it's unchecked we fall back to the
+  // deferred (first agent use) flow. M365 has its own device-code path above.
+  const claudeSelected = targets.has("claude-code");
+  const canConnectTimeSignin =
+    entry.transport === "http" && !isM365 && claudeSelected;
 
   const toggle = (id: string) =>
     setTargets((prev) => {
@@ -372,6 +417,116 @@ export function ConnectPanel({
         state: "error",
         error: err instanceof Error ? err.message : "Could not start sign-in",
       });
+    }
+  };
+
+  const OAUTH_URL = "/api/agents/config/mcp-catalog/oauth/login";
+
+  const cancelOauthLogin = () => {
+    stopPolling();
+    if (oauthLogin.sessionId) {
+      void fetch(`${OAUTH_URL}?sessionId=${encodeURIComponent(oauthLogin.sessionId)}`, {
+        method: "DELETE",
+      }).catch(() => {});
+    }
+    setOauthLogin({ state: "idle" });
+    setCallbackPaste("");
+  };
+
+  const pollOauthLogin = (sessionId: string) => {
+    pollRef.current = setInterval(async () => {
+      try {
+        const s = await fetch(`${OAUTH_URL}?sessionId=${encodeURIComponent(sessionId)}`, {
+          cache: "no-store",
+        });
+        const sj = await s.json();
+        if (sj.status === "success") {
+          stopPolling();
+          setOauthLogin({ state: "success", sessionId });
+          setAuthState("authenticated");
+          showSuccess(`Signed in to ${item.name}.`);
+          await load(); // connected state is driven by load()
+          setOauthLogin({ state: "idle" });
+          setCallbackPaste("");
+        } else if (sj.status === "error" || sj.status === "expired") {
+          stopPolling();
+          setOauthLogin({
+            state: "error",
+            error:
+              sj.error ||
+              (sj.status === "expired"
+                ? "Sign-in timed out before you finished. Try again."
+                : "Sign-in failed."),
+          });
+        }
+      } catch {
+        /* transient — keep polling */
+      }
+    }, 3000);
+  };
+
+  // Register the server (so the CLI exposes its authenticate tool), then drive
+  // the OAuth sign-in through Claude Code while keeping its loopback alive.
+  const startOauthLogin = async () => {
+    if (targets.size === 0) {
+      showError("Pick at least one environment.");
+      return;
+    }
+    stopPolling();
+    setOauthLogin({ state: "starting" });
+    try {
+      const reg = await fetch("/api/agents/config/mcp-catalog/connect", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: entry.id, providers: [...targets] }),
+      });
+      const regJson = await reg.json();
+      if (!reg.ok || !regJson.ok)
+        throw new Error(regJson.error || regJson.message || "Connect failed");
+
+      const res = await fetch(OAUTH_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: entry.id }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.ok) throw new Error(json.error || "Could not start sign-in");
+      if (json.alreadyAuthenticated) {
+        setOauthLogin({ state: "success" });
+        setAuthState("authenticated");
+        showSuccess(`${item.name} connected.`);
+        await load();
+        setOauthLogin({ state: "idle" });
+        return;
+      }
+      setOauthLogin({ state: "pending", sessionId: json.sessionId, url: json.authorizeUrl });
+      pollOauthLogin(json.sessionId);
+    } catch (err) {
+      setOauthLogin({
+        state: "error",
+        error: err instanceof Error ? err.message : "Could not start sign-in",
+      });
+    }
+  };
+
+  // Fallback when the browser can't reach the loopback: submit the pasted
+  // callback URL; the poll then flips to success.
+  const submitOauthCallback = async () => {
+    if (!oauthLogin.sessionId || !callbackPaste.trim()) return;
+    try {
+      const res = await fetch(OAUTH_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sessionId: oauthLogin.sessionId,
+          callbackUrl: callbackPaste.trim(),
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.ok) throw new Error(json.error || "Could not submit callback URL");
+      showSuccess("Finishing sign-in…");
+    } catch (err) {
+      showError(err instanceof Error ? err.message : "Could not submit callback URL");
     }
   };
 
@@ -589,6 +744,81 @@ export function ConnectPanel({
             <p className="mt-2 text-[12px] text-destructive">{msLogin.error}</p>
           )}
         </div>
+      ) : canConnectTimeSignin && authState !== "authenticated" ? (
+        <div className="mt-4">
+          {authState === "unknown" && oauthLogin.state !== "pending" ? (
+            <Button className="w-full" disabled>
+              <Loader2 className="h-4 w-4 animate-spin" />
+            </Button>
+          ) : oauthLogin.state === "pending" ? (
+            <div className="rounded-lg border border-border bg-background p-3">
+              <p className="text-[12px] font-medium text-foreground">
+                Approve access in your browser
+              </p>
+              <a
+                href={oauthLogin.url}
+                target="_blank"
+                rel="noreferrer"
+                className="mt-2 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-border bg-background px-3 py-2 text-[13px] font-medium text-foreground hover:bg-accent"
+              >
+                Open {item.name} sign-in <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+              <p className="mt-3 flex items-center gap-1.5 text-[12px] text-muted-foreground">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" /> Waiting for you to
+                finish…
+              </p>
+              <details className="mt-3">
+                <summary className="cursor-pointer text-[11px] text-muted-foreground hover:text-foreground">
+                  Stuck on a &ldquo;can&apos;t be reached&rdquo; page?
+                </summary>
+                <p className="mt-2 text-[11px] text-muted-foreground">
+                  That page is harmless. Copy its full address-bar URL (it starts
+                  with <code>http://localhost</code>) and paste it here:
+                </p>
+                <div className="mt-2 flex gap-2">
+                  <input
+                    value={callbackPaste}
+                    onChange={(e) => setCallbackPaste(e.target.value)}
+                    placeholder="http://localhost:…/callback?code=…"
+                    className="h-8 flex-1 rounded-md border border-border bg-background px-2.5 text-[12px] text-foreground placeholder:text-muted-foreground/50 outline-none focus:border-foreground/20"
+                  />
+                  <button
+                    type="button"
+                    onClick={submitOauthCallback}
+                    disabled={!callbackPaste.trim()}
+                    className="shrink-0 rounded-md border border-border px-3 py-2 text-[12px] font-medium text-foreground hover:bg-accent disabled:opacity-50"
+                  >
+                    Submit
+                  </button>
+                </div>
+              </details>
+              <button
+                type="button"
+                onClick={cancelOauthLogin}
+                className="mt-3 text-[12px] text-muted-foreground hover:text-destructive"
+              >
+                Cancel
+              </button>
+            </div>
+          ) : (
+            <Button
+              className="w-full"
+              disabled={targets.size === 0 || oauthLogin.state === "starting" || busy}
+              onClick={startOauthLogin}
+            >
+              {oauthLogin.state === "starting" || busy ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : isConnected ? (
+                "Sign in"
+              ) : (
+                "Connect & sign in"
+              )}
+            </Button>
+          )}
+          {oauthLogin.state === "error" && (
+            <p className="mt-2 text-[12px] text-destructive">{oauthLogin.error}</p>
+          )}
+        </div>
       ) : (
         <Button
           className="mt-4 w-full"
@@ -605,6 +835,12 @@ export function ConnectPanel({
         </Button>
       )}
 
+      {entry.transport === "http" && !isM365 && authState === "authenticated" && (
+        <p className="mt-2 flex items-center gap-1.5 text-[12px] text-emerald-600 dark:text-emerald-400">
+          <Check className="h-3.5 w-3.5 shrink-0" /> Signed in — ready for your agents.
+        </p>
+      )}
+
       {isConnected && (
         <button
           type="button"
@@ -616,10 +852,11 @@ export function ConnectPanel({
         </button>
       )}
 
-      {entry.transport === "http" && (
+      {entry.transport === "http" && !isM365 && !canConnectTimeSignin && !isConnected && (
         <p className="mt-3 flex items-start gap-1.5 text-[11px] text-muted-foreground">
           <ShieldCheck className="mt-0.5 h-3 w-3 shrink-0" />
-          The CLI opens a browser to finish sign-in the first time an agent uses it.
+          Select Claude Code above to sign in now. Otherwise the CLI prompts for
+          sign-in the first time an agent uses it.
         </p>
       )}
 

--- a/src/lib/agents/claude-mcp-login.ts
+++ b/src/lib/agents/claude-mcp-login.ts
@@ -1,0 +1,362 @@
+/**
+ * Drives Claude Code's MCP OAuth sign-in from Cabinet's own backend, so the
+ * connect panel can authenticate an HTTP (remote/OAuth) MCP server *at connect
+ * time* — instead of deferring it to the first agent run.
+ *
+ * Why this exists: Cabinet agents run by spawning a CLI (Claude Code), and that
+ * CLI is the MCP client that owns the OAuth token. For an HTTP server the CLI
+ * does an authorization-code + PKCE flow with an ephemeral loopback redirect
+ * (http://localhost:<port>/callback). Deferring this to the first agent use is
+ * broken: a one-shot task ends the moment it answers, killing the CLI process
+ * and its loopback listener — so by the time the user clicks the surfaced link
+ * the callback hits a dead port ("This site can't be reached") and the in-flight
+ * PKCE state is gone. See microsoft-login.ts for the same idea on M365.
+ *
+ * The fix: keep ONE `claude` process alive across the human approval step. We
+ * spawn it in stream-json mode (stdin stays open → process + loopback stay
+ * alive), tell it to call the server's `authenticate` helper tool, and parse the
+ * authorization URL it returns. When the user approves in the browser, the live
+ * loopback catches the callback and Claude Code persists the token to disk — we
+ * detect that via `claude mcp get <server>` flipping off "Needs authentication".
+ * For remote/headless setups where the browser can't reach localhost, the user
+ * can paste the callback URL and we forward it to `complete_authentication`.
+ *
+ * Claude Code only. Other CLIs keep the deferred (first-use) flow for now.
+ *
+ * The session registry is stashed on globalThis so it survives Next.js HMR in
+ * dev. This is a local, single-instance feature — no cross-process store needed.
+ */
+
+import { spawn, execFile, type ChildProcess } from "child_process";
+import { randomUUID } from "crypto";
+import { claudeCodeProvider } from "./providers/claude-code";
+import { getRuntimePath, resolveCliCommand } from "./provider-cli";
+
+export type McpLoginStatus = "pending" | "success" | "error" | "expired";
+
+interface McpLoginSession {
+  id: string;
+  /** The `cabinet-<id>` MCP server name as written into the CLI config. */
+  serverName: string;
+  proc: ChildProcess;
+  status: McpLoginStatus;
+  /** Authorization URL parsed from the `authenticate` tool result. */
+  authorizeUrl?: string;
+  error?: string;
+  startedAt: number;
+  /** When the session reached a terminal state. */
+  finishedAt?: number;
+  cleanupTimer?: ReturnType<typeof setTimeout>;
+  /** Polls `claude mcp get` until the server stops needing auth. */
+  statusPoll?: ReturnType<typeof setInterval>;
+  output: string;
+}
+
+const g = globalThis as unknown as {
+  __claudeMcpLoginSessions?: Map<string, McpLoginSession>;
+};
+const sessions = (g.__claudeMcpLoginSessions ??= new Map<string, McpLoginSession>());
+
+/** OAuth flows are short-lived; give the user a generous window to approve. */
+const LOGIN_TIMEOUT_MS = 10 * 60 * 1000;
+/** Allow first-run `npx`/cold start + the model to call authenticate. */
+const URL_WAIT_MS = 120_000;
+/** Keep a finished session briefly so the client can read the final status. */
+const COMPLETED_TTL_MS = 5 * 60 * 1000;
+/** How often to check whether the server has finished authenticating. */
+const STATUS_POLL_MS = 2500;
+
+function markTerminal(
+  session: McpLoginSession,
+  status: Exclude<McpLoginStatus, "pending">,
+): void {
+  if (session.status === "pending") session.status = status;
+  if (session.finishedAt == null) session.finishedAt = Date.now();
+  if (session.statusPoll) {
+    clearInterval(session.statusPoll);
+    session.statusPoll = undefined;
+  }
+  // The flow is done; release the held `claude` process (and its loopback).
+  try {
+    session.proc.stdin?.end();
+  } catch {
+    /* already closed */
+  }
+  try {
+    session.proc.kill();
+  } catch {
+    /* already gone */
+  }
+  if (!session.cleanupTimer) {
+    session.cleanupTimer = setTimeout(() => sessions.delete(session.id), COMPLETED_TTL_MS);
+    session.cleanupTimer.unref?.();
+  }
+}
+
+/** Reaper covering cleanup timers lost across an HMR reload. */
+function sweepSessions(): void {
+  const now = Date.now();
+  for (const [sid, s] of sessions) {
+    if (s.status !== "pending") {
+      if (s.finishedAt != null && now - s.finishedAt > COMPLETED_TTL_MS) {
+        sessions.delete(sid);
+      }
+    } else if (now - s.startedAt > LOGIN_TIMEOUT_MS + COMPLETED_TTL_MS) {
+      try {
+        s.proc.kill();
+      } catch {
+        /* already gone */
+      }
+      sessions.delete(sid);
+    }
+  }
+}
+
+function claudeCommand(): string {
+  return resolveCliCommand(claudeCodeProvider);
+}
+
+function claudeEnv(): NodeJS.ProcessEnv {
+  // Match the runtime PATH the provider uses so nvm/homebrew `claude` resolves.
+  return { ...process.env, PATH: getRuntimePath() };
+}
+
+/** A stream-json user turn, newline-delimited on the child's stdin. */
+function userMessage(text: string): string {
+  return (
+    JSON.stringify({
+      type: "user",
+      message: { role: "user", content: [{ type: "text", text }] },
+    }) + "\n"
+  );
+}
+
+/**
+ * The authorization URL is the first http(s) URL carrying OAuth params. Matching
+ * on `redirect_uri`/`code_challenge` keeps this provider-agnostic (Notion,
+ * GitHub, Linear, …) rather than hard-coding a host.
+ */
+function parseAuthorizeUrl(text: string): string | undefined {
+  const urls = text.match(/https?:\/\/[^\s"'`\\]+/g);
+  if (!urls) return undefined;
+  return urls.find((u) => /redirect_uri=|code_challenge=|client_id=/.test(u));
+}
+
+/**
+ * Read the server's connection status from a *separate* process, which only
+ * succeeds once Claude Code has persisted the OAuth token to disk. Resolves:
+ *   - "authenticated": connected / no longer needs auth
+ *   - "needs-auth":    still awaiting sign-in
+ *   - "unknown":       couldn't tell (treat as still pending)
+ */
+export function readServerAuthState(
+  serverName: string,
+): Promise<"authenticated" | "needs-auth" | "unknown"> {
+  return new Promise((resolve) => {
+    execFile(
+      claudeCommand(),
+      ["mcp", "get", serverName],
+      { env: claudeEnv(), timeout: 8000 },
+      (err, stdout) => {
+        const out = `${stdout ?? ""}`;
+        if (/needs authentication/i.test(out)) return resolve("needs-auth");
+        if (/\bconnected\b/i.test(out)) return resolve("authenticated");
+        if (err) return resolve("unknown");
+        // Got a clean read with neither marker → server is configured and not
+        // flagged as needing auth, so treat as authenticated.
+        return resolve(out.includes(serverName) ? "authenticated" : "unknown");
+      },
+    );
+  });
+}
+
+export interface McpLoginStartResult {
+  sessionId: string;
+  /** Present when a fresh sign-in is needed. */
+  authorizeUrl?: string;
+  /** True when the server was already authenticated — nothing to do. */
+  alreadyAuthenticated?: boolean;
+}
+
+/**
+ * Begin an OAuth sign-in for `serverName`. Resolves once the authorization URL
+ * is available (or immediately if already authenticated). The child keeps
+ * running so its loopback can catch the callback; poll `getMcpLoginStatus`.
+ *
+ * Precondition: the server must already be registered in Claude Code's config
+ * (so its `authenticate` helper tool exists). The connect route writes it first.
+ */
+export async function startMcpLogin(serverName: string): Promise<McpLoginStartResult> {
+  sweepSessions();
+
+  // Fast path: nothing to do if it's already signed in.
+  if ((await readServerAuthState(serverName)) === "authenticated") {
+    const id = randomUUID();
+    const session: McpLoginSession = {
+      id,
+      serverName,
+      proc: { kill() {}, stdin: null } as unknown as ChildProcess,
+      status: "success",
+      startedAt: Date.now(),
+      finishedAt: Date.now(),
+      output: "",
+    };
+    sessions.set(id, session);
+    session.cleanupTimer = setTimeout(() => sessions.delete(id), COMPLETED_TTL_MS);
+    session.cleanupTimer.unref?.();
+    return { sessionId: id, alreadyAuthenticated: true };
+  }
+
+  const id = randomUUID();
+  const authTool = `mcp__${serverName}__authenticate`;
+  const completeTool = `mcp__${serverName}__complete_authentication`;
+  const proc = spawn(
+    claudeCommand(),
+    [
+      "--dangerously-skip-permissions",
+      "-p",
+      "--input-format",
+      "stream-json",
+      "--output-format",
+      "stream-json",
+      "--verbose",
+      // Restrict to just the OAuth helpers so the model reliably calls them and
+      // can't wander off doing anything else.
+      "--allowedTools",
+      authTool,
+      completeTool,
+    ],
+    { env: claudeEnv(), stdio: ["pipe", "pipe", "pipe"] },
+  );
+
+  const session: McpLoginSession = {
+    id,
+    serverName,
+    proc,
+    status: "pending",
+    startedAt: Date.now(),
+    output: "",
+  };
+  sessions.set(id, session);
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const fail = (message: string) => {
+      if (!session.error) session.error = message;
+      markTerminal(session, "error");
+      if (!settled) {
+        settled = true;
+        reject(new Error(message));
+      }
+    };
+
+    const onData = (buf: Buffer) => {
+      session.output += buf.toString();
+      if (!session.authorizeUrl) {
+        const url = parseAuthorizeUrl(session.output);
+        if (url) {
+          session.authorizeUrl = url;
+          if (!settled) {
+            settled = true;
+            // Start watching for the user to finish in the browser.
+            session.statusPoll = setInterval(() => {
+              void readServerAuthState(serverName).then((state) => {
+                if (state === "authenticated") markTerminal(session, "success");
+              });
+            }, STATUS_POLL_MS);
+            session.statusPoll.unref?.();
+            resolve({ sessionId: id, authorizeUrl: url });
+          }
+        }
+      }
+    };
+
+    proc.stdout?.on("data", onData);
+    proc.stderr?.on("data", onData);
+    proc.on("error", (err) => fail(err.message));
+    proc.on("exit", () => {
+      // If the process dies before we got a URL, the start failed. If it dies
+      // after, the loopback is gone — but a poll may still confirm success
+      // (token persisted), so only flip to error when not already authenticated.
+      if (!settled) {
+        fail(session.error ?? "Sign-in ended before an authorization URL was issued");
+        return;
+      }
+      if (session.status === "pending") {
+        void readServerAuthState(serverName).then((state) => {
+          if (state === "authenticated") markTerminal(session, "success");
+          else fail("The sign-in process exited before authorization completed.");
+        });
+      }
+    });
+
+    // Kick off the flow.
+    try {
+      proc.stdin?.write(
+        userMessage(
+          `Call the ${authTool} tool now and then output ONLY the authorization URL it returns, nothing else. Do not call any other tool.`,
+        ),
+      );
+    } catch (err) {
+      fail(err instanceof Error ? err.message : "Could not write to sign-in process");
+    }
+
+    setTimeout(() => {
+      if (!settled) fail("Timed out waiting for the authorization URL");
+    }, URL_WAIT_MS);
+  });
+}
+
+export function getMcpLoginStatus(sessionId: string): {
+  status: McpLoginStatus;
+  authorizeUrl?: string;
+  error?: string;
+} | null {
+  const s = sessions.get(sessionId);
+  if (!s) return null;
+  if (s.status === "pending" && Date.now() - s.startedAt > LOGIN_TIMEOUT_MS) {
+    markTerminal(s, "expired");
+  }
+  return { status: s.status, authorizeUrl: s.authorizeUrl, error: s.error };
+}
+
+/**
+ * Fallback for when the browser can't reach the loopback (remote/headless): the
+ * user pastes the full `http://localhost:<port>/callback?code=...&state=...` URL
+ * and we forward it to the server's `complete_authentication` tool on the SAME
+ * live process (which still holds the in-flight PKCE state).
+ */
+export function completeMcpLogin(sessionId: string, callbackUrl: string): boolean {
+  const s = sessions.get(sessionId);
+  if (!s || s.status !== "pending") return false;
+  const completeTool = `mcp__${s.serverName}__complete_authentication`;
+  try {
+    s.proc.stdin?.write(
+      userMessage(
+        `Call the ${completeTool} tool with callback_url set to exactly: ${callbackUrl}`,
+      ),
+    );
+  } catch {
+    return false;
+  }
+  return true;
+}
+
+export function cancelMcpLogin(sessionId: string): boolean {
+  const s = sessions.get(sessionId);
+  if (!s) return false;
+  if (s.cleanupTimer) clearTimeout(s.cleanupTimer);
+  if (s.statusPoll) clearInterval(s.statusPoll);
+  try {
+    s.proc.stdin?.end();
+  } catch {
+    /* already closed */
+  }
+  try {
+    s.proc.kill();
+  } catch {
+    /* already gone */
+  }
+  sessions.delete(sessionId);
+  return true;
+}

--- a/src/lib/agents/mcp-catalog.ts
+++ b/src/lib/agents/mcp-catalog.ts
@@ -237,8 +237,8 @@ const NOTION: CatalogEntry = {
   ],
   setupSteps: [
     {
-      title: "Sign in with Notion",
-      body: "Click Connect & sign in — your agent's CLI opens Notion in the browser. Approve access and pick which pages or databases to share.",
+      title: "Connect Notion",
+      body: "Click Connect to register Notion. The first time an agent uses it, its CLI opens Notion in the browser — approve access and pick which pages or databases to share.",
     },
     {
       title: "Choose what to share",

--- a/src/lib/integrations/preview-catalog.ts
+++ b/src/lib/integrations/preview-catalog.ts
@@ -642,6 +642,7 @@ const LAUNCHED = new Set([
   "google-drive",
   "gmail",
   "microsoft-365",
+  "notion",
 ]);
 
 export const PREVIEW_INTEGRATIONS: IntegrationItem[] = RAW_INTEGRATIONS.map((i) => {


### PR DESCRIPTION
Launched Notion in the Integrations Hub catalog and corrected misleading "sign-in on first use" copy (preview-catalog.ts, mcp-catalog.ts).

Fixed the broken OAuth flow permanently by driving connect-time sign-in through a persistent Claude Code session whose loopback stays alive across approval, with a paste-callback fallback (claude-mcp-login.ts, oauth/login/route.ts).

Surfaced real auth state in the connect panel so it shows "Signed in" / "Sign in" / "Connect & sign in" accurately instead of conflating registration with authentication (connect-panel.tsx).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP-based integrations now support OAuth sign-in during the connect phase, with browser authorization and callback URL fallback options.
  * Notion integration is now available for use.

* **Documentation**
  * Updated Notion integration setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->