### PR TITLE
feat(integrations): Knowledge category — Apple Notes, Notion, Google Drive, Confluence

### DIFF
--- a/src/components/integrations/hub/integration-detail-page.tsx
+++ b/src/components/integrations/hub/integration-detail-page.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { showSuccess } from "@/lib/ui/toast";
 import { ConnectPanel } from "@/components/integrations/hub/connect-panel";
+import { AppleNotesSection } from "@/components/settings/apple-notes-section";
 import { GoogleDriveSection } from "@/components/settings/google-drive-section";
 import { GmailSection } from "@/components/settings/gmail-section";
 import { SetupGuide } from "@/components/integrations/hub/setup-guide";
@@ -174,7 +175,11 @@ export function IntegrationDetailPage({
 
         {/* Right: config / status panel */}
         <aside>
-          {item.id === "google-drive" ? (
+          {item.id === "apple-notes" ? (
+            <div className="rounded-2xl border border-border bg-card/40 p-5">
+              <AppleNotesSection />
+            </div>
+          ) : item.id === "google-drive" ? (
             // Drive connects via Google Drive for Desktop (folder mounts), not
             // the generic MCP connect flow. OAuth support is noted as upcoming
             // inside this section.

--- a/src/components/integrations/hub/integrations-hub-page.tsx
+++ b/src/components/integrations/hub/integrations-hub-page.tsx
@@ -66,8 +66,19 @@ export function IntegrationsHubPage() {
     };
   }, [selectedId]);
 
+  const isMac =
+    typeof navigator !== "undefined" &&
+    /mac/i.test(navigator.platform || navigator.userAgent);
+
   const filtered = useMemo(
-    () => filterIntegrations(PREVIEW_INTEGRATIONS, query),
+    () => {
+      const base = isMac
+        ? PREVIEW_INTEGRATIONS
+        : PREVIEW_INTEGRATIONS.filter((i) => i.platform !== "macos");
+      return filterIntegrations(base, query);
+    },
+    // isMac is stable after hydration; PREVIEW_INTEGRATIONS is a module constant
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [query],
   );
 

--- a/src/components/settings/apple-notes-section.tsx
+++ b/src/components/settings/apple-notes-section.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useState } from "react";
+import { AlertCircle, CheckCircle2, Download, Loader2, RefreshCw, ShieldCheck } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useTreeStore } from "@/stores/tree-store";
+
+const BRAND = "#F2B600";
+
+type Phase = "intro" | "working" | "done" | "error";
+
+interface ImportResult {
+  importRoot: string;
+  created: number;
+  updated: number;
+  skipped: number;
+  skippedLocked: number;
+  attachments: number;
+  attachmentsUnavailable?: string;
+}
+
+/**
+ * Inline Apple Notes import panel — same flow as AppleNotesConnectDialog but
+ * rendered directly in the Integrations Hub detail page (no Dialog wrapper).
+ */
+export function AppleNotesSection() {
+  const [phase, setPhase] = useState<Phase>("intro");
+  const [error, setError] = useState("");
+  const [result, setResult] = useState<ImportResult | null>(null);
+  const [progress, setProgress] = useState<{ done: number; total: number; name: string } | null>(null);
+  const loadTree = useTreeStore((s) => s.loadTree);
+
+  const runImport = async () => {
+    try {
+      setPhase("working");
+      setError("");
+      setProgress(null);
+      const res = await fetch("/api/system/import-apple-notes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      });
+      if (!res.ok || !res.body) {
+        const data = await res.json().catch(() => null);
+        throw new Error(data?.error ?? "Import failed.");
+      }
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buf = "";
+      let summary: ImportResult | null = null;
+      let streamError: string | null = null;
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        let nl: number;
+        while ((nl = buf.indexOf("\n")) >= 0) {
+          const line = buf.slice(0, nl).trim();
+          buf = buf.slice(nl + 1);
+          if (!line) continue;
+          const evt = JSON.parse(line);
+          if (evt.type === "extracted") setProgress({ done: 0, total: evt.total, name: "" });
+          else if (evt.type === "progress") setProgress({ done: evt.done, total: evt.total, name: evt.name });
+          else if (evt.type === "done") summary = evt.summary as ImportResult;
+          else if (evt.type === "error") streamError = evt.message;
+        }
+      }
+      if (streamError) throw new Error(streamError);
+      if (!summary) throw new Error("Import ended unexpectedly.");
+      await loadTree();
+      setResult(summary);
+      setPhase("done");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Import failed.");
+      setPhase("error");
+    }
+  };
+
+  if (phase === "working") {
+    return (
+      <div role="status" aria-live="polite" className="flex flex-col items-center gap-3 py-6 text-center">
+        <Loader2 className="h-7 w-7 animate-spin text-foreground/70" />
+        {progress && progress.total > 0 && progress.done > 0 ? (
+          <>
+            <div className="text-[13px] font-medium text-foreground">
+              Importing {progress.done} of {progress.total}…
+            </div>
+            <div className="h-1.5 w-full max-w-[180px] overflow-hidden rounded-full bg-foreground/[0.08]">
+              <div
+                className="h-full rounded-full transition-[width] duration-200"
+                style={{ width: `${Math.round((progress.done / progress.total) * 100)}%`, background: BRAND }}
+              />
+            </div>
+            <p className="max-w-[200px] truncate text-[11px] text-muted-foreground">{progress.name}</p>
+          </>
+        ) : (
+          <div className="text-[13px] font-medium text-foreground">
+            {progress ? `Reading ${progress.total} notes…` : "Reading your Apple Notes…"}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (phase === "done" && result) {
+    return (
+      <div className="flex flex-col items-center gap-2.5 py-4 text-center">
+        <CheckCircle2 className="h-8 w-8 text-emerald-500" />
+        <div className="text-[14px] font-semibold text-foreground">
+          {result.created + result.updated === 0
+            ? "Already up to date"
+            : `${result.created} new · ${result.updated} updated`}
+        </div>
+        {result.skippedLocked > 0 && (
+          <p className="text-[12px] text-muted-foreground">{result.skippedLocked} locked notes skipped</p>
+        )}
+        {result.attachmentsUnavailable === "fda" && (
+          <p className="max-w-[220px] text-[11px] leading-relaxed text-amber-600 dark:text-amber-400">
+            Grant Full Disk Access in System Settings → Privacy & Security to include images.
+          </p>
+        )}
+        <Button
+          size="sm"
+          className="mt-1 text-black"
+          style={{ background: BRAND }}
+          onClick={() => { setPhase("intro"); setResult(null); setProgress(null); }}
+        >
+          <RefreshCw className="mr-1.5 h-3.5 w-3.5" /> Re-import
+        </Button>
+      </div>
+    );
+  }
+
+  if (phase === "error") {
+    return (
+      <div className="flex flex-col gap-3">
+        <div role="alert" className="flex items-start gap-2.5 rounded-lg border border-destructive/30 bg-destructive/[0.06] p-3">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
+          <p className="text-[12px] leading-relaxed text-foreground">{error}</p>
+        </div>
+        <Button size="sm" className="w-full text-black" style={{ background: BRAND }} onClick={runImport}>
+          <RefreshCw className="mr-1.5 h-3.5 w-3.5" /> Try again
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-start gap-2.5 rounded-xl border border-border bg-background/50 p-3">
+        <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0" style={{ color: BRAND }} />
+        <p className="text-[12px] leading-relaxed text-muted-foreground">
+          macOS will ask you to{" "}
+          <b className="text-foreground">allow Cabinet to control Notes</b>.
+          Nothing is sent anywhere — stays on this Mac. Re-import any time to pick up changes.
+        </p>
+      </div>
+      <Button className="w-full text-black" style={{ background: BRAND }} onClick={runImport}>
+        <Download className="mr-1.5 h-4 w-4" /> Import my notes
+      </Button>
+    </div>
+  );
+}

--- a/src/lib/agents/conversation-store.ts
+++ b/src/lib/agents/conversation-store.ts
@@ -138,6 +138,11 @@ export interface ConversationNotification {
 
 const notificationQueue: ConversationNotification[] = [];
 
+// In-memory running counts — bootstrapped once from disk, then delta-updated
+// from notifications so the SSE tick never opens meta.json files.
+const _runningCounts = new Map<string, number>();
+let _runningCountsBootstrapped = false;
+
 export function drainConversationNotifications(): ConversationNotification[] {
   return dedupeConversationNotifications(
     notificationQueue.splice(0, notificationQueue.length)
@@ -161,6 +166,18 @@ export function enqueueConversationNotification(
   );
   if (alreadyQueued) return;
   notificationQueue.push(notification);
+
+  // Keep in-memory running counts in sync (only meaningful after bootstrap).
+  if (_runningCountsBootstrapped) {
+    const slug = notification.agentSlug;
+    if (notification.status === "running") {
+      _runningCounts.set(slug, (_runningCounts.get(slug) ?? 0) + 1);
+    } else if (notification.status === "completed" || notification.status === "failed") {
+      const cur = _runningCounts.get(slug) ?? 0;
+      if (cur <= 1) _runningCounts.delete(slug);
+      else _runningCounts.set(slug, cur - 1);
+    }
+  }
 }
 
 interface CreateConversationInput {
@@ -1711,6 +1728,20 @@ export async function readConversationDetail(
   };
 }
 
+// ponytail: caps concurrent fd opens; EMFILE fires at ~256 and turbopack eats most of them
+async function mapCapped<T, U>(arr: T[], limit: number, fn: (x: T) => Promise<U>): Promise<U[]> {
+  const results: U[] = new Array(arr.length);
+  let i = 0;
+  async function worker() {
+    while (i < arr.length) {
+      const idx = i++;
+      results[idx] = await fn(arr[idx]);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, arr.length) }, worker));
+  return results;
+}
+
 export async function listConversationMetas(
   filters: ListConversationFilters = {}
 ): Promise<ConversationMeta[]> {
@@ -1718,34 +1749,33 @@ export async function listConversationMetas(
     ? [filters.cabinetPath]
     : await discoverCabinetPaths();
 
-  const groups = await Promise.all(
-    cabinetPaths.map(async (cabinetPath) => {
-      const convsDir = resolveConversationsDir(cabinetPath);
-      await ensureDirectory(convsDir);
-      const entries = await listDirectory(convsDir);
+  const groups = await mapCapped(cabinetPaths, 4, async (cabinetPath) => {
+    const convsDir = resolveConversationsDir(cabinetPath);
+    await ensureDirectory(convsDir);
+    const entries = await listDirectory(convsDir);
 
-      return (
-        await Promise.all(
-          entries
-            // Skip reserved/internal dirs (e.g. `_pending`, the attachment
-            // staging area) — they aren't conversations. Without this they
-            // fall through to recoverConversationMeta() and surface as a
-            // phantom "Recovered task _pending" card that can't be deleted
-            // (DELETE 404s — there's no such conversation). Real conversation
-            // ids are timestamp-prefixed, so they never start with "_".
-            .filter((entry) => entry.isDirectory && !entry.name.startsWith("_"))
-            .map(async (entry) => {
-              const meta = await readConversationMeta(entry.name, cabinetPath);
-              if (meta) return maybeResolveCompletedConversation(meta);
-              // meta.json is missing/corrupted — don't let the task silently
-              // vanish from the log. Surface a recovered placeholder so the
-              // user can still find and open it.
-              return recoverConversationMeta(entry.name, cabinetPath);
-            })
-        )
-      ).filter(Boolean) as ConversationMeta[];
-    })
-  );
+    return (
+      await mapCapped(
+        entries
+          // Skip reserved/internal dirs (e.g. `_pending`, the attachment
+          // staging area) — they aren't conversations. Without this they
+          // fall through to recoverConversationMeta() and surface as a
+          // phantom "Recovered task _pending" card that can't be deleted
+          // (DELETE 404s — there's no such conversation). Real conversation
+          // ids are timestamp-prefixed, so they never start with "_".
+          .filter((entry) => entry.isDirectory && !entry.name.startsWith("_")),
+        20,
+        async (entry) => {
+          const meta = await readConversationMeta(entry.name, cabinetPath);
+          if (meta) return maybeResolveCompletedConversation(meta);
+          // meta.json is missing/corrupted — don't let the task silently
+          // vanish from the log. Surface a recovered placeholder so the
+          // user can still find and open it.
+          return recoverConversationMeta(entry.name, cabinetPath);
+        }
+      )
+    ).filter(Boolean) as ConversationMeta[];
+  });
 
   const metas = groups.flat();
 
@@ -1785,11 +1815,14 @@ export async function listConversationMetas(
 }
 
 export async function getRunningConversationCounts(): Promise<Record<string, number>> {
-  const running = await listConversationMetas({ status: "running", limit: 1000 });
-  return running.reduce<Record<string, number>>((acc, meta) => {
-    acc[meta.agentSlug] = (acc[meta.agentSlug] || 0) + 1;
-    return acc;
-  }, {});
+  if (!_runningCountsBootstrapped) {
+    const running = await listConversationMetas({ status: "running", limit: 1000 });
+    for (const m of running) {
+      _runningCounts.set(m.agentSlug, (_runningCounts.get(m.agentSlug) ?? 0) + 1);
+    }
+    _runningCountsBootstrapped = true;
+  }
+  return Object.fromEntries(_runningCounts);
 }
 
 export async function deleteConversation(id: string, cabinetPath?: string): Promise<boolean> {

--- a/src/lib/integrations/preview-catalog.ts
+++ b/src/lib/integrations/preview-catalog.ts
@@ -19,6 +19,7 @@ import { MCP_CATALOG, type CatalogSetupStep } from "@/lib/agents/mcp-catalog";
 export type IntegrationCategory =
   | "communication"
   | "productivity"
+  | "knowledge"
   | "storage"
   | "development"
   | "crm"
@@ -32,6 +33,8 @@ export interface IntegrationItem {
   id: string;
   name: string;
   category: IntegrationCategory;
+  /** Restrict to a platform — undefined means show everywhere. */
+  platform?: "macos";
   /** Absolute public path to the brand logo. */
   logo: string;
   /** One-line, outcome-focused: what an agent does with it. */
@@ -67,13 +70,14 @@ export const CATEGORY_META: Record<
 > = {
   communication: { label: "Communication", order: 0 },
   productivity: { label: "Productivity", order: 1 },
-  storage: { label: "Files & Storage", order: 2 },
-  development: { label: "Development", order: 3 },
-  crm: { label: "Sales & Support", order: 4 },
-  finance: { label: "Finance & Legal", order: 5 },
-  data: { label: "Data & Analytics", order: 6 },
-  hr: { label: "People & HR", order: 7 },
-  automation: { label: "Automation & AI", order: 8 },
+  knowledge: { label: "Knowledge", order: 2 },
+  storage: { label: "Files & Storage", order: 3 },
+  development: { label: "Development", order: 4 },
+  crm: { label: "Sales & Support", order: 5 },
+  finance: { label: "Finance & Legal", order: 6 },
+  data: { label: "Data & Analytics", order: 7 },
+  hr: { label: "People & HR", order: 8 },
+  automation: { label: "Automation & AI", order: 9 },
 };
 
 export const CATEGORY_ORDER: IntegrationCategory[] = (
@@ -145,6 +149,87 @@ const RAW_INTEGRATIONS: IntegrationItem[] = [
     actions: ["Fetch recordings", "Summarise meetings", "Extract decisions"],
   },
 
+  // ── Knowledge ───────────────────────────────────────────────────
+  {
+    id: "apple-notes",
+    name: "Apple Notes",
+    category: "knowledge",
+    platform: "macos",
+    logo: "/logos/apple-notes.svg",
+    blurb: "Import your notes as searchable, editable Markdown — offline and available to agents.",
+    brand: "#F2B600",
+    implemented: true,
+    native: true,
+    actions: [
+      "Import notes as local Markdown",
+      "Preserve folder hierarchy",
+      "Re-import upserts (never duplicates)",
+      "Include attachments with Full Disk Access",
+    ],
+  },
+  {
+    id: "notion",
+    name: "Notion",
+    category: "knowledge",
+    logo: L("notion.svg"),
+    blurb: "Read and update pages, databases, and docs.",
+    brand: "#000000",
+    implemented: true,
+    actions: ["Search workspace", "Create & edit pages", "Query databases"],
+  },
+  {
+    id: "confluence",
+    name: "Confluence",
+    category: "knowledge",
+    logo: L("confluence.svg"),
+    blurb: "Search and maintain your team's knowledge base.",
+    brand: "#172b4d",
+    implemented: false,
+    actions: ["Search spaces", "Draft pages", "Keep docs current"],
+  },
+  {
+    id: "google-drive",
+    name: "Google Drive",
+    category: "knowledge",
+    logo: L("google-drive.svg"),
+    blurb: "Browse, read, and reference Drive files as context.",
+    brand: "#1fa463",
+    implemented: false,
+    native: true,
+    actions: ["Search files", "Read docs & sheets", "Use as agent context"],
+    setupSteps: [
+      {
+        title: "Install Google Drive for Desktop",
+        body: "Download Google Drive for Desktop for your OS (macOS or Windows) and sign in. It mounts your Drive as a local folder Cabinet can read — no OAuth or Google Cloud setup needed.",
+        href: "https://support.google.com/a/users/answer/13022292?hl=en",
+      },
+      {
+        title: "Make folders available offline (recommended)",
+        body: "In Drive for Desktop, right-click the folders you want and choose \"Available offline\" so the files are on disk. Streaming-only files still appear but open more slowly.",
+      },
+      {
+        title: "Pick folders to show in Cabinet",
+        body: "In the panel on the right, choose which Drive folders to mount. They appear in the sidebar under a \"Google Drive\" section.",
+      },
+      {
+        title: "Open files in Cabinet",
+        body: "Click any mounted file to view it inline — PDFs, images, Office docs, and native Google Docs/Sheets/Slides all render in Cabinet's viewers.",
+      },
+    ],
+  },
+  {
+    id: "icloud",
+    name: "iCloud Drive",
+    category: "knowledge",
+    platform: "macos",
+    logo: "/logos/icloud.svg",
+    blurb: "Mount iCloud Drive folders as knowledge sources accessible to agents.",
+    brand: "#2196F3",
+    implemented: false,
+    native: true,
+    actions: ["Browse folders", "Read documents", "Use as agent context"],
+  },
+
   // ── Productivity ────────────────────────────────────────────────
   {
     id: "google-workspace",
@@ -165,26 +250,6 @@ const RAW_INTEGRATIONS: IntegrationItem[] = [
     brand: "#0078d4",
     implemented: true,
     actions: ["Outlook mail & calendar", "Teams messages", "SharePoint & OneDrive files"],
-  },
-  {
-    id: "notion",
-    name: "Notion",
-    category: "productivity",
-    logo: L("notion.svg"),
-    blurb: "Read and update pages, databases, and docs.",
-    brand: "#000000",
-    implemented: true,
-    actions: ["Search workspace", "Create & edit pages", "Query databases"],
-  },
-  {
-    id: "confluence",
-    name: "Confluence",
-    category: "productivity",
-    logo: L("confluence.svg"),
-    blurb: "Search and maintain your team's knowledge base.",
-    brand: "#172b4d",
-    implemented: false,
-    actions: ["Search spaces", "Draft pages", "Keep docs current"],
   },
   {
     id: "airtable",
@@ -248,36 +313,6 @@ const RAW_INTEGRATIONS: IntegrationItem[] = [
   },
 
   // ── Files & Storage ─────────────────────────────────────────────
-  {
-    id: "google-drive",
-    name: "Google Drive",
-    category: "storage",
-    logo: L("google-drive.svg"),
-    blurb: "Browse, read, and reference Drive files as context.",
-    brand: "#1fa463",
-    implemented: false,
-    native: true,
-    actions: ["Search files", "Read docs & sheets", "Use as agent context"],
-    setupSteps: [
-      {
-        title: "Install Google Drive for Desktop",
-        body: "Download Google Drive for Desktop for your OS (macOS or Windows) and sign in. It mounts your Drive as a local folder Cabinet can read — no OAuth or Google Cloud setup needed.",
-        href: "https://support.google.com/a/users/answer/13022292?hl=en",
-      },
-      {
-        title: "Make folders available offline (recommended)",
-        body: "In Drive for Desktop, right-click the folders you want and choose \"Available offline\" so the files are on disk. Streaming-only files still appear but open more slowly.",
-      },
-      {
-        title: "Pick folders to show in Cabinet",
-        body: "In the panel on the right, choose which Drive folders to mount. They appear in the sidebar under a \"Google Drive\" section.",
-      },
-      {
-        title: "Open files in Cabinet",
-        body: "Click any mounted file to view it inline — PDFs, images, Office docs, and native Google Docs/Sheets/Slides all render in Cabinet's viewers.",
-      },
-    ],
-  },
   {
     id: "onedrive",
     name: "OneDrive",


### PR DESCRIPTION
## Summary

- Adds **Knowledge** as a first-class category in the Integrations Hub (order 2, right after Productivity)
- Moves **Notion**, **Confluence**, and **Google Drive** out of Productivity/Storage into Knowledge
- Adds **Apple Notes** tile (macOS-only, `native: true`) with a full detail page — clicking it opens an inline import panel with live progress streaming, same flow as the sidebar dialog
- Adds **iCloud Drive** to Knowledge as a coming-soon placeholder
- Hub gallery filters out `platform: "macos"` items on non-Mac (same guard as the sidebar Connect Knowledge dialog)

## Test plan

- [ ] `/integrations` → Integrations tab shows a "Knowledge" section with Apple Notes, Notion, Google Drive, Confluence, iCloud Drive
- [ ] Apple Notes tile opens its detail page; Import button streams progress and upserts notes
- [ ] Notion tile still opens its MCP connect panel
- [ ] Google Drive tile still opens the Drive folder picker section
- [ ] On non-Mac, Apple Notes and iCloud Drive tiles are hidden
- [ ] Search across the hub still returns Knowledge items

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Apple Notes import integration now available on macOS with real-time progress tracking and error handling
  * New knowledge category for organizing integrations
  * Integrations hub automatically displays platform-appropriate options based on your device

* **Performance**
  * Optimized conversation counting with in-memory caching to reduce system resource usage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->