### PR TITLE
feat(editor): add LaTeX .tex embed rendering and file viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ skills-lock.json
 # installed skills bundles (per-machine; managed by Settings -> Skills)
 .agents/skills/
 .agents/skills-stats.json
+
+# latex.js static assets copied from node_modules by postinstall
+/public/latex-js/

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "jspdf": "^4.2.1",
     "jszip": "^3.10.1",
     "katex": "^0.16.45",
+    "latex.js": "^0.12.6",
     "lowlight": "^3.3.0",
     "lucide-react": "^0.577.0",
     "mermaid": "^11.14.0",

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -75,7 +75,11 @@ if (fs.existsSync(latexJsDist)) {
     }
     console.log("[cabinet] postinstall: latex.js assets copied to public/latex-js/");
   } catch (err) {
-    console.warn("[cabinet] postinstall: failed to copy latex.js assets:", err);
+    // A failed copy leaves the LaTeX embed iframe unable to load /latex-js/
+    // assets at runtime, so surface it as an error and fail the install rather
+    // than letting a broken build slip through.
+    console.error("[cabinet] postinstall: failed to copy latex.js assets:", err);
+    process.exitCode = 1;
   }
 }
 

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -52,6 +52,46 @@ for (const { label, cmd, target } of macFixes) {
   }
 }
 
+// Copy latex.js static assets (CSS, JS, fonts, document classes) to
+// public/latex-js/ so the LaTeX embed iframe can load them at /latex-js/.
+const latexJsDist = path.join("node_modules", "latex.js", "dist");
+const latexJsPublic = path.join("public", "latex-js");
+if (fs.existsSync(latexJsDist)) {
+  try {
+    fs.rmSync(latexJsPublic, { recursive: true, force: true });
+    fs.mkdirSync(latexJsPublic, { recursive: true });
+    for (const dir of ["css", "js", "fonts", "documentclasses", "packages"]) {
+      const src = path.join(latexJsDist, dir);
+      if (fs.existsSync(src)) {
+        copyDirRecursive(src, path.join(latexJsPublic, dir));
+      }
+    }
+    // Copy the main library files (parser + custom element)
+    for (const file of ["latex.mjs", "latex.js"]) {
+      const src = path.join(latexJsDist, file);
+      if (fs.existsSync(src)) {
+        fs.copyFileSync(src, path.join(latexJsPublic, file));
+      }
+    }
+    console.log("[cabinet] postinstall: latex.js assets copied to public/latex-js/");
+  } catch (err) {
+    console.warn("[cabinet] postinstall: failed to copy latex.js assets:", err);
+  }
+}
+
+function copyDirRecursive(src, dest) {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDirRecursive(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
 // better-sqlite3 prebuilds ship for a specific NODE_MODULE_VERSION; if the
 // user's runtime doesn't match, rebuild from source so the daemon boots
 // cleanly regardless of which Node version is active.

--- a/src/app/api/assets/[...path]/route.ts
+++ b/src/app/api/assets/[...path]/route.ts
@@ -44,6 +44,15 @@ const MIME_TYPES: Record<string, string> = {
   ".ipynb": "application/json",
 };
 
+// Editable text sources (LaTeX, CSV, markdown, notebooks, …) are viewed in-app
+// and re-rendered after edits or after being replaced on disk, so a long
+// browser cache would show stale content. Binary assets (images, fonts, video)
+// keep a long cache. Shared by both the local and mounted-Drive branches.
+const NO_CACHE_EXTS = new Set([
+  ".html", ".tex", ".csv", ".md", ".markdown", ".txt",
+  ".json", ".xml", ".yaml", ".yml", ".ipynb",
+]);
+
 type RouteParams = { params: Promise<{ path: string[] }> };
 
 export async function GET(req: NextRequest, { params }: RouteParams) {
@@ -92,6 +101,11 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
         const totalSize = stat.size;
         const ext = path.extname(realNormalized).toLowerCase();
         const contentType = MIME_TYPES[ext] || "application/octet-stream";
+        // Mounted Drive content is private; editable text still needs
+        // revalidation so in-app edits/replacements aren't served stale.
+        const cacheControl = NO_CACHE_EXTS.has(ext)
+          ? "private, no-cache, must-revalidate"
+          : "private, max-age=60";
 
         const rangeHeader = req.headers.get("range");
         if (rangeHeader) {
@@ -120,7 +134,7 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
                     "Content-Length": String(size),
                     "Content-Range": `bytes ${start}-${end}/${totalSize}`,
                     "Accept-Ranges": "bytes",
-                    "Cache-Control": "private, max-age=60",
+                    "Cache-Control": cacheControl,
                   },
                 });
               } finally {
@@ -140,7 +154,7 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
             "Content-Type": contentType,
             "Content-Length": String(totalSize),
             "Accept-Ranges": "bytes",
-            "Cache-Control": "private, max-age=60",
+            "Cache-Control": cacheControl,
           },
         });
       } catch {
@@ -160,16 +174,9 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
     const totalSize = stat.size;
     // HTML assets back in-Cabinet apps/websites that the user re-generates
     // (audit slideshows, dashboards, etc.). A 1h max-age served stale builds
-    // until the cache expired. Force revalidation on every fetch — the
-    // payload is small and the win on developer/UX feedback is large.
-    // Editable text sources (LaTeX, CSV, markdown, notebooks, …) get the same
-    // treatment: they're viewed in-app and re-rendered after edits or after
-    // being replaced on disk, so a long browser cache shows stale content.
-    // Binary assets (images, fonts, video) keep the long cache.
-    const NO_CACHE_EXTS = new Set([
-      ".html", ".tex", ".csv", ".md", ".markdown", ".txt",
-      ".json", ".xml", ".yaml", ".yml", ".ipynb",
-    ]);
+    // until the cache expired. Force revalidation on every fetch for the
+    // editable text types (see NO_CACHE_EXTS) — the payload is small and the
+    // win on developer/UX feedback is large. Binary assets keep the long cache.
     const cacheControl = NO_CACHE_EXTS.has(ext)
       ? "no-cache, must-revalidate"
       : "public, max-age=3600";

--- a/src/app/api/assets/[...path]/route.ts
+++ b/src/app/api/assets/[...path]/route.ts
@@ -35,6 +35,7 @@ const MIME_TYPES: Record<string, string> = {
   ".xml": "application/xml",
   ".yaml": "text/yaml",
   ".yml": "text/yaml",
+  ".tex": "text/x-tex",
   ".txt": "text/plain",
   ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
   ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
@@ -161,8 +162,15 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
     // (audit slideshows, dashboards, etc.). A 1h max-age served stale builds
     // until the cache expired. Force revalidation on every fetch — the
     // payload is small and the win on developer/UX feedback is large.
+    // Editable text sources (LaTeX, CSV, markdown, notebooks, …) get the same
+    // treatment: they're viewed in-app and re-rendered after edits or after
+    // being replaced on disk, so a long browser cache shows stale content.
     // Binary assets (images, fonts, video) keep the long cache.
-    const cacheControl = ext === ".html"
+    const NO_CACHE_EXTS = new Set([
+      ".html", ".tex", ".csv", ".md", ".markdown", ".txt",
+      ".json", ".xml", ".yaml", ".yml", ".ipynb",
+    ]);
+    const cacheControl = NO_CACHE_EXTS.has(ext)
       ? "no-cache, must-revalidate"
       : "public, max-age=3600";
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -777,6 +777,86 @@ html[lang^="zh-Hant"] h1.font-ui, html[lang^="zh-Hant"] h2.font-ui {
   background: color-mix(in oklch, var(--primary) 12%, transparent);
 }
 
+/* LaTeX viewer (KaTeX-based renderer) */
+.latex-rendered .latex-sc {
+  font-variant: small-caps;
+}
+.latex-rendered .latex-center {
+  text-align: center;
+}
+.latex-rendered .latex-abstract {
+  margin: 1.5rem 0;
+  padding: 0 1.5rem;
+  font-size: 0.95em;
+}
+.latex-rendered .latex-abstract > h4 {
+  text-align: center;
+  margin: 0 0 0.5rem;
+}
+.latex-rendered .latex-verbatim {
+  white-space: pre-wrap;
+}
+.latex-rendered .latex-math-error {
+  color: #dc2626;
+  background: color-mix(in oklch, #dc2626 10%, transparent);
+  padding: 0.05rem 0.25rem;
+  border-radius: 0.2rem;
+}
+.latex-rendered .katex-display {
+  padding: 0.25rem 0;
+}
+/* Only un-numbered display math scrolls horizontally. KaTeX centers numbered
+   equations with two `.mtr-glue { width: 50% }` columns; making that box a
+   scroll container rounds them to just over 100% and leaves a permanent
+   sub-pixel scrollbar. The renderer tags safe blocks with `.katex-scrollable`
+   (no `:has()` needed, so it works in any browser/Electron version). */
+.latex-rendered .katex-display.katex-scrollable {
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+/* Stylized TeX / LaTeX logos (\TeX, \LaTeX, \LaTeXe macros) */
+.latex-rendered .latex-logo,
+.latex-rendered .tex-logo {
+  font-family: "Latin Modern Roman", "CMU Serif", Georgia, serif;
+  letter-spacing: normal;
+  white-space: nowrap;
+}
+.latex-rendered .latex-logo .latex-a {
+  font-size: 0.75em;
+  vertical-align: 0.3em;
+  margin-left: -0.36em;
+  margin-right: -0.15em;
+}
+.latex-rendered .tex-logo .tex-e {
+  font-size: 1em;
+  vertical-align: -0.5ex;
+  margin-left: -0.1667em;
+  margin-right: -0.125em;
+  text-transform: uppercase;
+}
+.latex-rendered .latex-logo .latex-2e {
+  margin-left: -0.1em;
+  vertical-align: -0.5ex;
+}
+
+/* \maketitle title block */
+.latex-rendered .latex-titleblock {
+  text-align: center;
+  margin: 0 0 2rem;
+}
+.latex-rendered .latex-titleblock .latex-doc-title {
+  margin: 0 0 0.5rem;
+}
+.latex-rendered .latex-titleblock .latex-doc-author {
+  font-size: 1.1em;
+  margin: 0.25rem 0;
+}
+.latex-rendered .latex-titleblock .latex-doc-date {
+  margin: 0.25rem 0;
+  opacity: 0.8;
+}
+
 /* Text-align utility (TextAlign extension renders inline style attr,
    but also add a fallback for older content) */
 .tiptap [style*="text-align: center"] { text-align: center; }

--- a/src/components/editor/extensions.ts
+++ b/src/components/editor/extensions.ts
@@ -26,6 +26,7 @@ import { WikiLink } from "./wiki-link-extension";
 import { CalloutExtension } from "./callout-extension";
 import { ResizableImage } from "./extensions/resizable-image";
 import { EmbedExtension } from "./extensions/embed-extension";
+import { LatexEmbedExtension } from "./extensions/latex-extension";
 import { colorAndStyleExtensions } from "./extensions/color-highlight";
 import { DragHandle } from "./extensions/drag-handle";
 import { CabinetMath } from "./extensions/math-extension";
@@ -138,6 +139,7 @@ export const editorExtensions = [
   }),
   ...colorAndStyleExtensions,
   EmbedExtension,
+  LatexEmbedExtension,
   DragHandle,
   CabinetMath,
   IconExtension,

--- a/src/components/editor/extensions/latex-extension.tsx
+++ b/src/components/editor/extensions/latex-extension.tsx
@@ -273,8 +273,9 @@ function LatexEmbedView({ node, selected }: NodeViewProps) {
         setContent(newContent);
         setDirty(false);
       } catch (err) {
+        // Leave `dirty` set so the unsaved-changes indicator stays visible
+        // when the write fails.
         setError(err instanceof Error ? err.message : String(err));
-        setDirty(false);
       }
     }
   }, [content, virtualPath]);

--- a/src/components/editor/extensions/latex-extension.tsx
+++ b/src/components/editor/extensions/latex-extension.tsx
@@ -138,44 +138,58 @@ function buildLatexIframeDoc(texSource: string): string {
 </head>
 <body>
   <div id="latex-output"></div>
-  <script type="module">
-    import { parse, HtmlGenerator } from '/latex-js/latex.mjs';
-    try {
-      const texSource = ${texJson};
-      const generator = new HtmlGenerator({ hyphenate: true });
-      const result = parse(texSource, { generator });
-      const output = document.getElementById('latex-output');
+  <!--
+    Load latex.js as a classic UMD script (exposes window.latexjs) rather than
+    an ES module. The frame is sandboxed WITHOUT allow-same-origin, which gives
+    it an opaque origin; an ES module import of /latex-js/latex.mjs would be a
+    CORS-gated fetch and fail, while a classic <script src> is not CORS-gated.
+  -->
+  <script src="/latex-js/latex.js"></script>
+  <script>
+    (function () {
+      var output = document.getElementById('latex-output');
+      // The parent can't measure this frame cross-origin (no allow-same-origin),
+      // so report the rendered height back over postMessage for auto-resize.
+      function postHeight() {
+        var h = document.documentElement.scrollHeight;
+        if (h > 0) parent.postMessage({ type: 'cabinet:latex-height', height: h }, '*');
+      }
+      try {
+        var texSource = ${texJson};
+        var generator = new window.latexjs.HtmlGenerator({ hyphenate: true });
+        var result = window.latexjs.parse(texSource, { generator: generator });
 
-      // Inject styles (katex.css, article.css) and scripts (base.js)
-      output.appendChild(result.stylesAndScripts('/latex-js/'));
+        // Inject styles (katex.css, article.css) and scripts (base.js)
+        output.appendChild(result.stylesAndScripts('/latex-js/'));
 
-      // Inject the rendered DOM
-      const page = document.createElement('div');
-      page.setAttribute('class', 'page');
-      page.appendChild(result.domFragment());
-      output.appendChild(page);
+        // Inject the rendered DOM
+        var page = document.createElement('div');
+        page.setAttribute('class', 'page');
+        page.appendChild(result.domFragment());
+        output.appendChild(page);
 
-      // Apply CSS custom properties for page geometry
-      result.applyLengthsAndGeometryToDom(document.documentElement);
+        // Apply CSS custom properties for page geometry
+        result.applyLengthsAndGeometryToDom(document.documentElement);
 
-      // Also load the CMU fonts stylesheet
-      const fontLink = document.createElement('link');
-      fontLink.type = 'text/css';
-      fontLink.rel = 'stylesheet';
-      fontLink.href = '/latex-js/fonts/cmu.css';
-      document.head.appendChild(fontLink);
-    } catch (e) {
-      const output = document.getElementById('latex-output');
-      if (output) {
+        // Also load the CMU fonts stylesheet
+        var fontLink = document.createElement('link');
+        fontLink.type = 'text/css';
+        fontLink.rel = 'stylesheet';
+        fontLink.href = '/latex-js/fonts/cmu.css';
+        document.head.appendChild(fontLink);
+      } catch (e) {
         // Build with the DOM API + textContent so an error message that
         // contains markup can't inject HTML/script into the frame.
-        const errBox = document.createElement('div');
+        var errBox = document.createElement('div');
         errBox.className = 'latex-error';
         errBox.textContent = 'LaTeX parse error: ' + (e.message || 'Unknown error');
         output.replaceChildren(errBox);
+        console.error('LaTeX.js error:', e);
       }
-      console.error('LaTeX.js error:', e);
-    }
+      // Report height now and again after late layout (fonts) settles.
+      requestAnimationFrame(function () { requestAnimationFrame(postHeight); });
+      window.addEventListener('load', postHeight);
+    })();
   </script>
 </body>
 </html>`;
@@ -257,6 +271,22 @@ function LatexEmbedView({ node, selected }: NodeViewProps) {
     if (!iframe) return;
     iframe.srcdoc = buildLatexIframeDoc(content);
   }, [mode, visible, content]);
+
+  // Auto-resize the render frame from the height it posts back. The frame is
+  // sandboxed without allow-same-origin, so we can't read its DOM directly;
+  // match the message to our own iframe by comparing the event source.
+  useEffect(() => {
+    const onMessage = (e: MessageEvent) => {
+      const iframe = iframeRef.current;
+      if (!iframe || e.source !== iframe.contentWindow) return;
+      const data = e.data as { type?: string; height?: number } | null;
+      if (data?.type === "cabinet:latex-height" && typeof data.height === "number") {
+        iframe.style.height = `${data.height + 32}px`;
+      }
+    };
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, []);
 
   // Auto-resize textarea in edit mode
   useEffect(() => {
@@ -386,17 +416,10 @@ function LatexEmbedView({ node, selected }: NodeViewProps) {
               title="LaTeX render"
               className="w-full border-0 bg-white"
               style={{ minHeight: "200px" }}
-              sandbox="allow-scripts allow-same-origin"
-              onLoad={() => {
-                // Auto-resize iframe to fit content
-                try {
-                  const iframe = iframeRef.current;
-                  if (iframe && iframe.contentWindow) {
-                    const height = iframe.contentWindow.document.documentElement.scrollHeight;
-                    if (height > 0) iframe.style.height = `${height + 32}px`;
-                  }
-                } catch {}
-              }}
+              // No allow-same-origin: an opaque origin stops the rendered frame
+              // from reaching back into this document or clearing its own
+              // sandbox. Height is reported via postMessage instead.
+              sandbox="allow-scripts"
             />
           )}
         </div>

--- a/src/components/editor/extensions/latex-extension.tsx
+++ b/src/components/editor/extensions/latex-extension.tsx
@@ -1,0 +1,458 @@
+"use client";
+
+/**
+ * Tiptap extension for embedding and rendering full .tex files inline.
+ *
+ * Recognizes the `![[file.tex]]` embed syntax. When the node mounts, it
+ * resolves the file path relative to the current page and uses the Electron
+ * IPC bridge (or the /api/assets endpoint as fallback) to read the .tex
+ * content. The content is then rendered using LaTeX.js inside an iframe
+ * so that the generated DOM, CSS, and fonts are fully isolated.
+ *
+ * Interaction pattern:
+ *  - Rendered mode: shows the compiled LaTeX document (default).
+ *  - Edit mode: clicking the embed swaps to a textarea with the raw .tex
+ *    source. On blur, the content is saved back to disk and re-rendered.
+ *
+ * Lazy loading: rendering is deferred until the node scrolls into the
+ * viewport via an IntersectionObserver, so pages with many embeds stay fast.
+ */
+
+import { Node, mergeAttributes } from "@tiptap/core";
+import {
+  ReactNodeViewRenderer,
+  NodeViewWrapper,
+  type NodeViewProps,
+} from "@tiptap/react";
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+} from "react";
+import { FileText, Code, Eye, Loader2, AlertCircle } from "lucide-react";
+import { useEditorStore } from "@/stores/editor-store";
+
+/* -------------------------------------------------------------------------- */
+/*  Types                                                                      */
+/* -------------------------------------------------------------------------- */
+
+interface LatexEmbedAttrs {
+  path: string;
+}
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    latexEmbed: {
+      insertLatexEmbed: (options: { path: string }) => ReturnType;
+    };
+  }
+}
+
+type LatexFileBridge = {
+  readFile?: (filePath: string) => Promise<{ ok: boolean; content?: string; error?: string }>;
+  writeFile?: (filePath: string, content: string) => Promise<{ ok: boolean; error?: string }>;
+};
+
+/* -------------------------------------------------------------------------- */
+/*  Path resolution                                                            */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Resolve a .tex file path relative to the current page's directory.
+ * Returns a virtual path suitable for the IPC bridge or /api/assets.
+ */
+function resolveTexPath(texPath: string, pagePath: string | null): string {
+  // Absolute virtual path (starts with /)
+  if (texPath.startsWith("/")) {
+    return texPath.replace(/^\//, "");
+  }
+  // Already a relative path from root
+  if (!pagePath) return texPath;
+
+  // Resolve relative to the page's directory
+  const pageDir = pagePath.includes("/")
+    ? pagePath.substring(0, pagePath.lastIndexOf("/"))
+    : "";
+  return pageDir ? `${pageDir}/${texPath}` : texPath;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  File I/O                                                                    */
+/* -------------------------------------------------------------------------- */
+
+async function readTexFile(virtualPath: string): Promise<string> {
+  const bridge = (window as unknown as { CabinetDesktop?: LatexFileBridge }).CabinetDesktop;
+  if (bridge && bridge.readFile) {
+    const result = await bridge.readFile(virtualPath);
+    if (result.ok && result.content !== undefined) {
+      return result.content;
+    }
+    throw new Error(result.error || "Failed to read file");
+  }
+  // Fallback: use the /api/assets endpoint
+  const res = await fetch(`/api/assets/${virtualPath}`);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.text();
+}
+
+async function writeTexFile(virtualPath: string, content: string): Promise<void> {
+  const bridge = (window as unknown as { CabinetDesktop?: LatexFileBridge }).CabinetDesktop;
+  if (bridge && bridge.writeFile) {
+    const result = await bridge.writeFile(virtualPath, content);
+    if (!result.ok) throw new Error(result.error || "Failed to write file");
+    return;
+  }
+  // Fallback: PUT to /api/assets
+  const res = await fetch(`/api/assets/${virtualPath}`, {
+    method: "PUT",
+    headers: { "Content-Type": "text/plain" },
+    body: content,
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  LaTeX rendering inside an iframe                                           */
+/* -------------------------------------------------------------------------- */
+
+function buildLatexIframeDoc(texSource: string): string {
+  // Safely embed the tex source as a JSON string literal inside a <script>.
+  // JSON.stringify escapes quotes/backslashes/control chars; we also escape
+  // < so that </script> in the source can't prematurely close the tag.
+  const texJson = JSON.stringify(texSource).replace(/</g, "\\u003c");
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <style>
+    body { margin: 0; padding: 1rem; background: transparent; }
+    .latex-error {
+      color: #dc2626; font-family: monospace; font-size: 0.875rem;
+      padding: 1rem; border: 1px solid #fca5a5; border-radius: 0.5rem;
+      background: #fef2f2; white-space: pre-wrap; word-break: break-word;
+    }
+  </style>
+</head>
+<body>
+  <div id="latex-output"></div>
+  <script type="module">
+    import { parse, HtmlGenerator } from '/latex-js/latex.mjs';
+    try {
+      const texSource = ${texJson};
+      const generator = new HtmlGenerator({ hyphenate: true });
+      const result = parse(texSource, { generator });
+      const output = document.getElementById('latex-output');
+
+      // Inject styles (katex.css, article.css) and scripts (base.js)
+      output.appendChild(result.stylesAndScripts('/latex-js/'));
+
+      // Inject the rendered DOM
+      const page = document.createElement('div');
+      page.setAttribute('class', 'page');
+      page.appendChild(result.domFragment());
+      output.appendChild(page);
+
+      // Apply CSS custom properties for page geometry
+      result.applyLengthsAndGeometryToDom(document.documentElement);
+
+      // Also load the CMU fonts stylesheet
+      const fontLink = document.createElement('link');
+      fontLink.type = 'text/css';
+      fontLink.rel = 'stylesheet';
+      fontLink.href = '/latex-js/fonts/cmu.css';
+      document.head.appendChild(fontLink);
+    } catch (e) {
+      const output = document.getElementById('latex-output');
+      if (output) {
+        output.innerHTML = '<div class="latex-error">LaTeX parse error: ' + (e.message || 'Unknown error') + '</div>';
+      }
+      console.error('LaTeX.js error:', e);
+    }
+  </script>
+</body>
+</html>`;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  NodeView component                                                         */
+/* -------------------------------------------------------------------------- */
+
+type ViewMode = "rendered" | "edit";
+
+function LatexEmbedView({ node, selected }: NodeViewProps) {
+  const attrs = node.attrs as LatexEmbedAttrs;
+  const texPath = attrs.path;
+  const pagePath = useEditorStore((s) => s.currentPath);
+
+  const virtualPath = useMemo(
+    () => resolveTexPath(texPath, pagePath),
+    [texPath, pagePath]
+  );
+
+  const [mode, setMode] = useState<ViewMode>("rendered");
+  const [content, setContent] = useState<string>("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [dirty, setDirty] = useState(false);
+  const [visible, setVisible] = useState(false);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const editContentRef = useRef<string>("");
+
+  // Lazy loading: only render when scrolled into view
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          setVisible(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "200px" }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  // Load the .tex file when visible
+  useEffect(() => {
+    if (!visible) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const text = await readTexFile(virtualPath);
+        if (!cancelled) {
+          setContent(text);
+          editContentRef.current = text;
+          setLoading(false);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+          setLoading(false);
+        }
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [visible, virtualPath]);
+
+  // Update iframe srcdoc when content changes in rendered mode
+  useEffect(() => {
+    if (mode !== "rendered" || !visible || !content) return;
+    const iframe = iframeRef.current;
+    if (!iframe) return;
+    iframe.srcdoc = buildLatexIframeDoc(content);
+  }, [mode, visible, content]);
+
+  // Auto-resize textarea in edit mode
+  useEffect(() => {
+    if (mode !== "edit") return;
+    const ta = textareaRef.current;
+    if (ta) {
+      ta.style.height = "auto";
+      ta.style.height = `${Math.max(200, ta.scrollHeight)}px`;
+    }
+  }, [mode, content]);
+
+  const handleSaveAndRender = useCallback(async () => {
+    const newContent = editContentRef.current;
+    setMode("rendered");
+    if (newContent !== content) {
+      setDirty(true);
+      try {
+        await writeTexFile(virtualPath, newContent);
+        setContent(newContent);
+        setDirty(false);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+        setDirty(false);
+      }
+    }
+  }, [content, virtualPath]);
+
+  const handleTextareaChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      editContentRef.current = e.target.value;
+    },
+    []
+  );
+
+  return (
+    <NodeViewWrapper
+      as="div"
+      className="my-3"
+      data-latex-embed="true"
+      data-path={texPath}
+    >
+      <div
+        ref={containerRef}
+        className={`group relative rounded-lg border border-border bg-card overflow-hidden ${
+          selected ? "ring-2 ring-primary" : ""
+        }`}
+        contentEditable={false}
+      >
+        {/* Header bar */}
+        <div className="flex items-center justify-between px-3 py-2 border-b border-border bg-muted/30">
+          <span className="inline-flex items-center gap-1.5 text-xs font-medium text-primary">
+            <FileText className="h-3.5 w-3.5" />
+            {texPath}
+            {dirty && <span className="text-amber-500 ml-1">•</span>}
+          </span>
+          <div className="inline-flex rounded-md border border-border overflow-hidden text-xs">
+            <button
+              type="button"
+              onClick={() => setMode("edit")}
+              className={`inline-flex items-center gap-1 px-2 py-1 transition-colors ${
+                mode === "edit"
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-background text-muted-foreground hover:bg-accent"
+              }`}
+              aria-label="Edit LaTeX source"
+            >
+              <Code className="h-3 w-3" />
+              Edit
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                if (mode === "edit") {
+                  handleSaveAndRender();
+                } else {
+                  setMode("rendered");
+                }
+              }}
+              className={`inline-flex items-center gap-1 px-2 py-1 transition-colors ${
+                mode === "rendered"
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-background text-muted-foreground hover:bg-accent"
+              }`}
+              aria-label="Show rendered LaTeX"
+            >
+              <Eye className="h-3 w-3" />
+              Preview
+            </button>
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className="min-h-30">
+          {!visible ? (
+            <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin mr-2" />
+              Waiting to load…
+            </div>
+          ) : loading ? (
+            <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin mr-2" />
+              Loading LaTeX…
+            </div>
+          ) : error ? (
+            <div className="flex items-start gap-2 p-4 text-sm text-red-600 dark:text-red-400">
+              <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+              <div>
+                <p className="font-semibold">Failed to load .tex file</p>
+                <p className="text-xs mt-1">{error}</p>
+              </div>
+            </div>
+          ) : mode === "edit" ? (
+            <textarea
+              ref={textareaRef}
+              defaultValue={content}
+              onChange={handleTextareaChange}
+              onBlur={handleSaveAndRender}
+              spellCheck={false}
+              className="block w-full bg-zinc-950 p-4 font-mono text-sm leading-relaxed text-zinc-100 outline-none placeholder:text-zinc-500 resize-none"
+              placeholder="LaTeX source…"
+              style={{ minHeight: "200px" }}
+            />
+          ) : (
+            <iframe
+              ref={iframeRef}
+              title="LaTeX render"
+              className="w-full border-0 bg-white"
+              style={{ minHeight: "200px" }}
+              sandbox="allow-scripts allow-same-origin"
+              onLoad={() => {
+                // Auto-resize iframe to fit content
+                try {
+                  const iframe = iframeRef.current;
+                  if (iframe && iframe.contentWindow) {
+                    const height = iframe.contentWindow.document.documentElement.scrollHeight;
+                    if (height > 0) iframe.style.height = `${height + 32}px`;
+                  }
+                } catch {}
+              }}
+            />
+          )}
+        </div>
+      </div>
+    </NodeViewWrapper>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Tiptap Node definition                                                     */
+/* -------------------------------------------------------------------------- */
+
+export const LatexEmbedExtension = Node.create({
+  name: "latexEmbed",
+  group: "block",
+  atom: true,
+  draggable: true,
+  selectable: true,
+
+  addAttributes() {
+    return {
+      path: { default: "" },
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'div[data-latex-embed="true"]',
+        getAttrs: (el) => {
+          const element = el as HTMLElement;
+          return {
+            path: element.getAttribute("data-path") ?? "",
+          };
+        },
+      },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "div",
+      mergeAttributes(
+        { "data-latex-embed": "true" },
+        HTMLAttributes as Record<string, unknown>
+      ),
+    ];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(LatexEmbedView);
+  },
+
+  addCommands() {
+    return {
+      insertLatexEmbed:
+        ({ path }) =>
+        ({ commands }) =>
+          commands.insertContent({
+            type: this.name,
+            attrs: { path },
+          }),
+    };
+  },
+});

--- a/src/components/editor/extensions/latex-extension.tsx
+++ b/src/components/editor/extensions/latex-extension.tsx
@@ -167,7 +167,12 @@ function buildLatexIframeDoc(texSource: string): string {
     } catch (e) {
       const output = document.getElementById('latex-output');
       if (output) {
-        output.innerHTML = '<div class="latex-error">LaTeX parse error: ' + (e.message || 'Unknown error') + '</div>';
+        // Build with the DOM API + textContent so an error message that
+        // contains markup can't inject HTML/script into the frame.
+        const errBox = document.createElement('div');
+        errBox.className = 'latex-error';
+        errBox.textContent = 'LaTeX parse error: ' + (e.message || 'Unknown error');
+        output.replaceChildren(errBox);
       }
       console.error('LaTeX.js error:', e);
     }

--- a/src/components/editor/latex-render.ts
+++ b/src/components/editor/latex-render.ts
@@ -1,0 +1,587 @@
+import katex from "katex";
+
+export interface LatexRenderResult {
+  /** Rendered HTML for the document body. */
+  html: string;
+  /** Names of LaTeX commands/environments encountered that we don't support. */
+  unsupported: string[];
+  /** Whether rendering produced meaningful content. */
+  ok: boolean;
+}
+
+const PLACEHOLDER_OPEN = "\uE000";
+const PLACEHOLDER_CLOSE = "\uE001";
+
+/** Math environments that KaTeX can render in display mode. */
+const MATH_ENVIRONMENTS = [
+  "equation",
+  "equation*",
+  "align",
+  "align*",
+  "alignat",
+  "alignat*",
+  "gather",
+  "gather*",
+  "multline",
+  "multline*",
+  "eqnarray",
+  "eqnarray*",
+];
+
+/** Strip TeX comments (`%` to end of line) while respecting escaped `\%`. */
+function stripComments(input: string): string {
+  return input
+    .split("\n")
+    .map((line) => {
+      let result = "";
+      for (let i = 0; i < line.length; i++) {
+        if (line[i] === "%" && (i === 0 || line[i - 1] !== "\\")) break;
+        result += line[i];
+      }
+      return result;
+    })
+    .join("\n");
+}
+
+/**
+ * Given a string and the index of an opening `{`, return the content between
+ * the matching braces and the index just past the closing `}`.
+ */
+function readBracedArg(str: string, openIndex: number): { content: string; end: number } | null {
+  if (str[openIndex] !== "{") return null;
+  let depth = 0;
+  for (let i = openIndex; i < str.length; i++) {
+    const ch = str[i];
+    if (ch === "{" && str[i - 1] !== "\\") depth++;
+    else if (ch === "}" && str[i - 1] !== "\\") {
+      depth--;
+      if (depth === 0) return { content: str.slice(openIndex + 1, i), end: i + 1 };
+    }
+  }
+  return null;
+}
+
+/** Parse simple `\newcommand`/`\renewcommand` definitions into a KaTeX macro map. */
+function extractMacros(preamble: string): Record<string, string> {
+  const macros: Record<string, string> = {};
+  const re = /\\(?:re)?newcommand\*?\s*\{?\\([a-zA-Z]+)\}?(?:\[(\d+)\])?\s*\{/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(preamble)) !== null) {
+    const name = m[1];
+    const braceStart = re.lastIndex - 1;
+    const arg = readBracedArg(preamble, braceStart);
+    if (arg) {
+      macros[`\\${name}`] = arg.content;
+      re.lastIndex = arg.end;
+    }
+  }
+  return macros;
+}
+
+/** Read the braced argument of a preamble command like \title{...}. */
+function preambleArg(preamble: string, cmd: string): string | null {
+  const re = new RegExp(`\\\\${cmd}\\s*\\{`);
+  const m = re.exec(preamble);
+  if (!m) return null;
+  const arg = readBracedArg(preamble, m.index + m[0].length - 1);
+  return arg ? arg.content : null;
+}
+
+function escapeHtml(str: string): string {
+  return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+interface MathToken {
+  html: string;
+}
+
+/**
+ * Replace all math segments in `body` with placeholder tokens, rendering each
+ * with KaTeX. Returns the modified body and the list of rendered tokens.
+ */
+function extractMath(
+  body: string,
+  macros: Record<string, string>,
+  unsupported: Set<string>,
+): { text: string; tokens: MathToken[] } {
+  const tokens: MathToken[] = [];
+
+  const renderMath = (tex: string, displayMode: boolean): string => {
+    try {
+      const html = katex.renderToString(tex.trim(), {
+        displayMode,
+        throwOnError: false,
+        macros: { ...macros },
+        strict: false,
+        trust: true,
+      });
+      // Only plain (un-numbered) display math may scroll horizontally. KaTeX
+      // centers numbered equations with 50%-wide glue columns; making such a
+      // box a scroll container leaves a permanent sub-pixel scrollbar. Tag the
+      // safe ones explicitly so the CSS doesn't rely on `:has()` support.
+      if (displayMode && !html.includes("eqn-num")) {
+        return html.replace('class="katex-display"', 'class="katex-display katex-scrollable"');
+      }
+      return html;
+    } catch (e) {
+      unsupported.add(`math: ${(e as Error).message}`);
+      return `<code class="latex-math-error">${escapeHtml(tex)}</code>`;
+    }
+  };
+
+  const pushToken = (html: string): string => {
+    tokens.push({ html });
+    return `${PLACEHOLDER_OPEN}${tokens.length - 1}${PLACEHOLDER_CLOSE}`;
+  };
+
+  let text = body;
+
+  // Display math environments: \begin{equation}...\end{equation}, etc.
+  for (const env of MATH_ENVIRONMENTS) {
+    const escaped = env.replace(/[*]/g, "\\*");
+    const re = new RegExp(`\\\\begin\\{${escaped}\\}([\\s\\S]*?)\\\\end\\{${escaped}\\}`, "g");
+    text = text.replace(re, (_full, inner: string) => {
+      // KaTeX understands the aligned/gathered forms when wrapped in the env.
+      const wrapped = `\\begin{${env}}${inner}\\end{${env}}`;
+      return pushToken(renderMath(wrapped, true));
+    });
+  }
+
+  // Display math: \[ ... \] and $$ ... $$
+  text = text.replace(/\\\[([\s\S]*?)\\\]/g, (_full, inner: string) =>
+    pushToken(renderMath(inner, true)),
+  );
+  text = text.replace(/\$\$([\s\S]*?)\$\$/g, (_full, inner: string) =>
+    pushToken(renderMath(inner, true)),
+  );
+
+  // Inline math: \( ... \)
+  text = text.replace(/\\\(([\s\S]*?)\\\)/g, (_full, inner: string) =>
+    pushToken(renderMath(inner, false)),
+  );
+
+  // Inline math: $ ... $ (not $$, already handled). Avoid escaped \$.
+  text = text.replace(/(?<!\\)\$([^$]+?)(?<!\\)\$/g, (_full, inner: string) =>
+    pushToken(renderMath(inner, false)),
+  );
+
+  return { text, tokens };
+}
+
+/** Convert a known list environment body into <li> items. */
+function convertListItems(inner: string, processInline: (s: string) => string): string {
+  const parts = inner.split(/\\item\b/).map((p) => p.trim());
+  // First part before the first \item is usually empty.
+  const items = parts.slice(1);
+  if (items.length === 0) return "";
+  return items.map((it) => `<li>${processInline(it)}</li>`).join("");
+}
+
+/** Inline command handlers: command name -> wrapping HTML tag. */
+const INLINE_WRAPPERS: Record<string, [string, string]> = {
+  textbf: ["<strong>", "</strong>"],
+  textit: ["<em>", "</em>"],
+  emph: ["<em>", "</em>"],
+  textsl: ["<em>", "</em>"],
+  texttt: ["<code>", "</code>"],
+  textsc: ['<span class="latex-sc">', "</span>"],
+  underline: ["<u>", "</u>"],
+  textsuperscript: ["<sup>", "</sup>"],
+  textsubscript: ["<sub>", "</sub>"],
+  text: ["", ""],
+  mbox: ["", ""],
+  mathrm: ["", ""],
+};
+
+/** Commands whose single braced argument should simply be unwrapped. */
+const UNWRAP_COMMANDS = new Set(["small", "large", "Large", "huge", "normalsize", "footnotesize", "tiny", "scriptsize", "bf", "it", "em", "rm", "sf", "tt", "sc", "centering", "raggedright", "raggedleft", "noindent"]);
+
+/** The stylized TeX/LaTeX logos, reproduced with CSS-positioned letters. */
+const TEX_LOGO = '<span class="tex-logo">T<span class="tex-e">e</span>X</span>';
+const LATEX_LOGO = `<span class="latex-logo">L<span class="latex-a">a</span>${TEX_LOGO}</span>`;
+
+/** Format the current date the way LaTeX's \today does: "Month D, YYYY". */
+function todayString(): string {
+  const months = [
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December",
+  ];
+  const d = new Date();
+  return `${months[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`;
+}
+
+/**
+ * Zero-argument text macros that expand to a fixed symbol/markup. These are
+ * built-in LaTeX commands (logos, typographic symbols), not user macros.
+ */
+function textMacro(name: string): string | null {
+  switch (name) {
+    case "LaTeX":
+      return LATEX_LOGO;
+    case "LaTeXe":
+      return `${LATEX_LOGO}<span class="latex-2e">2&#x03b5;</span>`;
+    case "TeX":
+      return TEX_LOGO;
+    case "today":
+      return escapeHtml(todayString());
+    case "copyright":
+      return "&copy;";
+    case "textcopyright":
+      return "&copy;";
+    case "textregistered":
+      return "&reg;";
+    case "texttrademark":
+      return "&trade;";
+    case "pounds":
+    case "textsterling":
+      return "&pound;";
+    case "texteuro":
+    case "euro":
+      return "&euro;";
+    case "dag":
+      return "&dagger;";
+    case "ddag":
+      return "&Dagger;";
+    case "S":
+      return "&sect;";
+    case "P":
+      return "&para;";
+    case "textbackslash":
+      return "\\";
+    case "textbar":
+      return "|";
+    case "textless":
+      return "&lt;";
+    case "textgreater":
+      return "&gt;";
+    case "textasciitilde":
+      return "~";
+    case "textasciicircum":
+      return "^";
+    case "textbullet":
+      return "&bull;";
+    case "textendash":
+      return "&ndash;";
+    case "textemdash":
+      return "&mdash;";
+    default:
+      return null;
+  }
+}
+
+/** Process inline LaTeX commands within already-HTML-escaped text. */
+function processInline(input: string, unsupported: Set<string>): string {
+  let out = "";
+  let i = 0;
+  while (i < input.length) {
+    const ch = input[i];
+
+    if (ch === "\\") {
+      // Line break: \\ or \\[len]
+      if (input[i + 1] === "\\") {
+        let j = i + 2;
+        if (input[j] === "[") {
+          const close = input.indexOf("]", j);
+          if (close !== -1) j = close + 1;
+        }
+        out += "<br/>";
+        i = j;
+        continue;
+      }
+
+      const m = /^\\([a-zA-Z]+)\*?/.exec(input.slice(i));
+      if (m) {
+        const name = m[1];
+        let j = i + m[0].length;
+
+        // Links: \href{url}{text} and \url{url}
+        if (name === "href") {
+          const a1 = input[j] === "{" ? readBracedArg(input, j) : null;
+          if (a1) {
+            const a2 = input[a1.end] === "{" ? readBracedArg(input, a1.end) : null;
+            if (a2) {
+              const url = a1.content.replace(/&amp;/g, "&");
+              out += `<a href="${url}" target="_blank" rel="noopener noreferrer">${processInline(a2.content, unsupported)}</a>`;
+              i = a2.end;
+              continue;
+            }
+          }
+        }
+        if (name === "url") {
+          const a1 = input[j] === "{" ? readBracedArg(input, j) : null;
+          if (a1) {
+            const url = a1.content.replace(/&amp;/g, "&");
+            out += `<a href="${url}" target="_blank" rel="noopener noreferrer">${escapeHtml(url)}</a>`;
+            i = a1.end;
+            continue;
+          }
+        }
+
+        // Wrapping commands: \textbf{...}, \emph{...}, etc.
+        if (name in INLINE_WRAPPERS) {
+          const arg = input[j] === "{" ? readBracedArg(input, j) : null;
+          if (arg) {
+            const [open, close] = INLINE_WRAPPERS[name];
+            out += open + processInline(arg.content, unsupported) + close;
+            i = arg.end;
+            continue;
+          }
+        }
+
+        // Built-in zero-arg text macros: \LaTeX, \TeX, \today, \copyright, …
+        const symbol = textMacro(name);
+        if (symbol !== null) {
+          out += symbol;
+          // Match LaTeX spacing: a brace-less control word (\LaTeX is) gobbles
+          // following spaces, but \LaTeX{} ends the macro and keeps the space.
+          if (input[j] === "{" && input[j + 1] === "}") {
+            j += 2;
+          } else {
+            while (input[j] === " ") j++;
+          }
+          i = j;
+          continue;
+        }
+
+        // Font/size switches inside a group: \small, \bf, etc. -> drop the command.
+        if (UNWRAP_COMMANDS.has(name)) {
+          i = j;
+          continue;
+        }
+
+        // Spacing commands.
+        if (name === "ldots" || name === "dots") {
+          out += "&hellip;";
+          i = j;
+          continue;
+        }
+        if (name === "quad") {
+          out += "&emsp;";
+          i = j;
+          continue;
+        }
+        if (name === "qquad") {
+          out += "&emsp;&emsp;";
+          i = j;
+          continue;
+        }
+
+        // Unknown command: record it, then drop the command but keep any
+        // braced argument content so we don't lose text.
+        unsupported.add(`\\${name}`);
+        if (input[j] === "{") {
+          const arg = readBracedArg(input, j);
+          if (arg) {
+            out += processInline(arg.content, unsupported);
+            i = arg.end;
+            continue;
+          }
+        }
+        i = j;
+        continue;
+      }
+
+      // Escaped special characters: \%, \&, \_, \#, \$, \{, \}
+      const esc = input[i + 1];
+      if (esc && "%&_#${}".includes(esc)) {
+        out += esc === "&" ? "&amp;" : esc;
+        i += 2;
+        continue;
+      }
+      // Non-breaking space style commands: \, \; \: \!
+      if (esc === " " || esc === "," || esc === ";" || esc === ":" || esc === "!") {
+        out += " ";
+        i += 2;
+        continue;
+      }
+      out += "\\";
+      i += 1;
+      continue;
+    }
+
+    // Group braces: keep content, drop braces.
+    if (ch === "{" || ch === "}") {
+      i += 1;
+      continue;
+    }
+
+    if (ch === "~") {
+      out += "&nbsp;";
+      i += 1;
+      continue;
+    }
+
+    out += ch;
+    i += 1;
+  }
+
+  // Typographic replacements.
+  out = out
+    .replace(/---/g, "&mdash;")
+    .replace(/--/g, "&ndash;")
+    .replace(/``/g, "&ldquo;")
+    .replace(/''/g, "&rdquo;")
+    .replace(/`/g, "&lsquo;")
+    .replace(/'/g, "&rsquo;");
+
+  return out;
+}
+
+/** Convert block-level structure (environments, sections) into HTML. */
+function processBlocks(input: string, unsupported: Set<string>): string {
+  let text = input;
+
+  // Known list / text environments. Process innermost-first by repeating.
+  const envHandlers: Record<string, (inner: string) => string> = {
+    itemize: (inner) => `<ul>${convertListItems(inner, (s) => processInline(processBlocks(s, unsupported), unsupported))}</ul>`,
+    enumerate: (inner) => `<ol>${convertListItems(inner, (s) => processInline(processBlocks(s, unsupported), unsupported))}</ol>`,
+    description: (inner) => `<ul>${convertListItems(inner, (s) => processInline(processBlocks(s, unsupported), unsupported))}</ul>`,
+    quote: (inner) => `<blockquote>${processBlocks(inner, unsupported)}</blockquote>`,
+    quotation: (inner) => `<blockquote>${processBlocks(inner, unsupported)}</blockquote>`,
+    center: (inner) => `<div class="latex-center">${processBlocks(inner, unsupported)}</div>`,
+    flushleft: (inner) => `<div style="text-align:left">${processBlocks(inner, unsupported)}</div>`,
+    flushright: (inner) => `<div style="text-align:right">${processBlocks(inner, unsupported)}</div>`,
+    abstract: (inner) => `<div class="latex-abstract"><h4>Abstract</h4>${processBlocks(inner, unsupported)}</div>`,
+    verbatim: (inner) => `<pre class="latex-verbatim">${escapeHtml(inner)}</pre>`,
+  };
+
+  const envRe = /\\begin\{([a-zA-Z*]+)\}([\s\S]*?)\\end\{\1\}/;
+  let guard = 0;
+  while (guard++ < 500) {
+    const match = envRe.exec(text);
+    if (!match) break;
+    const [full, name, inner] = match;
+    const handler = envHandlers[name];
+    let replacement: string;
+    if (handler) {
+      replacement = handler(inner);
+    } else {
+      unsupported.add(`environment: ${name}`);
+      replacement = processBlocks(inner, unsupported);
+    }
+    text = text.slice(0, match.index) + replacement + text.slice(match.index + full.length);
+  }
+
+  return text;
+}
+
+/** Convert sectioning commands into headings. */
+function processSections(input: string, unsupported: Set<string>): string {
+  const levels: Array<[string, string]> = [
+    ["section", "h2"],
+    ["subsection", "h3"],
+    ["subsubsection", "h4"],
+    ["paragraph", "h5"],
+    ["chapter", "h1"],
+  ];
+  let text = input;
+  for (const [cmd, tag] of levels) {
+    const re = new RegExp(`\\\\${cmd}\\*?\\s*\\{`, "g");
+    let result = "";
+    let last = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) {
+      const braceStart = re.lastIndex - 1;
+      const arg = readBracedArg(text, braceStart);
+      if (!arg) continue;
+      result += text.slice(last, m.index);
+      result += `<${tag}>${processInline(arg.content, unsupported)}</${tag}>`;
+      last = arg.end;
+      re.lastIndex = arg.end;
+    }
+    result += text.slice(last);
+    text = result;
+  }
+  return text;
+}
+
+export function renderLatexToHtml(source: string): LatexRenderResult {
+  const unsupported = new Set<string>();
+
+  try {
+    const noComments = stripComments(source);
+
+    // Split preamble / body around \begin{document} ... \end{document}.
+    const beginDoc = noComments.search(/\\begin\{document\}/);
+    const endDoc = noComments.search(/\\end\{document\}/);
+    const preamble = beginDoc >= 0 ? noComments.slice(0, beginDoc) : noComments;
+    let body =
+      beginDoc >= 0
+        ? noComments.slice(beginDoc + "\\begin{document}".length, endDoc >= 0 ? endDoc : undefined)
+        : noComments;
+
+    const macros = extractMacros(preamble);
+
+    // Remove standalone preamble-only commands that may leak if no \begin{document}.
+    body = body.replace(/\\(documentclass|usepackage|newcommand|renewcommand|def|input|include|bibliographystyle|bibliography)\b[^\n]*/g, "");
+
+    // Drop common metadata/no-content commands that take no argument.
+    // (\maketitle is handled separately below so it can render a title block.)
+    body = body.replace(/\\(tableofcontents|newpage|clearpage|pagebreak|bigskip|medskip|smallskip|hfill|vfill|centering|noindent)\b/g, "");
+
+    // 1) Extract & render math first (needs raw TeX).
+    const { text: withPlaceholders, tokens } = extractMath(body, macros, unsupported);
+
+    // 1b) \maketitle: build a title block from preamble \title/\author/\date.
+    let withTitle = withPlaceholders;
+    if (/\\maketitle\b/.test(withTitle)) {
+      const title = preambleArg(preamble, "title");
+      const author = preambleArg(preamble, "author");
+      // \date defaults to \today when omitted; an explicit empty \date{} hides it.
+      const date = preambleArg(preamble, "date") ?? "\\today";
+      const parts: string[] = [];
+      if (title) parts.push(`<h1 class="latex-doc-title">${processInline(escapeHtml(title), unsupported)}</h1>`);
+      if (author) parts.push(`<div class="latex-doc-author">${processInline(escapeHtml(author), unsupported)}</div>`);
+      if (date.trim()) parts.push(`<div class="latex-doc-date">${processInline(escapeHtml(date), unsupported)}</div>`);
+      tokens.push({ html: `<div class="latex-titleblock">${parts.join("")}</div>` });
+      const ph = `${PLACEHOLDER_OPEN}${tokens.length - 1}${PLACEHOLDER_CLOSE}`;
+      withTitle = withTitle.replace(/\\maketitle\b[ \t]*/g, ph);
+    }
+
+    // 2) Escape HTML on the non-math text.
+    let html = escapeHtml(withTitle);
+
+    // 3) Block-level structure (environments).
+    html = processBlocks(html, unsupported);
+
+    // 4) Sectioning.
+    html = processSections(html, unsupported);
+
+    // 5) Paragraphs: split on blank lines, wrap loose text in <p>.
+    const phRe = new RegExp(`^${PLACEHOLDER_OPEN}(\\d+)${PLACEHOLDER_CLOSE}`);
+    const blocks = html.split(/\n\s*\n/);
+    html = blocks
+      .map((block) => {
+        const trimmed = block.trim();
+        if (!trimmed) return "";
+        // Don't wrap blocks that are already a single block-level element.
+        if (/^<(h[1-6]|ul|ol|blockquote|div|pre|table)[\s>]/.test(trimmed)) {
+          return processInline(trimmed, unsupported);
+        }
+        // Don't wrap blocks that begin with a block-level token (e.g. the
+        // \maketitle title block) — a <div> inside a <p> is invalid HTML.
+        const ph = phRe.exec(trimmed);
+        if (ph && /^<(div|table|h[1-6])/.test(tokens[Number(ph[1])]?.html ?? "")) {
+          return processInline(trimmed, unsupported);
+        }
+        return `<p>${processInline(trimmed, unsupported)}</p>`;
+      })
+      .join("\n");
+
+    // 6) Swap math placeholders back in.
+    html = html.replace(
+      new RegExp(`${PLACEHOLDER_OPEN}(\\d+)${PLACEHOLDER_CLOSE}`, "g"),
+      (_full, idx: string) => tokens[Number(idx)]?.html ?? "",
+    );
+
+    const ok = html.replace(/<[^>]+>/g, "").trim().length > 0 || tokens.length > 0;
+
+    return { html, unsupported: Array.from(unsupported), ok };
+  } catch (e) {
+    return {
+      html: "",
+      unsupported: [`fatal: ${(e as Error).message}`],
+      ok: false,
+    };
+  }
+}

--- a/src/components/editor/latex-render.ts
+++ b/src/components/editor/latex-render.ts
@@ -101,11 +101,15 @@ function escapeHtml(str: string): string {
 function safeHref(rawUrl: string): string {
   // Inline math/text already HTML-escaped `&` to `&amp;`; restore it first.
   const url = rawUrl.replace(/&amp;/g, "&").trim();
-  const scheme = /^([a-z][a-z0-9+.-]*):/i.exec(url);
+  // Strip control characters before checking the scheme. Browsers ignore
+  // embedded tabs/newlines when resolving an href, so `java\nscript:` would
+  // otherwise slip past the scheme regex and still execute.
+  const normalized = url.replace(/[\u0000-\u001F\u007F]/g, "");
+  const scheme = /^([a-z][a-z0-9+.-]*):/i.exec(normalized);
   if (scheme && !/^(https?|mailto|tel|ftp)$/i.test(scheme[1])) {
     return "#";
   }
-  return url
+  return normalized
     .replace(/&/g, "&amp;")
     .replace(/"/g, "&quot;")
     .replace(/</g, "&lt;")

--- a/src/components/editor/latex-render.ts
+++ b/src/components/editor/latex-render.ts
@@ -52,8 +52,9 @@ function readBracedArg(str: string, openIndex: number): { content: string; end: 
   let depth = 0;
   for (let i = openIndex; i < str.length; i++) {
     const ch = str[i];
-    if (ch === "{" && str[i - 1] !== "\\") depth++;
-    else if (ch === "}" && str[i - 1] !== "\\") {
+    // Guard `i > 0` so we never read str[-1] for the first character.
+    if (ch === "{" && (i === 0 || str[i - 1] !== "\\")) depth++;
+    else if (ch === "}" && (i === 0 || str[i - 1] !== "\\")) {
       depth--;
       if (depth === 0) return { content: str.slice(openIndex + 1, i), end: i + 1 };
     }

--- a/src/components/editor/latex-render.ts
+++ b/src/components/editor/latex-render.ts
@@ -92,6 +92,26 @@ function escapeHtml(str: string): string {
   return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
+/**
+ * Sanitize a URL pulled from `\href{}`/`\url{}` for use in an `href`
+ * attribute. Blocks dangerous schemes (javascript:, data:, vbscript:, …) so a
+ * malicious .tex file can't inject script via the rendered link, and escapes
+ * the result for the double-quoted attribute context.
+ */
+function safeHref(rawUrl: string): string {
+  // Inline math/text already HTML-escaped `&` to `&amp;`; restore it first.
+  const url = rawUrl.replace(/&amp;/g, "&").trim();
+  const scheme = /^([a-z][a-z0-9+.-]*):/i.exec(url);
+  if (scheme && !/^(https?|mailto|tel|ftp)$/i.test(scheme[1])) {
+    return "#";
+  }
+  return url
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
 interface MathToken {
   html: string;
 }
@@ -301,7 +321,7 @@ function processInline(input: string, unsupported: Set<string>): string {
           if (a1) {
             const a2 = input[a1.end] === "{" ? readBracedArg(input, a1.end) : null;
             if (a2) {
-              const url = a1.content.replace(/&amp;/g, "&");
+              const url = safeHref(a1.content);
               out += `<a href="${url}" target="_blank" rel="noopener noreferrer">${processInline(a2.content, unsupported)}</a>`;
               i = a2.end;
               continue;
@@ -311,8 +331,9 @@ function processInline(input: string, unsupported: Set<string>): string {
         if (name === "url") {
           const a1 = input[j] === "{" ? readBracedArg(input, j) : null;
           if (a1) {
-            const url = a1.content.replace(/&amp;/g, "&");
-            out += `<a href="${url}" target="_blank" rel="noopener noreferrer">${escapeHtml(url)}</a>`;
+            const display = a1.content.replace(/&amp;/g, "&");
+            const url = safeHref(a1.content);
+            out += `<a href="${url}" target="_blank" rel="noopener noreferrer">${escapeHtml(display)}</a>`;
             i = a1.end;
             continue;
           }

--- a/src/components/editor/latex-viewer.tsx
+++ b/src/components/editor/latex-viewer.tsx
@@ -24,6 +24,9 @@ export function LatexViewer({ path }: LatexViewerProps) {
   const [saving, setSaving] = useState(false);
 
   const editContentRef = useRef<string>("");
+  // Guards against overlapping writes — handleSave can fire from both the
+  // textarea's onBlur and the toolbar button click at nearly the same time.
+  const savingRef = useRef(false);
 
   const rendered = useMemo(() => (content ? renderLatexToHtml(content) : null), [content]);
 
@@ -69,11 +72,13 @@ export function LatexViewer({ path }: LatexViewerProps) {
   }, [fetchContent, mode]);
 
   const handleSave = useCallback(async () => {
+    if (savingRef.current) return;
     const newContent = editContentRef.current;
     if (newContent === content) {
       setMode("rendered");
       return;
     }
+    savingRef.current = true;
     setSaving(true);
     setSaveError(null);
     try {
@@ -100,6 +105,7 @@ export function LatexViewer({ path }: LatexViewerProps) {
       // non-blocking banner so the user can retry without losing their edits.
       setSaveError(e instanceof Error ? e.message : "Failed to save");
     } finally {
+      savingRef.current = false;
       setSaving(false);
     }
   }, [content, path, assetUrl]);
@@ -110,6 +116,7 @@ export function LatexViewer({ path }: LatexViewerProps) {
         <Button
           variant="ghost"
           size="sm"
+          disabled={mode === "source" && saving}
           onClick={() => {
             if (mode === "source") {
               handleSave();

--- a/src/components/editor/latex-viewer.tsx
+++ b/src/components/editor/latex-viewer.tsx
@@ -16,7 +16,10 @@ type ViewMode = "rendered" | "source";
 export function LatexViewer({ path }: LatexViewerProps) {
   const [content, setContent] = useState("");
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  // Load failures block the viewer (there's nothing to show); save failures
+  // must NOT — the editor has to stay open so the user can retry/copy.
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const [mode, setMode] = useState<ViewMode>("rendered");
   const [saving, setSaving] = useState(false);
 
@@ -29,7 +32,7 @@ export function LatexViewer({ path }: LatexViewerProps) {
 
   const fetchContent = useCallback(async () => {
     setLoading(true);
-    setError(null);
+    setLoadError(null);
     try {
       // `no-store` prevents the browser from serving a stale copy when the
       // file is replaced at the same path (the asset URL doesn't change).
@@ -39,7 +42,7 @@ export function LatexViewer({ path }: LatexViewerProps) {
       setContent(text);
       editContentRef.current = text;
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to load .tex file");
+      setLoadError(e instanceof Error ? e.message : "Failed to load .tex file");
     } finally {
       setLoading(false);
     }
@@ -72,6 +75,7 @@ export function LatexViewer({ path }: LatexViewerProps) {
       return;
     }
     setSaving(true);
+    setSaveError(null);
     try {
       const bridge = (window as unknown as {
         CabinetDesktop?: {
@@ -92,7 +96,9 @@ export function LatexViewer({ path }: LatexViewerProps) {
       setContent(newContent);
       setMode("rendered");
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to save");
+      // Keep the editor open (mode stays "source") and surface the error as a
+      // non-blocking banner so the user can retry without losing their edits.
+      setSaveError(e instanceof Error ? e.message : "Failed to save");
     } finally {
       setSaving(false);
     }
@@ -166,16 +172,23 @@ export function LatexViewer({ path }: LatexViewerProps) {
         </a>
       </ViewerToolbar>
 
+      {saveError && (
+        <div className="flex items-start gap-2 border-b border-red-300 bg-red-50 px-4 py-2 text-sm text-red-700 dark:border-red-700/60 dark:bg-red-950/40 dark:text-red-300">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>Couldn&apos;t save: {saveError}</span>
+        </div>
+      )}
+
       <div className="flex-1 overflow-auto">
         {loading ? (
           <div className="flex items-center justify-center h-full text-muted-foreground text-sm gap-2">
             <Loader2 className="h-4 w-4 animate-spin" />
             Loading LaTeX…
           </div>
-        ) : error ? (
+        ) : loadError ? (
           <div className="flex items-center justify-center h-full text-sm text-red-600 dark:text-red-400 gap-2">
             <AlertCircle className="h-4 w-4" />
-            {error}
+            {loadError}
           </div>
         ) : mode === "source" ? (
           <textarea

--- a/src/components/editor/latex-viewer.tsx
+++ b/src/components/editor/latex-viewer.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { useEffect, useState, useCallback, useRef, useMemo } from "react";
+import { ExternalLink, Download, Code2, Eye, Save, AlertCircle, Loader2, Info, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ViewerToolbar } from "@/components/layout/viewer-toolbar";
+import { renderLatexToHtml } from "./latex-render";
+
+interface LatexViewerProps {
+  path: string;
+  title?: string;
+}
+
+type ViewMode = "rendered" | "source";
+
+export function LatexViewer({ path }: LatexViewerProps) {
+  const [content, setContent] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [mode, setMode] = useState<ViewMode>("rendered");
+  const [saving, setSaving] = useState(false);
+
+  const editContentRef = useRef<string>("");
+
+  const rendered = useMemo(() => (content ? renderLatexToHtml(content) : null), [content]);
+
+  const assetUrl = `/api/assets/${path.split("/").map(encodeURIComponent).join("/")}`;
+  const filename = path.split("/").pop() || path;
+
+  const fetchContent = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      // `no-store` prevents the browser from serving a stale copy when the
+      // file is replaced at the same path (the asset URL doesn't change).
+      const res = await fetch(assetUrl, { cache: "no-store" });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const text = await res.text();
+      setContent(text);
+      editContentRef.current = text;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load .tex file");
+    } finally {
+      setLoading(false);
+    }
+  }, [assetUrl]);
+
+  useEffect(() => {
+    void fetchContent();
+  }, [fetchContent]);
+
+  // Re-fetch when the user returns to the window/tab — picks up a file that
+  // was replaced on disk while this viewer stayed mounted on the same path.
+  // Skip while editing source so we never clobber unsaved changes.
+  useEffect(() => {
+    if (mode === "source") return;
+    const onFocus = () => {
+      if (document.visibilityState === "visible") void fetchContent();
+    };
+    window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onFocus);
+    return () => {
+      window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onFocus);
+    };
+  }, [fetchContent, mode]);
+
+  const handleSave = useCallback(async () => {
+    const newContent = editContentRef.current;
+    if (newContent === content) {
+      setMode("rendered");
+      return;
+    }
+    setSaving(true);
+    try {
+      const bridge = (window as unknown as {
+        CabinetDesktop?: {
+          writeFile?: (p: string, c: string) => Promise<{ ok: boolean; error?: string }>;
+        };
+      }).CabinetDesktop;
+      if (bridge?.writeFile) {
+        const result = await bridge.writeFile(path, newContent);
+        if (!result.ok) throw new Error(result.error || "Failed to save");
+      } else {
+        const res = await fetch(assetUrl, {
+          method: "PUT",
+          headers: { "Content-Type": "text/plain" },
+          body: newContent,
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      }
+      setContent(newContent);
+      setMode("rendered");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }, [content, path, assetUrl]);
+
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden">
+      <ViewerToolbar path={path} badge="TEX" sublabel={filename}>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            if (mode === "source") {
+              handleSave();
+            } else {
+              setMode("source");
+            }
+          }}
+          className="gap-1.5"
+        >
+          {mode === "source" ? (
+            <>
+              <Save className="h-3.5 w-3.5" />
+              {saving ? "Saving…" : "Save & Render"}
+            </>
+          ) : (
+            <>
+              <Code2 className="h-3.5 w-3.5" />
+              Edit Source
+            </>
+          )}
+        </Button>
+        {mode === "source" && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setMode("rendered")}
+            className="gap-1.5"
+          >
+            <Eye className="h-3.5 w-3.5" />
+            Preview
+          </Button>
+        )}
+        {mode === "rendered" && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => void fetchContent()}
+            disabled={loading}
+            className="gap-1.5"
+            title="Reload the file from disk"
+          >
+            <RefreshCw className={`h-3.5 w-3.5 ${loading ? "animate-spin" : ""}`} />
+            Refresh
+          </Button>
+        )}
+        <a
+          href={assetUrl}
+          download={filename}
+          className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+        >
+          <Download className="h-3.5 w-3.5" />
+        </a>
+        <a
+          href={assetUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+        >
+          <ExternalLink className="h-3.5 w-3.5" />
+        </a>
+      </ViewerToolbar>
+
+      <div className="flex-1 overflow-auto">
+        {loading ? (
+          <div className="flex items-center justify-center h-full text-muted-foreground text-sm gap-2">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading LaTeX…
+          </div>
+        ) : error ? (
+          <div className="flex items-center justify-center h-full text-sm text-red-600 dark:text-red-400 gap-2">
+            <AlertCircle className="h-4 w-4" />
+            {error}
+          </div>
+        ) : mode === "source" ? (
+          <textarea
+            defaultValue={content}
+            onChange={(e) => {
+              editContentRef.current = e.target.value;
+            }}
+            onBlur={handleSave}
+            spellCheck={false}
+            className="block w-full h-full bg-zinc-950 p-4 font-mono text-sm leading-relaxed text-zinc-100 outline-none resize-none"
+            style={{ minHeight: "100%" }}
+          />
+        ) : rendered && rendered.ok ? (
+          <div className="mx-auto max-w-3xl px-6 py-8">
+            {rendered.unsupported.length > 0 && (
+              <div className="mb-6 flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-700/60 dark:bg-amber-950/40 dark:text-amber-200">
+                <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                <div>
+                  <span className="font-medium">Some LaTeX features aren&apos;t supported by the preview</span> and were
+                  approximated or skipped:{" "}
+                  <span className="font-mono">{rendered.unsupported.slice(0, 12).join(", ")}</span>
+                  {rendered.unsupported.length > 12 ? ` (+${rendered.unsupported.length - 12} more)` : ""}.
+                </div>
+              </div>
+            )}
+            <article
+              className="latex-rendered prose prose-zinc max-w-none dark:prose-invert"
+              dangerouslySetInnerHTML={{ __html: rendered.html }}
+            />
+          </div>
+        ) : (
+          <div className="flex h-full flex-col">
+            <div className="flex items-start gap-2 border-b border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-700/60 dark:bg-amber-950/40 dark:text-amber-200">
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+              <div>
+                <span className="font-medium">This document couldn&apos;t be rendered.</span> It likely uses LaTeX
+                packages or macros the in-app preview doesn&apos;t support
+                {rendered && rendered.unsupported.length > 0 ? (
+                  <>
+                    {" "}(<span className="font-mono">{rendered.unsupported.slice(0, 8).join(", ")}</span>)
+                  </>
+                ) : null}
+                . Showing the source instead.
+              </div>
+            </div>
+            <pre className="flex-1 overflow-auto bg-zinc-950 p-4 font-mono text-sm leading-relaxed text-zinc-100">
+              {content}
+            </pre>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/editor/slash-commands.tsx
+++ b/src/components/editor/slash-commands.tsx
@@ -18,6 +18,7 @@ import {
   Video,
   Sparkles,
   File,
+  FileText,
   Sigma,
   Smile,
   Type,
@@ -77,6 +78,14 @@ const commands: SlashCommand[] = [
   { label: "Warning", icon: AlertTriangle, description: "Insert a warning callout", category: "advanced", action: { type: "direct", run: (editor) => editor.chain().focus().wrapIn("callout", { type: "warning" }).run() } },
   { label: "Math", icon: Sigma, description: "Insert a LaTeX math expression", category: "advanced", action: { type: "direct", run: (editor) => editor.chain().focus().insertContent("$x=y$").run() } },
   { label: "Emoji", icon: Smile, description: "Pick an emoji", category: "advanced", action: { type: "popover", kind: { type: "emoji" } } },
+  { label: "LaTeX File", icon: FileText, description: "Embed and render a .tex file", category: "advanced", action: { type: "direct", run: (editor) => {
+    const path = typeof window !== "undefined" ? window.prompt("Path to .tex file (relative to current page or vault root):", "document.tex") : null;
+    if (path && path.trim()) {
+      editor.chain().focus().insertLatexEmbed({ path: path.trim() }).run();
+    } else {
+      editor.chain().focus().run();
+    }
+  } } },
 ];
 
 interface SlashCommandsProps {

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -13,6 +13,7 @@ import { NotebookViewer } from "@/components/editor/notebook-viewer";
 import { ImageViewer } from "@/components/editor/image-viewer";
 import { MediaViewer } from "@/components/editor/media-viewer";
 import { MermaidViewer } from "@/components/editor/mermaid-viewer";
+import { LatexViewer } from "@/components/editor/latex-viewer";
 import { FileFallbackViewer } from "@/components/editor/file-fallback-viewer";
 import dynamic from "next/dynamic";
 import { GoogleDocViewer } from "@/components/editor/google-doc-viewer";
@@ -727,6 +728,7 @@ export function AppShell() {
         if (lower.endsWith(".pptx")) return "pptx";
         if (lower.endsWith(".ipynb")) return "notebook";
         if (lower.endsWith(".mmd") || lower.endsWith(".mermaid")) return "mermaid";
+        if (lower.endsWith(".tex") || lower.endsWith(".latex")) return "latex";
         if (/\.(png|jpe?g|gif|webp|svg|bmp)$/.test(lower)) return "image";
         if (/\.(mp4|mov|webm|avi|mkv)$/.test(lower)) return "video";
         if (/\.(mp3|wav|ogg|flac|m4a)$/.test(lower)) return "audio";
@@ -747,6 +749,7 @@ export function AppShell() {
   const isVideo = nodeType === "video";
   const isAudio = nodeType === "audio";
   const isMermaid = nodeType === "mermaid";
+  const isLatex = nodeType === "latex";
   const isDocx = nodeType === "docx";
   const isXlsx = nodeType === "xlsx";
   const isPptx = nodeType === "pptx";
@@ -953,6 +956,12 @@ export function AppShell() {
       const mmdPath = selectedNode?.path || selectedPath!;
       const mmdTitle = selectedNode?.frontmatter?.title || selectedNode?.name || mmdPath.split("/").pop() || "Diagram";
       return <MermaidViewer path={mmdPath} title={mmdTitle} />;
+    }
+
+    if (isLatex && (selectedNode || selectedPath)) {
+      const texPath = selectedNode?.path || selectedPath!;
+      const texTitle = selectedNode?.frontmatter?.title || selectedNode?.name || texPath.split("/").pop() || "LaTeX";
+      return <LatexViewer path={texPath} title={texTitle} />;
     }
 
     if (isDocx && (selectedNode || selectedPath)) {

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -961,7 +961,7 @@ export function AppShell() {
     if (isLatex && (selectedNode || selectedPath)) {
       const texPath = selectedNode?.path || selectedPath!;
       const texTitle = selectedNode?.frontmatter?.title || selectedNode?.name || texPath.split("/").pop() || "LaTeX";
-      return <LatexViewer path={texPath} title={texTitle} />;
+      return <LatexViewer key={texPath} path={texPath} title={texTitle} />;
     }
 
     if (isDocx && (selectedNode || selectedPath)) {

--- a/src/components/sidebar/tree-node.tsx
+++ b/src/components/sidebar/tree-node.tsx
@@ -28,6 +28,7 @@ import {
   File,
   FileSpreadsheet,
   NotebookText,
+  Sigma,
   Presentation,
   TriangleAlert,
   ArrowRightLeft,
@@ -736,6 +737,8 @@ function TreeNodeImpl({
               <Presentation className="h-3.5 w-3.5 shrink-0 text-orange-400" />
             ) : node.type === "notebook" ? (
               <NotebookText className="h-3.5 w-3.5 shrink-0 text-[#F37626]" />
+            ) : node.type === "latex" ? (
+              <Sigma className="h-3.5 w-3.5 shrink-0 text-indigo-400" />
             ) : node.type === "unknown" ? (
               <File className="h-3.5 w-3.5 shrink-0 text-muted-foreground/50" />
             ) : node.type === "cabinet" ? (

--- a/src/lib/markdown/to-html.ts
+++ b/src/lib/markdown/to-html.ts
@@ -8,6 +8,20 @@ import { slugifyPageName } from "@/lib/markdown/wiki-links";
 import { addHeadingIds } from "@/lib/markdown/heading-slug";
 
 /**
+ * Pre-process markdown to convert ![[file.tex]] embeds into
+ * <div data-latex-embed> markers before the remark pipeline.
+ * Only matches .tex files so wiki-link-style image embeds for other
+ * types are unaffected.
+ */
+function convertLatexEmbeds(markdown: string): string {
+  return markdown.replace(
+    /!\[\[([^\]]+\.tex)\]\]/g,
+    (_match, path: string) =>
+      `<div data-latex-embed="true" data-path="${path}"></div>`
+  );
+}
+
+/**
  * Pre-process markdown to convert [[Wiki Links]] to HTML anchors
  * before the remark pipeline (which doesn't understand wiki-link syntax).
  */
@@ -149,8 +163,10 @@ const processor = unified()
   .freeze();
 
 export async function markdownToHtml(markdown: string, pagePath?: string): Promise<string> {
+  // Convert ![[file.tex]] LaTeX embeds to HTML markers before remark
+  const withLatex = convertLatexEmbeds(markdown);
   // Pre-process wiki-links before remark (which would treat [[ as text)
-  const preprocessed = convertWikiLinks(markdown);
+  const preprocessed = convertWikiLinks(withLatex);
 
   const result = await processor.process(preprocessed);
 

--- a/src/lib/markdown/to-html.ts
+++ b/src/lib/markdown/to-html.ts
@@ -16,8 +16,16 @@ import { addHeadingIds } from "@/lib/markdown/heading-slug";
 function convertLatexEmbeds(markdown: string): string {
   return markdown.replace(
     /!\[\[([^\]]+\.tex)\]\]/g,
-    (_match, path: string) =>
-      `<div data-latex-embed="true" data-path="${path}"></div>`
+    (_match, path: string) => {
+      // Escape the path before it lands in the data-path attribute so a name
+      // containing `"`, `<`, `>` or `&` can't break out and inject markup.
+      const safePath = path
+        .replace(/&/g, "&amp;")
+        .replace(/"/g, "&quot;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
+      return `<div data-latex-embed="true" data-path="${safePath}"></div>`;
+    }
   );
 }
 

--- a/src/lib/markdown/to-html.ts
+++ b/src/lib/markdown/to-html.ts
@@ -15,7 +15,7 @@ import { addHeadingIds } from "@/lib/markdown/heading-slug";
  */
 function convertLatexEmbeds(markdown: string): string {
   return markdown.replace(
-    /!\[\[([^\]]+\.tex)\]\]/g,
+    /!\[\[([^\]]+\.(?:tex|latex))\]\]/gi,
     (_match, path: string) => {
       // Escape the path before it lands in the data-path attribute so a name
       // containing `"`, `<`, `>` or `&` can't break out and inject markup.

--- a/src/lib/markdown/to-markdown.ts
+++ b/src/lib/markdown/to-markdown.ts
@@ -192,6 +192,18 @@ turndown.addRule("twitterEmbed", {
   },
 });
 
+// Serialize LaTeX embed blocks back to ![[file.tex]] syntax.
+turndown.addRule("latexEmbed", {
+  filter: (node) =>
+    node.nodeName === "DIV" &&
+    (node as HTMLElement).getAttribute("data-latex-embed") === "true",
+  replacement: (_content, node) => {
+    const el = node as HTMLElement;
+    const path = el.getAttribute("data-path") ?? "";
+    return `\n![[${path}]]\n`;
+  },
+});
+
 // Preserve images that have inline width/align data. Turndown's default image
 // rule emits `![]()`, losing size info — so when the <img> has width, align, or
 // wraps in a resizable-image div we emit the raw HTML instead.

--- a/src/lib/storage/tree-builder.ts
+++ b/src/lib/storage/tree-builder.ts
@@ -41,6 +41,8 @@ const AUDIO_EXTENSIONS = new Set([
 
 const MERMAID_EXTENSIONS = new Set([".mermaid", ".mmd"]);
 
+const LATEX_EXTENSIONS = new Set([".tex", ".latex"]);
+
 // Office types that Cabinet can render inline.
 const DOCX_EXTENSIONS = new Set([".docx"]);
 const XLSX_EXTENSIONS = new Set([".xlsx", ".xlsm"]);
@@ -73,6 +75,7 @@ function classifyFile(ext: string): TreeNode["type"] | null {
   if (VIDEO_EXTENSIONS.has(ext)) return "video";
   if (AUDIO_EXTENSIONS.has(ext)) return "audio";
   if (MERMAID_EXTENSIONS.has(ext)) return "mermaid";
+  if (LATEX_EXTENSIONS.has(ext)) return "latex";
   if (DOCX_EXTENSIONS.has(ext)) return "docx";
   if (XLSX_EXTENSIONS.has(ext)) return "xlsx";
   if (PPTX_EXTENSIONS.has(ext)) return "pptx";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -47,6 +47,7 @@ export interface TreeNode {
     | "xlsx"
     | "pptx"
     | "notebook"
+    | "latex"
     | "unknown";
   hasRepo?: boolean;
   isLinked?: boolean;

--- a/src/types/latex.js.d.ts
+++ b/src/types/latex.js.d.ts
@@ -1,0 +1,21 @@
+declare module "latex.js" {
+  export class Generator {
+    constructor(options?: { hyphenate?: boolean; CustomMacros?: unknown });
+  }
+
+  export class HtmlGenerator {
+    domFragment(): DocumentFragment;
+    stylesAndScripts(baseURL?: string): DocumentFragment;
+    htmlDocument(baseURL?: string): HTMLDocument;
+    applyLengthsAndGeometryToDom(element: HTMLElement): void;
+  }
+
+  export function parse(
+    latex: string,
+    options?: { generator?: Generator }
+  ): HtmlGenerator;
+
+  export class SyntaxError extends Error {}
+
+  export class LaTeXJSComponent extends HTMLElement {}
+}


### PR DESCRIPTION
Ported from hilash/cabinet#96 (commit 5bf2b1d7), excluding the unrelated changes bundled in that branch (Typst, table-menu UX, Tailwind migrations).

- New `.tex`/`.latex` filetype: classified in tree-builder, indigo Sigma icon in the sidebar, routed to a dedicated viewer in app-shell
- LatexViewer: full-file .tex viewer with rendered/source modes, edit + save-back-to-disk, refresh, and download (KaTeX-based renderer in latex-render.ts — no extra runtime dependency for the viewer)
- LatexEmbedExtension: inline `![[file.tex]]` embeds in the editor, rendered via latex.js in a sandboxed, lazy-loaded iframe with click-to-edit; added a "LaTeX File" slash command to insert one
- Markdown round-trip: ![[file.tex]] <-> <div data-latex-embed> across to-html (convertLatexEmbeds) and to-markdown (turndown rule)
- /api/assets: serve .tex as text/x-tex and skip the long cache for editable text sources so edits/replacements aren't served stale
- latex.js dependency + postinstall step copying its dist assets into public/latex-js/ (gitignored) for the embed iframe

Read/edit/save works in both browser and desktop via the existing /api/assets GET+PUT route, so no Electron IPC handlers were needed.

Note: run `npm install` after checkout — the inline embed needs the latex.js assets copied by postinstall; the full-file viewer works without.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native LaTeX file support with a dedicated viewer for `.tex`/`.latex`
  * Enabled LaTeX embeds via `![[file.tex]]` (including Markdown ⇄ editor round-tripping)
  * Implemented rendered preview and source edit modes with save, refresh, and download/external links
  * Added LaTeX-aware file explorer classification and iconography
* **Enhancements**
  * Improved LaTeX asset handling with correct MIME type and extension-aware caching
  * Added KaTeX-based rendering with styled math errors/unsupported-feature notices and updated LaTeX viewer styling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->