### PR TITLE
feat(editor,sidebar): add file:// links and tree-view sorting

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -4,7 +4,7 @@ const fs = require("fs");
 const path = require("path");
 const net = require("net");
 const { spawn } = require("child_process");
-const { app, BrowserWindow, dialog, autoUpdater, ipcMain, shell } = require("electron");
+const { app, BrowserWindow, dialog, autoUpdater, ipcMain } = require("electron");
 const { updateElectronApp } = require("update-electron-app");
 const {
   initBrowserViews,
@@ -709,20 +709,10 @@ async function openRoomWindow(suffix) {
 
 ipcMain.handle("cabinet:open-window", (_event, suffix) => openRoomWindow(suffix));
 
-// Open a local file with the OS default application (e.g. Preview for PDFs).
-// file:// URLs can't be loaded in a BrowserWindow or window.open, so the
-// renderer calls this instead for file:// links clicked in the editor.
-ipcMain.handle("cabinet:open-local-file", async (_event, payload) => {
-  try {
-    const filePath = typeof payload?.path === "string" ? payload.path : "";
-    if (!filePath) return { ok: false, error: "no-path" };
-    const errorMessage = await shell.openPath(filePath);
-    if (errorMessage) return { ok: false, error: errorMessage };
-    return { ok: true };
-  } catch (error) {
-    return { ok: false, error: error instanceof Error ? error.message : String(error) };
-  }
-});
+// Note: the "cabinet:open-local-file" IPC handler lives in browser-views.cjs
+// (registerHandlers); it's shared by editor file:// links and browse mode, and
+// adds a same-renderer auth check. Don't register a second handler here —
+// ipcMain.handle throws on a duplicate channel.
 
 app.on("window-all-closed", () => {
   destroyAllBrowserViews();

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -4,7 +4,7 @@ const fs = require("fs");
 const path = require("path");
 const net = require("net");
 const { spawn } = require("child_process");
-const { app, BrowserWindow, dialog, autoUpdater, ipcMain } = require("electron");
+const { app, BrowserWindow, dialog, autoUpdater, ipcMain, shell } = require("electron");
 const { updateElectronApp } = require("update-electron-app");
 
 if (require("electron-squirrel-startup")) {
@@ -704,6 +704,21 @@ async function openRoomWindow(suffix) {
 }
 
 ipcMain.handle("cabinet:open-window", (_event, suffix) => openRoomWindow(suffix));
+
+// Open a local file with the OS default application (e.g. Preview for PDFs).
+// file:// URLs can't be loaded in a BrowserWindow or window.open, so the
+// renderer calls this instead for file:// links clicked in the editor.
+ipcMain.handle("cabinet:open-local-file", async (_event, payload) => {
+  try {
+    const filePath = typeof payload?.path === "string" ? payload.path : "";
+    if (!filePath) return { ok: false, error: "no-path" };
+    const errorMessage = await shell.openPath(filePath);
+    if (errorMessage) return { ok: false, error: errorMessage };
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+});
 
 app.on("window-all-closed", () => {
   cleanupBackends();

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -12,6 +12,11 @@ contextBridge.exposeInMainWorld("CabinetDesktop", {
    */
   uninstallApp: () => ipcRenderer.invoke("cabinet:uninstall-app"),
   /**
+   * Open a local file with the OS default application. Used for file://
+   * links clicked in the editor (e.g. open a PDF in Preview).
+   */
+  openLocalFile: (filePath) => ipcRenderer.invoke("cabinet:open-local-file", { path: filePath }),
+  /**
    * The OS keyboard / input languages, most-preferred first, plus the
    * Electron app + system locale. Used on the first onboarding screen to
    * localize Cabinet out of the box. Renderer maps these BCP-47 tags onto a

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -31,8 +31,6 @@ contextBridge.exposeInMainWorld("CabinetDesktop", {
   runtime: "electron",
   platform: process.platform,
   // --- In-app browser ("browse mode") backed by a native WebContentsView ---
-  openLocalFile: (filePath) =>
-    ipcRenderer.invoke("cabinet:open-local-file", { path: filePath }),
   createBrowserView: async (url) => {
     try {
       return await ipcRenderer.invoke("cabinet:create-browser-view", {

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -19,6 +19,7 @@ import { markdownToHtml } from "@/lib/markdown/to-html";
 import { htmlToMarkdown } from "@/lib/markdown/to-markdown";
 import { slugifyPageName } from "@/lib/markdown/wiki-links";
 import { detectEmbed } from "@/lib/embeds/detect";
+import { openLocalFileUrl } from "@/lib/runtime/open-local-file";
 import { cellAround, isInTable } from "@tiptap/pm/tables";
 import type { TreeNode } from "@/types";
 import { useLocale } from "@/i18n/use-locale";
@@ -265,6 +266,19 @@ export function KBEditor() {
                 `${window.location.pathname}${href}`
               );
             }
+            return true;
+          }
+
+          // Local file links: open with the OS default app (Electron) or
+          // surface the path (browser). file:// can't load in a webview.
+          if (href.startsWith("file://")) {
+            event.preventDefault();
+            event.stopPropagation();
+            const pathPart = href.slice("file://".length);
+            const encoded = pathPart.includes("%20") || !pathPart.includes(" ")
+              ? href
+              : "file://" + encodeURI(pathPart);
+            openLocalFileUrl(encoded);
             return true;
           }
 

--- a/src/components/editor/extensions.ts
+++ b/src/components/editor/extensions.ts
@@ -100,6 +100,7 @@ export const editorExtensions = [
   }),
   Link.configure({
     openOnClick: false, // we handle clicks ourselves in the editor
+    isAllowedUri: (url) => !!url, // allow file:// and any other protocol
     HTMLAttributes: {
       class: "text-primary underline cursor-pointer",
     },

--- a/src/components/settings/settings-page.tsx
+++ b/src/components/settings/settings-page.tsx
@@ -366,7 +366,14 @@ const REQUESTED_LOCALES_KEY = "cabinet-requested-locales";
 
 export function SettingsPage() {
   const { t } = useLocale();
-  const { showHiddenFiles, setShowHiddenFiles } = useTreeStore();
+  const {
+    showHiddenFiles,
+    setShowHiddenFiles,
+    sortAlphabetical,
+    setSortAlphabetical,
+    foldersFirst,
+    setFoldersFirst,
+  } = useTreeStore();
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [defaultProvider, setDefaultProvider] = useState("");
   const [defaultModel, setDefaultModel] = useState("");
@@ -1072,31 +1079,73 @@ export function SettingsPage() {
                   {t("settings:appearance.sidebarDescription")}
                 </p>
 
-                <label className="flex items-center justify-between gap-3 rounded-lg border border-border p-3 cursor-pointer hover:border-primary/30 transition-colors">
-                  <div className="flex items-center gap-3">
-                    <input
-                      type="checkbox"
-                      checked={showHiddenFiles}
-                      onChange={(e) => setShowHiddenFiles(e.target.checked)}
-                      className="h-4 w-4 rounded border-border accent-primary"
-                    />
-                    <div>
-                      <span className="text-[13px] font-medium">{t("settings:appearance.showHiddenFiles")}</span>
-                      <p className="text-[11px] text-muted-foreground mt-0.5">
-                        {t("settings:appearance.showHiddenFilesHint")}
-                      </p>
+                <div className="space-y-3">
+                  <label className="flex items-center justify-between gap-3 rounded-lg border border-border p-3 cursor-pointer hover:border-primary/30 transition-colors">
+                    <div className="flex items-center gap-3">
+                      <input
+                        type="checkbox"
+                        checked={showHiddenFiles}
+                        onChange={(e) => setShowHiddenFiles(e.target.checked)}
+                        className="h-4 w-4 rounded border-border accent-primary"
+                      />
+                      <div>
+                        <span className="text-[13px] font-medium">{t("settings:appearance.showHiddenFiles")}</span>
+                        <p className="text-[11px] text-muted-foreground mt-0.5">
+                          {t("settings:appearance.showHiddenFilesHint")}
+                        </p>
+                      </div>
                     </div>
-                  </div>
-                  {/*
-                   * Audit #043: macOS convention concatenates modifier glyphs
-                   * with no separator (⌘⇧.); Windows/Linux uses Ctrl+Shift+. .
-                   */}
-                  <kbd className="hidden sm:inline-flex items-center gap-0.5 rounded border border-border bg-muted/50 px-1.5 py-0.5 text-[10px] font-mono text-muted-foreground">
-                    {typeof navigator !== "undefined" && /Mac/.test(navigator.platform)
-                      ? "⌘⇧."
-                      : "Ctrl+Shift+."}
-                  </kbd>
-                </label>
+                    {/*
+                     * Audit #043: macOS convention concatenates modifier glyphs
+                     * with no separator (⌘⇧.); Windows/Linux uses Ctrl+Shift+. .
+                     */}
+                    <kbd className="hidden sm:inline-flex items-center gap-0.5 rounded border border-border bg-muted/50 px-1.5 py-0.5 text-[10px] font-mono text-muted-foreground">
+                      {typeof navigator !== "undefined" && /Mac/.test(navigator.platform)
+                        ? "⌘⇧."
+                        : "Ctrl+Shift+."}
+                    </kbd>
+                  </label>
+
+                  <label className="flex items-center justify-between gap-3 rounded-lg border border-border p-3 cursor-pointer hover:border-primary/30 transition-colors">
+                    <div className="flex items-center gap-3">
+                      <input
+                        type="checkbox"
+                        checked={sortAlphabetical}
+                        onChange={(e) => setSortAlphabetical(e.target.checked)}
+                        className="h-4 w-4 rounded border-border accent-primary"
+                      />
+                      <div>
+                        <span className="text-[13px] font-medium">{t("settings:appearance.autoSortAlphabetical")}</span>
+                        <p className="text-[11px] text-muted-foreground mt-0.5">
+                          {t("settings:appearance.autoSortAlphabeticalHint")}
+                        </p>
+                      </div>
+                    </div>
+                  </label>
+
+                  <label className={cn(
+                    "flex items-center justify-between gap-3 rounded-lg border border-border p-3 transition-colors ms-6",
+                    sortAlphabetical
+                      ? "cursor-pointer hover:border-primary/30"
+                      : "opacity-40 cursor-not-allowed pointer-events-none bg-muted/20"
+                  )}>
+                    <div className="flex items-center gap-3">
+                      <input
+                        type="checkbox"
+                        checked={foldersFirst}
+                        disabled={!sortAlphabetical}
+                        onChange={(e) => setFoldersFirst(e.target.checked)}
+                        className="h-4 w-4 rounded border-border accent-primary"
+                      />
+                      <div>
+                        <span className="text-[13px] font-medium">{t("settings:appearance.foldersFirst")}</span>
+                        <p className="text-[11px] text-muted-foreground mt-0.5">
+                          {t("settings:appearance.foldersFirstHint")}
+                        </p>
+                      </div>
+                    </div>
+                  </label>
+                </div>
               </div>
 
               <div className="border-t border-border pt-6">

--- a/src/components/sidebar/google-drive-tree.tsx
+++ b/src/components/sidebar/google-drive-tree.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect, useState, useCallback, useRef } from "react";
+import { useEffect, useState, useCallback, useRef, useMemo } from "react";
 import { Cloud, ChevronRight, ChevronDown, Folder, Loader2, FolderOpen, ClipboardCopy, FileText } from "lucide-react";
 import { GoogleNodeIcon } from "./google-node-icon";
 import { useAppStore } from "@/stores/app-store";
-import { useTreeStore } from "@/stores/tree-store";
+import { useTreeStore, sortTreeNodes } from "@/stores/tree-store";
 import type { TreeNode, GoogleDriveSection } from "@/types";
 import { cn } from "@/lib/utils";
 import { decodeDrivePath } from "@/lib/google-drive/paths";
@@ -253,13 +253,23 @@ export function GoogleDriveTreeSection({ depth, padFn, cabinetPath }: GoogleDriv
     });
   };
 
-  if (sections.length === 0) return null;
+  const sortAlphabetical = useTreeStore((s) => s.sortAlphabetical);
+  const foldersFirst = useTreeStore((s) => s.foldersFirst);
+
+  const sortedSections = useMemo(() => {
+    return sections.map((section) => ({
+      ...section,
+      children: sortTreeNodes(section.children, sortAlphabetical, foldersFirst),
+    }));
+  }, [sections, sortAlphabetical, foldersFirst]);
+
+  if (sortedSections.length === 0) return null;
 
   return (
     <div>
       {/* Mounted Drive folders render inline with the cabinet files — each
           mount is a collapsible folder, set apart only by the cloud glyph. */}
-      {sections.map((section) => {
+      {sortedSections.map((section) => {
         const expanded = sectionExpanded[section.mountId] ?? true;
         const mountChildrenId = `gdrive-mount-${section.mountId.replace(/[^a-z0-9]/gi, "-")}`;
         const sectionLogo = providerLogo(section.provider ?? "google-drive");

--- a/src/components/sidebar/tree-view.tsx
+++ b/src/components/sidebar/tree-view.tsx
@@ -102,7 +102,14 @@ const itemClass = (active: boolean) =>
 
 export function TreeView() {
   const { t } = useLocale();
-  const { nodes, loading } = useTreeStore();
+  const {
+    nodes,
+    loading,
+    pendingMove,
+    setPendingMove,
+    executeMovePage,
+    setSortAlphabetical,
+  } = useTreeStore();
   const selectPage = useTreeStore((s) => s.selectPage);
   const createPage = useTreeStore((s) => s.createPage);
   const deletePage = useTreeStore((s) => s.deletePage);
@@ -1049,6 +1056,48 @@ export function TreeView() {
             }}
           >
             Delete
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+
+    <Dialog open={!!pendingMove} onOpenChange={(open) => !open && setPendingMove(null)}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Disable Alphabetical Sorting?</DialogTitle>
+          <DialogDescription>
+            You are manually reordering files or folders, but alphabetical auto-sorting is currently enabled.
+            Would you like to disable alphabetical sorting to apply your manual ordering?
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="mt-2 flex gap-2 sm:justify-end">
+          <Button variant="outline" onClick={() => setPendingMove(null)}>
+            Cancel
+          </Button>
+          <Button
+            variant="outline"
+            onClick={async () => {
+              if (pendingMove) {
+                const move = pendingMove;
+                setPendingMove(null);
+                await executeMovePage(move);
+              }
+            }}
+          >
+            Keep Auto-Sorting
+          </Button>
+          <Button
+            variant="default"
+            onClick={async () => {
+              if (pendingMove) {
+                const move = pendingMove;
+                setPendingMove(null);
+                setSortAlphabetical(false);
+                await executeMovePage(move);
+              }
+            }}
+          >
+            Disable Auto-Sorting &amp; Move
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1601,7 +1601,11 @@
       "sidebar": "Sidebar",
       "showHiddenFiles": "Show hidden files",
       "sidebarDescription": "Configure how files are displayed in the sidebar.",
-      "showHiddenFilesHint": "Display files and folders starting with a dot (e.g. .env, .git)"
+      "showHiddenFilesHint": "Display files and folders starting with a dot (e.g. .env, .git)",
+      "autoSortAlphabetical": "Sort alphabetically",
+      "autoSortAlphabeticalHint": "Auto-sort files and folders alphabetically by name.",
+      "foldersFirst": "Folders first",
+      "foldersFirstHint": "Position all folders above files in the same directory."
     },
     "tabs": {
       "profile": "Profile",

--- a/src/lib/markdown/to-html.ts
+++ b/src/lib/markdown/to-html.ts
@@ -19,6 +19,19 @@ function convertWikiLinks(markdown: string): string {
 }
 
 /**
+ * Pre-process markdown to URL-encode spaces in file:// link URLs.
+ * CommonMark terminates a bare URL at the first whitespace, so
+ * [text](file:///path/My File.pdf) is not parsed as a link. This encodes
+ * spaces in the path so the remark pipeline sees a valid URL.
+ */
+function encodeFileUrls(markdown: string): string {
+  return markdown.replace(
+    /\]\((file:\/\/[^)]+)\)/g,
+    (_match, url: string) => `](${url.replace(/ /g, "%20")})`
+  );
+}
+
+/**
  * Post-process HTML to fix task list structure for Tiptap compatibility.
  * remark-gfm outputs: <li><input type="checkbox" ...> text</li>
  * Tiptap expects:     <li data-type="taskItem" data-checked="..."><label><input ...></label><div><p>text</p></div></li>
@@ -149,8 +162,11 @@ const processor = unified()
   .freeze();
 
 export async function markdownToHtml(markdown: string, pagePath?: string): Promise<string> {
+  // Encode spaces in file:// link URLs before remark (which terminates
+  // bare URLs at whitespace)
+  const withFileUrls = encodeFileUrls(markdown);
   // Pre-process wiki-links before remark (which would treat [[ as text)
-  const preprocessed = convertWikiLinks(markdown);
+  const preprocessed = convertWikiLinks(withFileUrls);
 
   const result = await processor.process(preprocessed);
 

--- a/src/lib/runtime/open-local-file.ts
+++ b/src/lib/runtime/open-local-file.ts
@@ -10,6 +10,20 @@ function getBridge(): CabinetDesktopBridge {
     .CabinetDesktop ?? {};
 }
 
+function dispatchOpenError(filePath: string, error?: string): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent("cabinet:toast", {
+      detail: {
+        kind: "error",
+        message: error
+          ? `Couldn't open file: ${error}`
+          : `Couldn't open file: ${filePath}`,
+      },
+    })
+  );
+}
+
 /**
  * Open a `file://` URL.
  *
@@ -25,7 +39,18 @@ export function openLocalFileUrl(url: string): void {
   const bridge = getBridge();
 
   if (bridge.runtime === "electron" && bridge.openLocalFile) {
-    void bridge.openLocalFile(filePath);
+    // Surface failures (missing file, permissions) as a toast instead of
+    // silently swallowing the bridge result.
+    void bridge
+      .openLocalFile(filePath)
+      .then((result) => {
+        if (!result?.ok) {
+          dispatchOpenError(filePath, result?.error);
+        }
+      })
+      .catch((err) => {
+        dispatchOpenError(filePath, err instanceof Error ? err.message : String(err));
+      });
     return;
   }
 

--- a/src/lib/runtime/open-local-file.ts
+++ b/src/lib/runtime/open-local-file.ts
@@ -1,0 +1,46 @@
+"use client";
+
+interface CabinetDesktopBridge {
+  runtime?: "electron";
+  openLocalFile?: (path: string) => Promise<{ ok: boolean; error?: string }>;
+}
+
+function getBridge(): CabinetDesktopBridge {
+  return (window as unknown as { CabinetDesktop?: CabinetDesktopBridge })
+    .CabinetDesktop ?? {};
+}
+
+/**
+ * Open a `file://` URL.
+ *
+ * file:// URLs can't be loaded in a browser view or window.open — Electron
+ * blocks them. In the desktop app we use shell.openPath (via the IPC bridge)
+ * to open the file with the OS default application (e.g. Preview for PDFs).
+ *
+ * In browser mode there's no way to open a local file, so we surface a toast
+ * with the path and a "Copy path" action instead.
+ */
+export function openLocalFileUrl(url: string): void {
+  const filePath = decodeURIComponent(url.slice("file://".length));
+  const bridge = getBridge();
+
+  if (bridge.runtime === "electron" && bridge.openLocalFile) {
+    void bridge.openLocalFile(filePath);
+    return;
+  }
+
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(
+      new CustomEvent("cabinet:toast", {
+        detail: {
+          kind: "info",
+          message: `Local file: ${filePath}`,
+          actionLabel: "Copy path",
+          onAction: () => {
+            navigator.clipboard?.writeText(filePath).catch(() => {});
+          },
+        },
+      })
+    );
+  }
+}

--- a/src/stores/tree-store.ts
+++ b/src/stores/tree-store.ts
@@ -26,6 +26,20 @@ interface TreeState {
   dragOverZone: DragZone | null;
   movingPaths: Set<string>;
   showHiddenFiles: boolean;
+  /** Sort the tree alphabetically by name instead of by manual `order`. */
+  sortAlphabetical: boolean;
+  /** When alphabetical sorting is on, place folders above files. */
+  foldersFirst: boolean;
+  /** The unsorted tree as returned by the server — `nodes` is the sorted
+   *  view derived from this, so toggling sort doesn't need a server refetch. */
+  rawNodes: TreeNode[];
+  /** A drag-move awaiting confirmation because alphabetical sorting is on
+   *  (manual ordering would otherwise be overridden by the sort). */
+  pendingMove: {
+    fromPath: string;
+    toParentPath: string;
+    neighbors?: { prevName?: string | null; nextName?: string | null };
+  } | null;
   /** Bumped whenever we want the sidebar to scroll to + blink the selected row. */
   focusTick: number;
   /** Tree paths an agent task recently created/changed — highlighted in the
@@ -53,6 +67,20 @@ interface TreeState {
   setDragOver: (path: string | null, zone?: DragZone | null) => void;
   setShowHiddenFiles: (show: boolean) => void;
   toggleHiddenFiles: () => void;
+  setSortAlphabetical: (sort: boolean) => void;
+  setFoldersFirst: (foldersFirst: boolean) => void;
+  setPendingMove: (
+    move: {
+      fromPath: string;
+      toParentPath: string;
+      neighbors?: { prevName?: string | null; nextName?: string | null };
+    } | null
+  ) => void;
+  executeMovePage: (move: {
+    fromPath: string;
+    toParentPath: string;
+    neighbors?: { prevName?: string | null; nextName?: string | null };
+  }) => Promise<void>;
   /** Mark tree paths as recently changed by a task (sidebar highlight + dot). */
   markChanged: (paths: string[]) => void;
   /** Clear the "recently changed" mark for one path (e.g. when it's opened). */
@@ -78,6 +106,69 @@ function loadShowHiddenFiles(): boolean {
   } catch {
     return false;
   }
+}
+
+function loadSortAlphabetical(): boolean {
+  if (typeof window === "undefined") return true;
+  try {
+    const stored = localStorage.getItem("kb-sort-alphabetical");
+    return stored === null ? true : stored === "true";
+  } catch {
+    return true;
+  }
+}
+
+function loadFoldersFirst(): boolean {
+  if (typeof window === "undefined") return true;
+  try {
+    const stored = localStorage.getItem("kb-folders-first");
+    return stored === null ? true : stored === "true";
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Recursively sort tree nodes. When `sortAlphabetical` is on, sort by name
+ * (optionally folders-first); otherwise honor the manual `frontmatter.order`
+ * with name as a tiebreaker.
+ */
+export function sortTreeNodes(
+  nodes: TreeNode[],
+  sortAlphabetical: boolean,
+  foldersFirst: boolean
+): TreeNode[] {
+  return [...nodes]
+    .map((node) => {
+      if (node.children && node.children.length > 0) {
+        return {
+          ...node,
+          children: sortTreeNodes(node.children, sortAlphabetical, foldersFirst),
+        };
+      }
+      return node;
+    })
+    .sort((a, b) => {
+      const isFolderA = a.type === "directory" || a.type === "cabinet";
+      const isFolderB = b.type === "directory" || b.type === "cabinet";
+
+      if (sortAlphabetical && foldersFirst && isFolderA !== isFolderB) {
+        return isFolderA ? -1 : 1;
+      }
+
+      if (sortAlphabetical) {
+        const nameA = a.frontmatter?.title || a.name;
+        const nameB = b.frontmatter?.title || b.name;
+        return nameA.localeCompare(nameB, undefined, { numeric: true, sensitivity: "base" });
+      } else {
+        const orderA = a.frontmatter?.order ?? Number.POSITIVE_INFINITY;
+        const orderB = b.frontmatter?.order ?? Number.POSITIVE_INFINITY;
+        if (orderA !== orderB) return orderA - orderB;
+        const nameA = a.frontmatter?.title || a.name;
+        const nameB = b.frontmatter?.title || b.name;
+        return nameA.localeCompare(nameB, undefined, { numeric: true, sensitivity: "base" });
+      }
+    });
 }
 
 function saveExpandedPaths(paths: Set<string>) {
@@ -112,6 +203,7 @@ function saveCachedTree(nodes: TreeNode[], showHidden: boolean) {
 
 export const useTreeStore = create<TreeState>((set, get) => ({
   nodes: [],
+  rawNodes: [],
   selectedPath: null,
   driveNode: null,
   driveLoading: false,
@@ -121,27 +213,34 @@ export const useTreeStore = create<TreeState>((set, get) => ({
   dragOverZone: null,
   movingPaths: new Set<string>(),
   showHiddenFiles: loadShowHiddenFiles(),
+  sortAlphabetical: loadSortAlphabetical(),
+  foldersFirst: loadFoldersFirst(),
+  pendingMove: null,
   focusTick: 0,
   recentlyChanged: new Set<string>(),
+
+  setPendingMove: (move) => set({ pendingMove: move }),
 
   setDriveNode: (node) => set({ driveNode: node }),
   setDriveLoading: (loading) => set({ driveLoading: loading }),
 
   loadTree: async (opts) => {
-    const { showHiddenFiles, nodes: existing } = get();
+    const { showHiddenFiles, nodes: existing, sortAlphabetical, foldersFirst } = get();
     // Paint instantly from cache on first load, then revalidate in the
     // background. Keeps the sidebar from flashing empty on refresh.
     if (existing.length === 0) {
       const cached = loadCachedTree(showHiddenFiles);
       if (cached.length > 0) {
-        set({ nodes: cached, loading: false });
+        const sorted = sortTreeNodes(cached, sortAlphabetical, foldersFirst);
+        set({ rawNodes: cached, nodes: sorted, loading: false });
       } else {
         set({ loading: true });
       }
     }
     try {
       const nodes = await fetchTree(showHiddenFiles, opts?.fresh ?? false);
-      set({ nodes, loading: false });
+      const sorted = sortTreeNodes(nodes, sortAlphabetical, foldersFirst);
+      set({ rawNodes: nodes, nodes: sorted, loading: false });
       saveCachedTree(nodes, showHiddenFiles);
     } catch {
       set({ loading: false });
@@ -226,6 +325,17 @@ export const useTreeStore = create<TreeState>((set, get) => ({
     toParentPath: string,
     neighbors: { prevName?: string | null; nextName?: string | null } = {}
   ) => {
+    const { sortAlphabetical } = get();
+    // Manual drag-reordering conflicts with alphabetical auto-sorting — ask
+    // the user before applying the move (TreeView renders the dialog).
+    if (sortAlphabetical) {
+      set({ pendingMove: { fromPath, toParentPath, neighbors } });
+      return;
+    }
+    await get().executeMovePage({ fromPath, toParentPath, neighbors });
+  },
+
+  executeMovePage: async ({ fromPath, toParentPath, neighbors = {} }) => {
     const fromParent = fromPath.split("/").slice(0, -1).join("/");
     const sameParent =
       fromParent === toParentPath &&
@@ -396,5 +506,19 @@ export const useTreeStore = create<TreeState>((set, get) => ({
   toggleHiddenFiles: () => {
     const { showHiddenFiles } = get();
     get().setShowHiddenFiles(!showHiddenFiles);
+  },
+
+  setSortAlphabetical: (sort: boolean) => {
+    localStorage.setItem("kb-sort-alphabetical", String(sort));
+    const { rawNodes, foldersFirst } = get();
+    const sorted = sortTreeNodes(rawNodes, sort, foldersFirst);
+    set({ sortAlphabetical: sort, nodes: sorted });
+  },
+
+  setFoldersFirst: (foldersFirst: boolean) => {
+    localStorage.setItem("kb-folders-first", String(foldersFirst));
+    const { rawNodes, sortAlphabetical } = get();
+    const sorted = sortTreeNodes(rawNodes, sortAlphabetical, foldersFirst);
+    set({ foldersFirst, nodes: sorted });
   },
 }));

--- a/src/stores/tree-store.ts
+++ b/src/stores/tree-store.ts
@@ -509,14 +509,22 @@ export const useTreeStore = create<TreeState>((set, get) => ({
   },
 
   setSortAlphabetical: (sort: boolean) => {
-    localStorage.setItem("kb-sort-alphabetical", String(sort));
+    try {
+      localStorage.setItem("kb-sort-alphabetical", String(sort));
+    } catch {
+      // Ignore storage failures (private mode, quota) — sort still applies.
+    }
     const { rawNodes, foldersFirst } = get();
     const sorted = sortTreeNodes(rawNodes, sort, foldersFirst);
     set({ sortAlphabetical: sort, nodes: sorted });
   },
 
   setFoldersFirst: (foldersFirst: boolean) => {
-    localStorage.setItem("kb-folders-first", String(foldersFirst));
+    try {
+      localStorage.setItem("kb-folders-first", String(foldersFirst));
+    } catch {
+      // Ignore storage failures (private mode, quota) — sort still applies.
+    }
     const { rawNodes, sortAlphabetical } = get();
     const sorted = sortTreeNodes(rawNodes, sortAlphabetical, foldersFirst);
     set({ foldersFirst, nodes: sorted });


### PR DESCRIPTION
Ported from hilash/cabinet#96, excluding the unrelated changes bundled in those commits (Typst, table-menu UX, PDF icon, Tailwind migrations).

file:// protocol support:
- Link extension now allows any URI (isAllowedUri) so file:// links render
- editor click handler opens file:// links via a new openLocalFileUrl helper: shell.openPath in Electron, a "Copy path" toast in the browser
- markdownToHtml encodes spaces in file:// URLs so [text](file://…) with spaces parses as a single link
- new cabinet:open-local-file IPC handler + openLocalFile preload bridge

Tree-view sorting:
- alphabetical sort with an optional folders-first toggle (Settings → Appearance → Sidebar), persisted to localStorage
- sortTreeNodes applied to the local tree and Google Drive mounts; toggling re-sorts from rawNodes without a server refetch
- dragging while sorting is on prompts a confirm dialog (movePage now defers to executeMovePage)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Click `file://` links in the editor to open the local file with the OS default app.
  * Added Settings → Appearance sidebar sorting controls: auto alphabetical sorting, a “folders first” toggle, and a manual-move conflict dialog when auto-sort is enabled.
* **Bug Fixes**
  * Improved handling of `file://` URLs containing spaces in rendered Markdown/links, so they parse and open correctly.
  * Updated link handling to allow `file://` URIs and route local-file openings through a shared runtime flow (with error/info toasts and “Copy path” outside Electron).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->