### PR TITLE
feat(browser): in-app browse mode ported faithfully from PR #96

### DIFF
--- a/electron/browser-preload.cjs
+++ b/electron/browser-preload.cjs
@@ -1,0 +1,19 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const { webFrame } = require("electron");
+
+// Spoof navigator.userAgentData and provide a fake chrome.webstorePrivate to pass Google's strict client-side checks
+webFrame.executeJavaScript(`
+  Object.defineProperty(navigator, 'userAgentData', {
+    get: () => ({
+      brands: [
+        { brand: "Google Chrome", version: "136" },
+        { brand: "Chromium", version: "136" },
+        { brand: "Not_A Brand", version: "24" }
+      ],
+      mobile: false,
+      platform: "macOS"
+    })
+  });
+  window.chrome = window.chrome || {};
+  window.chrome.webstorePrivate = window.chrome.webstorePrivate || {};
+`);

--- a/electron/browser-views.cjs
+++ b/electron/browser-views.cjs
@@ -93,6 +93,30 @@ function getBrowserBaseUrl() {
   );
 }
 
+// Report the real OS so client-sniffing sites don't misidentify Windows/Linux
+// users as macOS (which can change layout, downloads, and shortcut hints).
+function clientPlatformLabel() {
+  switch (process.platform) {
+    case "win32":
+      return "Windows";
+    case "linux":
+      return "Linux";
+    default:
+      return "macOS";
+  }
+}
+
+function userAgentPlatformToken() {
+  switch (process.platform) {
+    case "win32":
+      return "Windows NT 10.0; Win64; x64";
+    case "linux":
+      return "X11; Linux x86_64";
+    default:
+      return "Macintosh; Intel Mac OS X 10_15_7";
+  }
+}
+
 // Make Google (and other client-sniffing sites) treat the browser session as
 // desktop Chrome rather than Electron, so they don't downgrade or block.
 function setupBrowserSession() {
@@ -102,9 +126,9 @@ function setupBrowserSession() {
     details.requestHeaders["Sec-CH-UA"] =
       '"Google Chrome";v="136", "Chromium";v="136", "Not_A Brand";v="24"';
     details.requestHeaders["Sec-CH-UA-Mobile"] = "?0";
-    details.requestHeaders["Sec-CH-UA-Platform"] = '"macOS"';
+    details.requestHeaders["Sec-CH-UA-Platform"] = `"${clientPlatformLabel()}"`;
     details.requestHeaders["User-Agent"] =
-      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36";
+      `Mozilla/5.0 (${userAgentPlatformToken()}) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36`;
     callback({ requestHeaders: details.requestHeaders });
   });
 }
@@ -295,7 +319,8 @@ function applyClicksToSubmenu(submenu, items, resolveOnce) {
 function registerHandlers() {
   // Open a local file with the OS default app (e.g. Preview for PDFs). file://
   // URLs can't load in a WebContentsView, so the renderer routes them here.
-  ipcMain.handle("cabinet:open-local-file", async (_event, payload) => {
+  ipcMain.handle("cabinet:open-local-file", async (event, payload) => {
+    if (!isMainRendererSender(event)) return { ok: false, error: "unauthorized" };
     try {
       const filePath = typeof payload?.path === "string" ? payload.path : "";
       if (!filePath) return { ok: false, error: "no-path" };

--- a/electron/browser-views.cjs
+++ b/electron/browser-views.cjs
@@ -1,0 +1,576 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+//
+// In-app browser ("browse mode") backed by Electron's native WebContentsView.
+// Ported from hilash/cabinet PR #96. A WebContentsView is a real Chromium view,
+// so unlike the iframe fallback it is NOT subject to `X-Frame-Options: DENY` /
+// CSP `frame-ancestors` — sites like Google, GitHub and X load normally.
+//
+// The renderer (src/components/layout/browser-view.tsx) drives this over the
+// `CabinetDesktop` bridge methods exposed in electron/preload.cjs. The view is
+// parented to the main window's contentView and positioned/sized by the
+// renderer via set-browser-view-bounds, so the React chrome (toolbar,
+// bookmarks) renders around it.
+//
+// Browse mode loads two kinds of URLs: external web pages, and the app's own
+// `/api/assets/...` KB content (opened from the viewer-toolbar Globe button or
+// while browsing the tree). The latter sit behind the `kb-auth` cookie gate, so
+// syncBrowserAuthCookie() copies that cookie into the browser session before
+// each load.
+
+const path = require("path");
+const {
+  BrowserWindow,
+  WebContentsView,
+  Menu,
+  session,
+  shell,
+  ipcMain,
+} = require("electron");
+
+const BROWSER_VIEW_PARTITION = "persist:cabinet-browser";
+
+// Injected by initBrowserViews() so this module stays decoupled from main.cjs.
+let getMainWindow = () => null;
+let getBaseAppUrl = () => null;
+let isDev = false;
+
+const browserViews = new Map();
+let nextBrowserViewId = 1;
+
+function liveMainWindow() {
+  try {
+    const win = getMainWindow();
+    return win && !win.isDestroyed() ? win : null;
+  } catch {
+    return null;
+  }
+}
+
+function isMainRendererSender(event) {
+  const win = liveMainWindow();
+  return !!win && event.sender.id === win.webContents.id;
+}
+
+function sendBrowserViewNavigateEvent(ownerWebContentsId, viewId, url) {
+  const win = liveMainWindow();
+  if (!win) return;
+  const wc = win.webContents;
+  if (!wc || wc.id !== ownerWebContentsId || wc.isDestroyed()) return;
+  try {
+    wc.send("cabinet:browser-view-navigated", { viewId, url });
+  } catch {}
+}
+
+function sendBrowserViewLoadFailedEvent(ownerWebContentsId, viewId, payload) {
+  const win = liveMainWindow();
+  if (!win) return;
+  const wc = win.webContents;
+  if (!wc || wc.id !== ownerWebContentsId || wc.isDestroyed()) return;
+  try {
+    wc.send("cabinet:browser-view-load-failed", { viewId, ...payload });
+  } catch {}
+}
+
+function getBrowserSession() {
+  return session.fromPartition(BROWSER_VIEW_PARTITION);
+}
+
+function getMainRendererSession() {
+  const win = liveMainWindow();
+  if (win) {
+    const wc = win.webContents;
+    if (wc && !wc.isDestroyed()) return wc.session;
+  }
+  return session.defaultSession;
+}
+
+function getBrowserBaseUrl() {
+  const win = liveMainWindow();
+  return (
+    (win && win.webContents.getURL()) ||
+    getBaseAppUrl() ||
+    "http://127.0.0.1"
+  );
+}
+
+// Make Google (and other client-sniffing sites) treat the browser session as
+// desktop Chrome rather than Electron, so they don't downgrade or block.
+function setupBrowserSession() {
+  const browserSession = getBrowserSession();
+  const filter = { urls: ["*://*.google.com/*"] };
+  browserSession.webRequest.onBeforeSendHeaders(filter, (details, callback) => {
+    details.requestHeaders["Sec-CH-UA"] =
+      '"Google Chrome";v="136", "Chromium";v="136", "Not_A Brand";v="24"';
+    details.requestHeaders["Sec-CH-UA-Mobile"] = "?0";
+    details.requestHeaders["Sec-CH-UA-Platform"] = '"macOS"';
+    details.requestHeaders["User-Agent"] =
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36";
+    callback({ requestHeaders: details.requestHeaders });
+  });
+}
+
+// The browser session is a separate partition, so it doesn't share the main
+// renderer's auth cookie. Copy the `kb-auth` cookie across before loading
+// in-app `/api/assets/...` content so those requests aren't rejected by the gate.
+async function syncBrowserAuthCookie() {
+  const sourceSession = getMainRendererSession();
+  const targetSession = getBrowserSession();
+  let origin;
+  try {
+    origin = new URL(getBrowserBaseUrl()).origin;
+  } catch {
+    return;
+  }
+  try {
+    const sourceCookies = await sourceSession.cookies.get({ url: origin, name: "kb-auth" });
+    const authCookie = sourceCookies.find((cookie) => cookie && typeof cookie.value === "string");
+    if (!authCookie) {
+      try {
+        await targetSession.cookies.remove(origin, "kb-auth");
+      } catch {}
+      return;
+    }
+    const cookieUrl = `${origin}${authCookie.path || "/"}`;
+    const cookiePayload = {
+      url: cookieUrl,
+      name: authCookie.name,
+      value: authCookie.value,
+      path: authCookie.path || "/",
+      secure: authCookie.secure,
+      httpOnly: authCookie.httpOnly,
+      sameSite: authCookie.sameSite,
+    };
+    if (typeof authCookie.expirationDate === "number") {
+      cookiePayload.expirationDate = authCookie.expirationDate;
+    }
+    await targetSession.cookies.set(cookiePayload);
+  } catch {}
+}
+
+function isAbortNavigationError(error) {
+  if (!error || typeof error !== "object") return false;
+  return error.code === "ERR_ABORTED" || error.errno === -3;
+}
+
+// Normalize a requested target to a loadable absolute URL. External URLs pass
+// through; app-relative paths (incl. /api/assets KB content) resolve against the
+// embedded server's base URL and load over http (the daemon always runs, so this
+// works in dev and prod alike).
+function resolveBrowserTarget(value) {
+  if (typeof value !== "string") return { primaryUrl: null };
+  const trimmed = value.trim();
+  if (!trimmed) return { primaryUrl: null };
+  if (trimmed === "about:blank") return { primaryUrl: trimmed };
+  if (trimmed.startsWith("file://")) return { primaryUrl: trimmed };
+  if (trimmed.startsWith("//")) return { primaryUrl: `https:${trimmed}` };
+  if (trimmed.startsWith("/") || trimmed.startsWith("./") || trimmed.startsWith("../")) {
+    try {
+      return { primaryUrl: new URL(trimmed, getBrowserBaseUrl()).toString() };
+    } catch {
+      return { primaryUrl: null };
+    }
+  }
+  if (/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(trimmed)) return { primaryUrl: trimmed };
+  return { primaryUrl: `https://${trimmed}` };
+}
+
+async function loadBrowserViewUrlSafe(webContents, nextUrl) {
+  const { primaryUrl } = resolveBrowserTarget(nextUrl);
+  if (!primaryUrl) {
+    return {
+      ok: false,
+      error: "invalid-target-url",
+      requestedUrl: typeof nextUrl === "string" ? nextUrl : "",
+      primaryUrl: "",
+      primaryError: "invalid-target-url",
+    };
+  }
+  try {
+    await webContents.loadURL(primaryUrl);
+    return { ok: true, loadedUrl: primaryUrl };
+  } catch (error) {
+    if (isAbortNavigationError(error)) {
+      return { ok: true, aborted: true, loadedUrl: primaryUrl };
+    }
+    return {
+      ok: false,
+      error: "load-failed",
+      requestedUrl: typeof nextUrl === "string" ? nextUrl : "",
+      primaryUrl,
+      primaryError: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function destroyBrowserView(viewId) {
+  const entry = browserViews.get(viewId);
+  const win = liveMainWindow();
+  if (!entry || !win) {
+    browserViews.delete(viewId);
+    return;
+  }
+  try {
+    win.contentView.removeChildView(entry.view);
+  } catch {}
+  try {
+    entry.view.webContents.close();
+  } catch {}
+  browserViews.delete(viewId);
+}
+
+function destroyAllBrowserViews() {
+  for (const viewId of [...browserViews.keys()]) {
+    destroyBrowserView(viewId);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bookmarks context menu (native). The renderer hands us the bookmark tree and
+// we pop a native menu, resolving with the chosen item's id/url.
+// ---------------------------------------------------------------------------
+
+function buildBookmarkSubmenuTemplate(items) {
+  if (!Array.isArray(items)) return [];
+  const template = [];
+  for (const item of items) {
+    if (!item || typeof item !== "object") continue;
+    const id = typeof item.id === "string" ? item.id : "";
+    const name =
+      typeof item.name === "string" && item.name.trim() ? item.name.trim() : "Untitled";
+    const type = item.type === "folder" ? "folder" : "url";
+    if (type === "folder") {
+      const children = buildBookmarkSubmenuTemplate(item.children);
+      template.push({
+        id,
+        label: name,
+        submenu: children.length > 0 ? children : [{ label: "Empty", enabled: false }],
+      });
+      continue;
+    }
+    const url = typeof item.url === "string" ? item.url.trim() : "";
+    if (!url) continue;
+    template.push({ id, label: name, click: () => {} });
+  }
+  return template;
+}
+
+function findMenuItemById(items, id) {
+  if (!Array.isArray(items) || typeof id !== "string") return null;
+  for (const item of items) {
+    if (!item || typeof item !== "object") continue;
+    if (item.id === id) return item;
+    if (item.type === "folder") {
+      const nested = findMenuItemById(item.children, id);
+      if (nested) return nested;
+    }
+  }
+  return null;
+}
+
+function applyClicksToSubmenu(submenu, items, resolveOnce) {
+  if (!Array.isArray(submenu)) return [];
+  return submenu.map((entry) => {
+    if (!entry || typeof entry !== "object") return entry;
+    if (entry.submenu) {
+      return {
+        ...entry,
+        submenu: applyClicksToSubmenu(entry.submenu, items, resolveOnce),
+      };
+    }
+    if (!entry.id) return entry;
+    return {
+      ...entry,
+      click: () => {
+        const selected = findMenuItemById(items, entry.id);
+        resolveOnce({ ok: true, id: entry.id, url: selected?.url });
+      },
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// IPC registration
+// ---------------------------------------------------------------------------
+
+function registerHandlers() {
+  // Open a local file with the OS default app (e.g. Preview for PDFs). file://
+  // URLs can't load in a WebContentsView, so the renderer routes them here.
+  ipcMain.handle("cabinet:open-local-file", async (_event, payload) => {
+    try {
+      const filePath = typeof payload?.path === "string" ? payload.path : "";
+      if (!filePath) return { ok: false, error: "no-path" };
+      const errorMessage = await shell.openPath(filePath);
+      if (errorMessage) return { ok: false, error: errorMessage };
+      return { ok: true };
+    } catch (error) {
+      return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  });
+
+  ipcMain.handle("cabinet:create-browser-view", async (event, payload) => {
+    if (!isMainRendererSender(event)) return { ok: false, error: "unauthorized" };
+    const win = liveMainWindow();
+    if (!win) return { ok: false, error: "window-unavailable" };
+    const initialUrl = typeof payload?.url === "string" ? payload.url.trim() : "";
+    const viewId = String(nextBrowserViewId++);
+    const view = new WebContentsView({
+      webPreferences: {
+        partition: BROWSER_VIEW_PARTITION,
+        contextIsolation: true,
+        sandbox: true,
+        nodeIntegration: false,
+        preload: path.join(__dirname, "browser-preload.cjs"),
+      },
+    });
+    view.setBounds({ x: 0, y: 0, width: 0, height: 0 });
+    view.setVisible(false);
+
+    const defaultUA = view.webContents.userAgent || "";
+    view.webContents.userAgent = defaultUA
+      .replace(/Electron\/[\d.]+ ?/g, "")
+      .replace(/cabinet\/[\d.]+ ?/g, "");
+
+    win.contentView.addChildView(view);
+    browserViews.set(viewId, { view, ownerWebContentsId: event.sender.id });
+
+    view.webContents.on("did-navigate", (_navEvent, nextUrl) => {
+      sendBrowserViewNavigateEvent(event.sender.id, viewId, String(nextUrl || "about:blank"));
+    });
+    view.webContents.on("did-navigate-in-page", (_navEvent, nextUrl) => {
+      sendBrowserViewNavigateEvent(event.sender.id, viewId, String(nextUrl || "about:blank"));
+    });
+    view.webContents.on("did-fail-load", (_navEvent, errorCode, errorDescription, validatedUrl) => {
+      if (errorCode === -3) return;
+      sendBrowserViewLoadFailedEvent(event.sender.id, viewId, {
+        errorCode,
+        errorDescription: String(errorDescription || "load-failed"),
+        validatedUrl: String(validatedUrl || ""),
+      });
+    });
+    // Open popups/target=_blank in the same view rather than a new OS window.
+    view.webContents.setWindowOpenHandler(({ url: nextUrl }) => {
+      void syncBrowserAuthCookie()
+        .then(() => loadBrowserViewUrlSafe(view.webContents, nextUrl))
+        .then((result) => {
+          if (result?.ok) return;
+          sendBrowserViewLoadFailedEvent(event.sender.id, viewId, {
+            requestedUrl: typeof nextUrl === "string" ? nextUrl : "",
+            primaryUrl: result?.primaryUrl || "",
+            primaryError: result?.primaryError || result?.error || "load-failed",
+          });
+        })
+        .catch(() => {});
+      return { action: "deny" };
+    });
+    view.webContents.on("context-menu", (_menuEvent, params) => {
+      const devToolsOpen = !!win && !win.isDestroyed() && win.webContents.isDevToolsOpened();
+      const canInspect = isDev || devToolsOpen;
+      const template = [{ role: "copy" }, { role: "paste" }, { role: "selectAll" }];
+      if (canInspect) {
+        template.push({ type: "separator" });
+        template.push({
+          label: "Inspect Element",
+          click: () => {
+            if (!view.webContents.isDevToolsOpened()) {
+              view.webContents.openDevTools({ mode: "detach" });
+            }
+            view.webContents.inspectElement(params.x, params.y);
+          },
+        });
+      }
+      const menu = Menu.buildFromTemplate(template);
+      const popupWindow = BrowserWindow.fromWebContents(event.sender);
+      menu.popup({ window: popupWindow || undefined });
+    });
+
+    await syncBrowserAuthCookie();
+    await loadBrowserViewUrlSafe(view.webContents, initialUrl);
+    return { ok: true, viewId };
+  });
+
+  ipcMain.handle("cabinet:load-browser-view-url", async (event, payload) => {
+    try {
+      if (!isMainRendererSender(event)) return { ok: false, error: "unauthorized" };
+      const viewId = typeof payload?.viewId === "string" ? payload.viewId : "";
+      const nextUrl = typeof payload?.url === "string" ? payload.url.trim() : "";
+      const entry = browserViews.get(viewId);
+      if (!entry || entry.ownerWebContentsId !== event.sender.id) {
+        return { ok: false, error: "not-found" };
+      }
+      const wc = entry.view.webContents;
+      if (nextUrl === "__cabinet_nav_back__") {
+        if (!wc.canGoBack()) return { ok: true, skipped: true };
+        wc.goBack();
+        return { ok: true };
+      }
+      if (nextUrl === "__cabinet_nav_forward__") {
+        if (!wc.canGoForward()) return { ok: true, skipped: true };
+        wc.goForward();
+        return { ok: true };
+      }
+      if (nextUrl === "__cabinet_nav_reload__") {
+        wc.reload();
+        return { ok: true };
+      }
+      await syncBrowserAuthCookie();
+      const result = await loadBrowserViewUrlSafe(wc, nextUrl);
+      if (!result.ok) {
+        sendBrowserViewLoadFailedEvent(event.sender.id, viewId, {
+          requestedUrl: nextUrl,
+          primaryUrl: result.primaryUrl || "",
+          primaryError: result.primaryError || "",
+        });
+      }
+      return result;
+    } catch {
+      return { ok: false, error: "handler-failed" };
+    }
+  });
+
+  ipcMain.handle("cabinet:set-browser-view-bounds", (event, payload) => {
+    if (!isMainRendererSender(event)) return { ok: false, error: "unauthorized" };
+    const viewId = typeof payload?.viewId === "string" ? payload.viewId : "";
+    const bounds = payload?.bounds;
+    const entry = browserViews.get(viewId);
+    if (!entry || entry.ownerWebContentsId !== event.sender.id) {
+      return { ok: false, error: "not-found" };
+    }
+    const x = Number.isFinite(bounds?.x) ? Math.max(0, Math.round(bounds.x)) : 0;
+    const y = Number.isFinite(bounds?.y) ? Math.max(0, Math.round(bounds.y)) : 0;
+    const width = Number.isFinite(bounds?.width) ? Math.max(0, Math.round(bounds.width)) : 0;
+    const height = Number.isFinite(bounds?.height) ? Math.max(0, Math.round(bounds.height)) : 0;
+    if (width >= 64 && height >= 64) {
+      entry.view.setBounds({ x, y, width, height });
+    }
+    return { ok: true };
+  });
+
+  ipcMain.handle("cabinet:set-browser-view-visible", (event, payload) => {
+    if (!isMainRendererSender(event)) return { ok: false, error: "unauthorized" };
+    const viewId = typeof payload?.viewId === "string" ? payload.viewId : "";
+    const visible = payload?.visible === true;
+    const entry = browserViews.get(viewId);
+    if (!entry || entry.ownerWebContentsId !== event.sender.id) {
+      return { ok: false, error: "not-found" };
+    }
+    try {
+      entry.view.setVisible(visible);
+    } catch {}
+    return { ok: true };
+  });
+
+  ipcMain.handle("cabinet:browser-view-go-back", async (event, payload) => {
+    if (!isMainRendererSender(event)) return { ok: false, error: "unauthorized" };
+    const viewId = typeof payload?.viewId === "string" ? payload.viewId : "";
+    const entry = browserViews.get(viewId);
+    if (!entry || entry.ownerWebContentsId !== event.sender.id) {
+      return { ok: false, error: "not-found" };
+    }
+    const wc = entry.view.webContents;
+    if (!wc.canGoBack()) return { ok: true, skipped: true };
+    wc.goBack();
+    return { ok: true };
+  });
+
+  ipcMain.handle("cabinet:browser-view-go-forward", async (event, payload) => {
+    if (!isMainRendererSender(event)) return { ok: false, error: "unauthorized" };
+    const viewId = typeof payload?.viewId === "string" ? payload.viewId : "";
+    const entry = browserViews.get(viewId);
+    if (!entry || entry.ownerWebContentsId !== event.sender.id) {
+      return { ok: false, error: "not-found" };
+    }
+    const wc = entry.view.webContents;
+    if (!wc.canGoForward()) return { ok: true, skipped: true };
+    wc.goForward();
+    return { ok: true };
+  });
+
+  ipcMain.handle("cabinet:browser-view-reload", async (event, payload) => {
+    if (!isMainRendererSender(event)) return { ok: false, error: "unauthorized" };
+    const viewId = typeof payload?.viewId === "string" ? payload.viewId : "";
+    const entry = browserViews.get(viewId);
+    if (!entry || entry.ownerWebContentsId !== event.sender.id) {
+      return { ok: false, error: "not-found" };
+    }
+    entry.view.webContents.reload();
+    return { ok: true };
+  });
+
+  ipcMain.handle("cabinet:destroy-browser-view", (event, payload) => {
+    if (!isMainRendererSender(event)) return { ok: false, error: "unauthorized" };
+    const viewId = typeof payload?.viewId === "string" ? payload.viewId : "";
+    const entry = browserViews.get(viewId);
+    if (!entry || entry.ownerWebContentsId !== event.sender.id) {
+      return { ok: false, error: "not-found" };
+    }
+    destroyBrowserView(viewId);
+    return { ok: true };
+  });
+
+  ipcMain.handle("cabinet:show-browser-bookmarks-menu", async (event, payload) => {
+    if (!isMainRendererSender(event)) return { ok: false, error: "unauthorized" };
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (!win || win.isDestroyed()) return { ok: false, error: "window-unavailable" };
+
+    const x = Number.isFinite(payload?.x) ? Math.max(0, Math.round(payload.x)) : 0;
+    const y = Number.isFinite(payload?.y) ? Math.max(0, Math.round(payload.y)) : 0;
+    const items = Array.isArray(payload?.items) ? payload.items : [];
+    const template = buildBookmarkSubmenuTemplate(items);
+
+    if (template.length === 0) return { ok: true, cancelled: true };
+
+    return await new Promise((resolve) => {
+      let resolved = false;
+      const resolveOnce = (value) => {
+        if (resolved) return;
+        resolved = true;
+        resolve(value);
+      };
+
+      const withClicks = template.map((entry) => {
+        if (!entry.submenu) {
+          return {
+            ...entry,
+            click: () => {
+              const selected = findMenuItemById(items, entry.id);
+              resolveOnce({ ok: true, id: entry.id, url: selected?.url });
+            },
+          };
+        }
+        return {
+          ...entry,
+          submenu: applyClicksToSubmenu(entry.submenu, items, resolveOnce),
+        };
+      });
+
+      const menu = Menu.buildFromTemplate(withClicks);
+      menu.popup({
+        window: win,
+        x,
+        y,
+        callback: () => {
+          resolveOnce({ ok: true, cancelled: true });
+        },
+      });
+    });
+  });
+}
+
+/**
+ * Wire up the native browse-mode handlers. Call once after `app` is ready.
+ * @param {object} opts
+ * @param {() => Electron.BrowserWindow | null} opts.getMainWindow resolver for
+ *   the window the browser views attach to.
+ * @param {() => string | null} [opts.getBaseAppUrl] resolver for the embedded
+ *   server base URL, used to load app-relative /api/assets content.
+ * @param {boolean} [opts.isDev] enables the "Inspect Element" context menu item.
+ */
+function initBrowserViews(opts) {
+  getMainWindow = opts?.getMainWindow ?? (() => null);
+  getBaseAppUrl = opts?.getBaseAppUrl ?? (() => null);
+  isDev = opts?.isDev === true;
+  setupBrowserSession();
+  registerHandlers();
+}
+
+module.exports = { initBrowserViews, destroyAllBrowserViews };

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -6,6 +6,10 @@ const net = require("net");
 const { spawn } = require("child_process");
 const { app, BrowserWindow, dialog, autoUpdater, ipcMain } = require("electron");
 const { updateElectronApp } = require("update-electron-app");
+const {
+  initBrowserViews,
+  destroyAllBrowserViews,
+} = require("./browser-views.cjs");
 
 if (require("electron-squirrel-startup")) {
   app.quit();
@@ -706,6 +710,7 @@ async function openRoomWindow(suffix) {
 ipcMain.handle("cabinet:open-window", (_event, suffix) => openRoomWindow(suffix));
 
 app.on("window-all-closed", () => {
+  destroyAllBrowserViews();
   cleanupBackends();
   if (process.platform !== "darwin") {
     app.quit();
@@ -713,6 +718,7 @@ app.on("window-all-closed", () => {
 });
 
 app.on("before-quit", () => {
+  destroyAllBrowserViews();
   cleanupBackends();
 });
 
@@ -733,6 +739,14 @@ app.on("second-instance", () => {
 
 app.whenReady().then(async () => {
   configureAutoUpdates();
+  // Native in-app browser (browse mode). Attaches WebContentsViews to the
+  // current main window; getBaseAppUrl resolves app-relative /api/assets KB
+  // URLs; isDev enables the "Inspect Element" context menu.
+  initBrowserViews({
+    getMainWindow: () => mainWindow,
+    getBaseAppUrl: () => baseAppUrl,
+    isDev,
+  });
   await createWindow();
 
   app.on("activate", async () => {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -1,9 +1,85 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { contextBridge, ipcRenderer } = require("electron");
 
+// Fan-out registries for browse-mode events pushed from the main process
+// (electron/browser-views.cjs). The renderer subscribes via the bridge's
+// onBrowserView* methods, which return an unsubscribe function.
+const browserViewNavigateListeners = new Set();
+const browserViewLoadFailedListeners = new Set();
+
+ipcRenderer.on("cabinet:browser-view-navigated", (_event, payload) => {
+  for (const listener of browserViewNavigateListeners) {
+    try {
+      listener(payload);
+    } catch {}
+  }
+});
+
+ipcRenderer.on("cabinet:browser-view-load-failed", (_event, payload) => {
+  for (const listener of browserViewLoadFailedListeners) {
+    try {
+      listener(payload);
+    } catch {}
+  }
+});
+
+function normalizeBridgeUrl(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
 contextBridge.exposeInMainWorld("CabinetDesktop", {
   runtime: "electron",
   platform: process.platform,
+  // --- In-app browser ("browse mode") backed by a native WebContentsView ---
+  openLocalFile: (filePath) =>
+    ipcRenderer.invoke("cabinet:open-local-file", { path: filePath }),
+  createBrowserView: async (url) => {
+    try {
+      return await ipcRenderer.invoke("cabinet:create-browser-view", {
+        url: normalizeBridgeUrl(url),
+      });
+    } catch {
+      return { ok: false, error: "invoke-failed" };
+    }
+  },
+  loadBrowserViewUrl: async (viewId, url) => {
+    try {
+      return await ipcRenderer.invoke("cabinet:load-browser-view-url", {
+        viewId,
+        url: normalizeBridgeUrl(url),
+      });
+    } catch {
+      return { ok: false, error: "invoke-failed" };
+    }
+  },
+  setBrowserViewBounds: (viewId, bounds) =>
+    ipcRenderer.invoke("cabinet:set-browser-view-bounds", { viewId, bounds }),
+  setBrowserViewVisible: (viewId, visible) =>
+    ipcRenderer.invoke("cabinet:set-browser-view-visible", { viewId, visible }),
+  browserViewGoBack: (viewId) =>
+    ipcRenderer.invoke("cabinet:browser-view-go-back", { viewId }),
+  browserViewGoForward: (viewId) =>
+    ipcRenderer.invoke("cabinet:browser-view-go-forward", { viewId }),
+  browserViewReload: (viewId) =>
+    ipcRenderer.invoke("cabinet:browser-view-reload", { viewId }),
+  showBrowserBookmarksMenu: (payload) =>
+    ipcRenderer.invoke("cabinet:show-browser-bookmarks-menu", payload),
+  destroyBrowserView: (viewId) =>
+    ipcRenderer.invoke("cabinet:destroy-browser-view", { viewId }),
+  onBrowserViewNavigated: (listener) => {
+    if (typeof listener !== "function") return () => {};
+    browserViewNavigateListeners.add(listener);
+    return () => {
+      browserViewNavigateListeners.delete(listener);
+    };
+  },
+  onBrowserViewLoadFailed: (listener) => {
+    if (typeof listener !== "function") return () => {};
+    browserViewLoadFailedListeners.add(listener);
+    return () => {
+      browserViewLoadFailedListeners.delete(listener);
+    };
+  },
   /**
    * Trigger the in-app macOS uninstall flow. Returns
    * `{ ok: true, dataPath }` on success — the renderer should show a

--- a/forge.config.cjs
+++ b/forge.config.cjs
@@ -21,7 +21,7 @@ const PACKAGER_IGNORE = [
   /^\/assets(?:\/|$)/,
   /^\/cli(?:\/|$)/,
   /^\/public(?:\/|$)/,
-  /^\/electron\/(?!main\.cjs$|preload\.cjs$).*/,
+  /^\/electron\/(?!main\.cjs$|preload\.cjs$|browser-views\.cjs$|browser-preload\.cjs$).*/,
   /^\/server(?:\/|$)/,
   /^\/src(?:\/|$)/,
   /^\/data(?:\/|$)/,

--- a/src/app/api/browser/bookmarks/route.ts
+++ b/src/app/api/browser/bookmarks/route.ts
@@ -1,0 +1,485 @@
+import crypto from "crypto";
+import fs from "fs/promises";
+import path from "path";
+import { NextRequest, NextResponse } from "next/server";
+import { CABINET_INTERNAL_DIR } from "@/lib/storage/path-utils";
+
+export const dynamic = "force-dynamic";
+
+type BookmarkUrlNode = {
+  id: string;
+  name: string;
+  type: "url";
+  date_added: string;
+  date_last_used: string;
+  url: string;
+  tags: string[];
+  meta_info?: Record<string, string>;
+};
+
+type BookmarkFolderNode = {
+  id: string;
+  name: string;
+  type: "folder";
+  date_added: string;
+  date_modified: string;
+  children: BookmarkNode[];
+};
+
+type BookmarkNode = BookmarkUrlNode | BookmarkFolderNode;
+
+type BookmarkRoots = {
+  bookmark_bar: BookmarkFolderNode;
+  other: BookmarkFolderNode;
+};
+
+type BookmarkFile = {
+  checksum: string;
+  roots: BookmarkRoots;
+  version: 1;
+};
+
+type AddBookmarkPayload = {
+  action: "addBookmark";
+  name?: string;
+  url: string;
+  parentId?: string;
+  tags?: string[];
+};
+
+type CreateFolderPayload = {
+  action: "createFolder";
+  name?: string;
+  parentId?: string;
+};
+
+type MarkUsedPayload = {
+  action: "markUsed";
+  id: string;
+};
+
+type ResolveTitlePayload = {
+  action: "resolveTitle";
+  url: string;
+};
+
+type PostPayload = AddBookmarkPayload | CreateFolderPayload | MarkUsedPayload | ResolveTitlePayload;
+
+const BOOKMARKS_PATH = path.join(CABINET_INTERNAL_DIR, "bookmarks.json");
+const EPOCH_OFFSET_US = BigInt("11644473600000000");
+
+function chromeNow(): string {
+  return (BigInt(Date.now()) * BigInt(1000) + EPOCH_OFFSET_US).toString();
+}
+
+function computeChecksum(roots: BookmarkRoots, version: number): string {
+  return crypto.createHash("sha1").update(JSON.stringify({ roots, version })).digest("hex");
+}
+
+function makeDefaultBookmarks(): BookmarkFile {
+  const now = chromeNow();
+  const roots: BookmarkRoots = {
+    bookmark_bar: {
+      id: "1",
+      name: "Bookmarks bar",
+      type: "folder",
+      date_added: now,
+      date_modified: now,
+      children: [],
+    },
+    other: {
+      id: "2",
+      name: "Other bookmarks",
+      type: "folder",
+      date_added: now,
+      date_modified: now,
+      children: [],
+    },
+  };
+  return {
+    checksum: computeChecksum(roots, 1),
+    roots,
+    version: 1,
+  };
+}
+
+function normalizeTags(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((entry): entry is string => typeof entry === "string")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+function sanitizeNode(input: unknown): BookmarkNode | null {
+  const node = input as Partial<BookmarkNode> | null;
+  if (!node || typeof node !== "object") return null;
+  if (node.type === "url") {
+    if (typeof node.id !== "string") return null;
+    if (typeof node.name !== "string") return null;
+    if (typeof (node as Partial<BookmarkUrlNode>).url !== "string") return null;
+      return {
+        id: node.id,
+        name: node.name,
+        type: "url",
+        url: (node as Partial<BookmarkUrlNode>).url || "about:blank",
+        date_added: typeof node.date_added === "string" ? node.date_added : chromeNow(),
+        date_last_used: typeof (node as Partial<BookmarkUrlNode>).date_last_used === "string"
+          ? (node as Partial<BookmarkUrlNode>).date_last_used as string
+          : "0",
+        tags: normalizeTags((node as Partial<BookmarkUrlNode>).tags),
+        meta_info: typeof (node as Partial<BookmarkUrlNode>).meta_info === "object"
+          ? (node as Partial<BookmarkUrlNode>).meta_info as Record<string, string>
+          : undefined,
+      };
+  }
+  if (node.type === "folder") {
+    if (typeof node.id !== "string") return null;
+    if (typeof node.name !== "string") return null;
+    const childrenRaw: unknown[] = Array.isArray((node as Partial<BookmarkFolderNode>).children)
+      ? ((node as Partial<BookmarkFolderNode>).children as unknown[])
+      : [];
+    const children = childrenRaw
+      .map((child) => sanitizeNode(child))
+      .filter((child): child is BookmarkNode => child !== null);
+    return {
+      id: node.id,
+      name: node.name,
+      type: "folder",
+      date_added: typeof node.date_added === "string" ? node.date_added : chromeNow(),
+      date_modified: typeof (node as Partial<BookmarkFolderNode>).date_modified === "string"
+        ? (node as Partial<BookmarkFolderNode>).date_modified as string
+        : chromeNow(),
+      children,
+    };
+  }
+  return null;
+}
+
+function sanitizeRootFolder(input: unknown, fallbackName: string, fallbackId: string): BookmarkFolderNode {
+  const node = sanitizeNode(input);
+  if (node?.type === "folder") {
+    return node;
+  }
+  const now = chromeNow();
+  return {
+    id: fallbackId,
+    name: fallbackName,
+    type: "folder",
+    date_added: now,
+    date_modified: now,
+    children: [],
+  };
+}
+
+function sanitizeBookmarkFile(input: unknown): BookmarkFile {
+  const raw = input as Partial<BookmarkFile> | null;
+  if (!raw || typeof raw !== "object") {
+    return makeDefaultBookmarks();
+  }
+  const rootsObj = (raw.roots ?? {}) as Partial<BookmarkRoots>;
+  const roots: BookmarkRoots = {
+    bookmark_bar: sanitizeRootFolder(rootsObj.bookmark_bar, "Bookmarks bar", "1"),
+    other: sanitizeRootFolder(rootsObj.other, "Other bookmarks", "2"),
+  };
+  return {
+    checksum: computeChecksum(roots, 1),
+    roots,
+    version: 1,
+  };
+}
+
+async function readBookmarks(): Promise<BookmarkFile> {
+  try {
+    const raw = await fs.readFile(BOOKMARKS_PATH, "utf-8");
+    return sanitizeBookmarkFile(JSON.parse(raw));
+  } catch {
+    const defaults = makeDefaultBookmarks();
+    await writeBookmarks(defaults);
+    return defaults;
+  }
+}
+
+async function writeBookmarks(bookmarks: BookmarkFile): Promise<void> {
+  const payload: BookmarkFile = {
+    ...bookmarks,
+    version: 1,
+    checksum: computeChecksum(bookmarks.roots, 1),
+  };
+  await fs.mkdir(path.dirname(BOOKMARKS_PATH), { recursive: true });
+  await fs.writeFile(BOOKMARKS_PATH, `${JSON.stringify(payload, null, 2)}\n`, "utf-8");
+}
+
+function walkNodes(folder: BookmarkFolderNode, visit: (node: BookmarkNode, parent: BookmarkFolderNode) => void): void {
+  for (const child of folder.children) {
+    visit(child, folder);
+    if (child.type === "folder") {
+      walkNodes(child, visit);
+    }
+  }
+}
+
+function getNextId(file: BookmarkFile): string {
+  let maxId = 0;
+  const parseId = (value: string) => {
+    const num = Number.parseInt(value, 10);
+    if (Number.isFinite(num) && num > maxId) {
+      maxId = num;
+    }
+  };
+  parseId(file.roots.bookmark_bar.id);
+  parseId(file.roots.other.id);
+  walkNodes(file.roots.bookmark_bar, (node) => parseId(node.id));
+  walkNodes(file.roots.other, (node) => parseId(node.id));
+  return String(maxId + 1);
+}
+
+function findFolderById(file: BookmarkFile, folderId: string | undefined): BookmarkFolderNode {
+  const fallback = file.roots.bookmark_bar;
+  if (!folderId) return fallback;
+  if (file.roots.bookmark_bar.id === folderId) return file.roots.bookmark_bar;
+  if (file.roots.other.id === folderId) return file.roots.other;
+  let found: BookmarkFolderNode | null = null;
+  const tryFind = (root: BookmarkFolderNode) => {
+    walkNodes(root, (node) => {
+      if (found) return;
+      if (node.type === "folder" && node.id === folderId) {
+        found = node;
+      }
+    });
+  };
+  tryFind(file.roots.bookmark_bar);
+  tryFind(file.roots.other);
+  return found ?? fallback;
+}
+
+function findNodeAndParent(
+  file: BookmarkFile,
+  nodeId: string
+): { node: BookmarkNode; parent: BookmarkFolderNode } | null {
+  let found: { node: BookmarkNode; parent: BookmarkFolderNode } | null = null;
+  const inspectRoot = (root: BookmarkFolderNode) => {
+    walkNodes(root, (node, parent) => {
+      if (found) return;
+      if (node.id === nodeId) {
+        found = { node, parent };
+      }
+    });
+  };
+  inspectRoot(file.roots.bookmark_bar);
+  inspectRoot(file.roots.other);
+  return found;
+}
+
+function normalizeName(value: string | undefined, fallback: string): string {
+  const next = value?.trim();
+  return next && next.length > 0 ? next : fallback;
+}
+
+function normalizeUrl(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return "about:blank";
+  if (/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(trimmed) || trimmed.startsWith("//")) return trimmed;
+  return `https://${trimmed}`;
+}
+
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&#x([\da-fA-F]+);/g, (_match, hex) => {
+      const codepoint = Number.parseInt(hex, 16);
+      if (!Number.isFinite(codepoint)) return _match;
+      try {
+        return String.fromCodePoint(codepoint);
+      } catch {
+        return _match;
+      }
+    })
+    .replace(/&#(\d+);/g, (_match, dec) => {
+      const codepoint = Number.parseInt(dec, 10);
+      if (!Number.isFinite(codepoint)) return _match;
+      try {
+        return String.fromCodePoint(codepoint);
+      } catch {
+        return _match;
+      }
+    })
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&apos;/gi, "'");
+}
+
+function extractTitleFromHtml(html: string): string | null {
+  const headMatch = html.match(/<head\b[^>]*>([\s\S]*?)<\/head>/i);
+  const source = headMatch?.[1] ?? html;
+  const titleMatch = source.match(/<title\b[^>]*>([\s\S]*?)<\/title>/i);
+  if (!titleMatch?.[1]) return null;
+  const cleaned = decodeHtmlEntities(titleMatch[1]).replace(/\s+/g, " ").trim();
+  return cleaned.length > 0 ? cleaned : null;
+}
+
+async function resolveBookmarkTitle(nextUrl: string): Promise<string | null> {
+  let parsed: URL;
+  try {
+    parsed = new URL(nextUrl);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return null;
+  }
+  try {
+    const response = await fetch(parsed.toString(), {
+      method: "GET",
+      redirect: "follow",
+      cache: "no-store",
+      headers: {
+        accept: "text/html,application/xhtml+xml;q=0.9,*/*;q=0.8",
+      },
+    });
+    if (!response.ok) return null;
+    const html = await response.text();
+    return extractTitleFromHtml(html);
+  } catch {
+    return null;
+  }
+}
+
+export async function GET() {
+  try {
+    const bookmarks = await readBookmarks();
+    return NextResponse.json(bookmarks);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to read bookmarks";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const payload = (await request.json()) as PostPayload;
+    const bookmarks = await readBookmarks();
+    const now = chromeNow();
+
+    if (payload.action === "addBookmark") {
+      const targetFolder = findFolderById(bookmarks, payload.parentId);
+      const nextUrl = normalizeUrl(payload.url);
+      const requestedName = payload.name?.trim();
+      const fetchedTitle = await resolveBookmarkTitle(nextUrl);
+      const nextName = fetchedTitle ?? (requestedName && requestedName.length > 0 ? requestedName : nextUrl);
+      const node: BookmarkUrlNode = {
+        id: getNextId(bookmarks),
+        name: nextName,
+        type: "url",
+        url: nextUrl,
+        date_added: now,
+        date_last_used: "0",
+        tags: normalizeTags(payload.tags),
+      };
+      targetFolder.children.push(node);
+      targetFolder.date_modified = now;
+      await writeBookmarks(bookmarks);
+      return NextResponse.json({ ok: true, bookmarks, node });
+    }
+
+    if (payload.action === "createFolder") {
+      const targetFolder = findFolderById(bookmarks, payload.parentId);
+      const folder: BookmarkFolderNode = {
+        id: getNextId(bookmarks),
+        name: normalizeName(payload.name, "New Folder"),
+        type: "folder",
+        date_added: now,
+        date_modified: now,
+        children: [],
+      };
+      targetFolder.children.push(folder);
+      targetFolder.date_modified = now;
+      await writeBookmarks(bookmarks);
+      return NextResponse.json({ ok: true, bookmarks, node: folder });
+    }
+
+    if (payload.action === "markUsed") {
+      const found = findNodeAndParent(bookmarks, payload.id);
+      if (!found || found.node.type !== "url") {
+        return NextResponse.json({ error: "Bookmark not found" }, { status: 404 });
+      }
+      found.node.date_last_used = now;
+      found.parent.date_modified = now;
+      await writeBookmarks(bookmarks);
+      return NextResponse.json({ ok: true, bookmarks });
+    }
+
+    if (payload.action === "resolveTitle") {
+      const nextUrl = normalizeUrl(payload.url);
+      const title = await resolveBookmarkTitle(nextUrl);
+      return NextResponse.json({ ok: true, title });
+    }
+
+    return NextResponse.json({ error: "Unsupported action" }, { status: 400 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to update bookmarks";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const payload = (await request.json()) as { id?: string; name?: string; url?: string; tags?: unknown; parentId?: string };
+    if (!payload.id) {
+      return NextResponse.json({ error: "id is required" }, { status: 400 });
+    }
+    const bookmarks = await readBookmarks();
+    const found = findNodeAndParent(bookmarks, payload.id);
+    if (!found) {
+      return NextResponse.json({ error: "Node not found" }, { status: 404 });
+    }
+    const now = chromeNow();
+    found.node.name = normalizeName(payload.name, found.node.name);
+    if (found.node.type === "url") {
+      if (typeof payload.url === "string") {
+        found.node.url = normalizeUrl(payload.url);
+      }
+      if (payload.tags !== undefined) {
+        found.node.tags = normalizeTags(payload.tags);
+      }
+      if (typeof payload.parentId === "string") {
+        const targetFolder = findFolderById(bookmarks, payload.parentId);
+        if (targetFolder.id !== found.parent.id) {
+          found.parent.children = found.parent.children.filter((child) => child.id !== found.node.id);
+          targetFolder.children.push(found.node);
+          targetFolder.date_modified = now;
+        }
+      }
+    }
+    found.parent.date_modified = now;
+    await writeBookmarks(bookmarks);
+    return NextResponse.json({ ok: true, bookmarks });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to patch bookmarks";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  try {
+    const payload = (await request.json()) as { id?: string };
+    if (!payload.id) {
+      return NextResponse.json({ error: "id is required" }, { status: 400 });
+    }
+    const bookmarks = await readBookmarks();
+    const found = findNodeAndParent(bookmarks, payload.id);
+    if (!found) {
+      return NextResponse.json({ error: "Node not found" }, { status: 404 });
+    }
+    const now = chromeNow();
+    found.parent.children = found.parent.children.filter((child) => child.id !== payload.id);
+    found.parent.date_modified = now;
+    await writeBookmarks(bookmarks);
+    return NextResponse.json({ ok: true, bookmarks });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to delete bookmark";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/browser/bookmarks/route.ts
+++ b/src/app/api/browser/bookmarks/route.ts
@@ -191,14 +191,21 @@ function sanitizeBookmarkFile(input: unknown): BookmarkFile {
 }
 
 async function readBookmarks(): Promise<BookmarkFile> {
+  let raw: string;
   try {
-    const raw = await fs.readFile(BOOKMARKS_PATH, "utf-8");
-    return sanitizeBookmarkFile(JSON.parse(raw));
-  } catch {
-    const defaults = makeDefaultBookmarks();
-    await writeBookmarks(defaults);
-    return defaults;
+    raw = await fs.readFile(BOOKMARKS_PATH, "utf-8");
+  } catch (err) {
+    // Only seed defaults when the file genuinely doesn't exist. A transient
+    // read error (permissions, EBUSY, …) must NOT overwrite existing data, so
+    // rethrow anything that isn't ENOENT.
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+      const defaults = makeDefaultBookmarks();
+      await writeBookmarks(defaults);
+      return defaults;
+    }
+    throw err;
   }
+  return sanitizeBookmarkFile(JSON.parse(raw));
 }
 
 async function writeBookmarks(bookmarks: BookmarkFile): Promise<void> {
@@ -208,7 +215,29 @@ async function writeBookmarks(bookmarks: BookmarkFile): Promise<void> {
     checksum: computeChecksum(bookmarks.roots, 1),
   };
   await fs.mkdir(path.dirname(BOOKMARKS_PATH), { recursive: true });
-  await fs.writeFile(BOOKMARKS_PATH, `${JSON.stringify(payload, null, 2)}\n`, "utf-8");
+  // Atomic write: serialize to a temp file then rename over the target so a
+  // crash mid-write can't truncate or corrupt the existing bookmarks file.
+  const tmpPath = `${BOOKMARKS_PATH}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    await fs.writeFile(tmpPath, `${JSON.stringify(payload, null, 2)}\n`, "utf-8");
+    await fs.rename(tmpPath, BOOKMARKS_PATH);
+  } catch (err) {
+    await fs.rm(tmpPath, { force: true }).catch(() => {});
+    throw err;
+  }
+}
+
+// Serialize read-modify-write cycles so concurrent requests can't clobber each
+// other's updates or hand out duplicate ids. Single-process in-memory mutex —
+// each mutation waits for the previous one to settle.
+let mutationQueue: Promise<unknown> = Promise.resolve();
+function withBookmarkLock<T>(fn: () => Promise<T>): Promise<T> {
+  const run = mutationQueue.then(fn, fn);
+  mutationQueue = run.then(
+    () => undefined,
+    () => undefined
+  );
+  return run;
 }
 
 function walkNodes(folder: BookmarkFolderNode, visit: (node: BookmarkNode, parent: BookmarkFolderNode) => void): void {
@@ -368,72 +397,82 @@ export async function GET() {
 export async function POST(request: NextRequest) {
   try {
     const payload = (await request.json()) as PostPayload;
-    const bookmarks = await readBookmarks();
-    const now = chromeNow();
 
-    if (payload.action === "addBookmark") {
-      const targetFolder = findFolderById(bookmarks, payload.parentId);
-      const nextUrl = normalizeUrl(payload.url);
-      const requestedName = payload.name?.trim();
-      // Honor a user-supplied name verbatim; only fetch the page title when the
-      // user didn't provide one (avoids clobbering edits and skips the network
-      // round-trip when it's unnecessary).
-      let nextName: string;
-      if (requestedName && requestedName.length > 0) {
-        nextName = requestedName;
-      } else {
-        const fetchedTitle = await resolveBookmarkTitle(nextUrl);
-        nextName = fetchedTitle ?? nextUrl;
-      }
-      const node: BookmarkUrlNode = {
-        id: getNextId(bookmarks),
-        name: nextName,
-        type: "url",
-        url: nextUrl,
-        date_added: now,
-        date_last_used: "0",
-        tags: normalizeTags(payload.tags),
-      };
-      targetFolder.children.push(node);
-      targetFolder.date_modified = now;
-      await writeBookmarks(bookmarks);
-      return NextResponse.json({ ok: true, bookmarks, node });
-    }
-
-    if (payload.action === "createFolder") {
-      const targetFolder = findFolderById(bookmarks, payload.parentId);
-      const folder: BookmarkFolderNode = {
-        id: getNextId(bookmarks),
-        name: normalizeName(payload.name, "New Folder"),
-        type: "folder",
-        date_added: now,
-        date_modified: now,
-        children: [],
-      };
-      targetFolder.children.push(folder);
-      targetFolder.date_modified = now;
-      await writeBookmarks(bookmarks);
-      return NextResponse.json({ ok: true, bookmarks, node: folder });
-    }
-
-    if (payload.action === "markUsed") {
-      const found = findNodeAndParent(bookmarks, payload.id);
-      if (!found || found.node.type !== "url") {
-        return NextResponse.json({ error: "Bookmark not found" }, { status: 404 });
-      }
-      found.node.date_last_used = now;
-      found.parent.date_modified = now;
-      await writeBookmarks(bookmarks);
-      return NextResponse.json({ ok: true, bookmarks });
-    }
-
+    // resolveTitle performs no file mutation — handle it outside the lock so a
+    // slow title fetch can't block other bookmark writes.
     if (payload.action === "resolveTitle") {
       const nextUrl = normalizeUrl(payload.url);
       const title = await resolveBookmarkTitle(nextUrl);
       return NextResponse.json({ ok: true, title });
     }
 
-    return NextResponse.json({ error: "Unsupported action" }, { status: 400 });
+    // For addBookmark, resolve the name (possibly a network fetch) before
+    // taking the lock so we hold it only for the read-modify-write.
+    let resolvedName: string | null = null;
+    let normalizedAddUrl: string | null = null;
+    if (payload.action === "addBookmark") {
+      normalizedAddUrl = normalizeUrl(payload.url);
+      const requestedName = payload.name?.trim();
+      // Honor a user-supplied name verbatim; only fetch the page title when the
+      // user didn't provide one (avoids clobbering edits and the round-trip).
+      if (requestedName && requestedName.length > 0) {
+        resolvedName = requestedName;
+      } else {
+        const fetchedTitle = await resolveBookmarkTitle(normalizedAddUrl);
+        resolvedName = fetchedTitle ?? normalizedAddUrl;
+      }
+    }
+
+    return await withBookmarkLock(async () => {
+      const bookmarks = await readBookmarks();
+      const now = chromeNow();
+
+      if (payload.action === "addBookmark") {
+        const targetFolder = findFolderById(bookmarks, payload.parentId);
+        const node: BookmarkUrlNode = {
+          id: getNextId(bookmarks),
+          name: resolvedName ?? (normalizedAddUrl as string),
+          type: "url",
+          url: normalizedAddUrl as string,
+          date_added: now,
+          date_last_used: "0",
+          tags: normalizeTags(payload.tags),
+        };
+        targetFolder.children.push(node);
+        targetFolder.date_modified = now;
+        await writeBookmarks(bookmarks);
+        return NextResponse.json({ ok: true, bookmarks, node });
+      }
+
+      if (payload.action === "createFolder") {
+        const targetFolder = findFolderById(bookmarks, payload.parentId);
+        const folder: BookmarkFolderNode = {
+          id: getNextId(bookmarks),
+          name: normalizeName(payload.name, "New Folder"),
+          type: "folder",
+          date_added: now,
+          date_modified: now,
+          children: [],
+        };
+        targetFolder.children.push(folder);
+        targetFolder.date_modified = now;
+        await writeBookmarks(bookmarks);
+        return NextResponse.json({ ok: true, bookmarks, node: folder });
+      }
+
+      if (payload.action === "markUsed") {
+        const found = findNodeAndParent(bookmarks, payload.id);
+        if (!found || found.node.type !== "url") {
+          return NextResponse.json({ error: "Bookmark not found" }, { status: 404 });
+        }
+        found.node.date_last_used = now;
+        found.parent.date_modified = now;
+        await writeBookmarks(bookmarks);
+        return NextResponse.json({ ok: true, bookmarks });
+      }
+
+      return NextResponse.json({ error: "Unsupported action" }, { status: 400 });
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Failed to update bookmarks";
     return NextResponse.json({ error: message }, { status: 500 });
@@ -446,32 +485,34 @@ export async function PATCH(request: NextRequest) {
     if (!payload.id) {
       return NextResponse.json({ error: "id is required" }, { status: 400 });
     }
-    const bookmarks = await readBookmarks();
-    const found = findNodeAndParent(bookmarks, payload.id);
-    if (!found) {
-      return NextResponse.json({ error: "Node not found" }, { status: 404 });
-    }
-    const now = chromeNow();
-    found.node.name = normalizeName(payload.name, found.node.name);
-    if (found.node.type === "url") {
-      if (typeof payload.url === "string") {
-        found.node.url = normalizeUrl(payload.url);
+    return await withBookmarkLock(async () => {
+      const bookmarks = await readBookmarks();
+      const found = findNodeAndParent(bookmarks, payload.id!);
+      if (!found) {
+        return NextResponse.json({ error: "Node not found" }, { status: 404 });
       }
-      if (payload.tags !== undefined) {
-        found.node.tags = normalizeTags(payload.tags);
-      }
-      if (typeof payload.parentId === "string") {
-        const targetFolder = findFolderById(bookmarks, payload.parentId);
-        if (targetFolder.id !== found.parent.id) {
-          found.parent.children = found.parent.children.filter((child) => child.id !== found.node.id);
-          targetFolder.children.push(found.node);
-          targetFolder.date_modified = now;
+      const now = chromeNow();
+      found.node.name = normalizeName(payload.name, found.node.name);
+      if (found.node.type === "url") {
+        if (typeof payload.url === "string") {
+          found.node.url = normalizeUrl(payload.url);
+        }
+        if (payload.tags !== undefined) {
+          found.node.tags = normalizeTags(payload.tags);
+        }
+        if (typeof payload.parentId === "string") {
+          const targetFolder = findFolderById(bookmarks, payload.parentId);
+          if (targetFolder.id !== found.parent.id) {
+            found.parent.children = found.parent.children.filter((child) => child.id !== found.node.id);
+            targetFolder.children.push(found.node);
+            targetFolder.date_modified = now;
+          }
         }
       }
-    }
-    found.parent.date_modified = now;
-    await writeBookmarks(bookmarks);
-    return NextResponse.json({ ok: true, bookmarks });
+      found.parent.date_modified = now;
+      await writeBookmarks(bookmarks);
+      return NextResponse.json({ ok: true, bookmarks });
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Failed to patch bookmarks";
     return NextResponse.json({ error: message }, { status: 500 });
@@ -484,16 +525,18 @@ export async function DELETE(request: NextRequest) {
     if (!payload.id) {
       return NextResponse.json({ error: "id is required" }, { status: 400 });
     }
-    const bookmarks = await readBookmarks();
-    const found = findNodeAndParent(bookmarks, payload.id);
-    if (!found) {
-      return NextResponse.json({ error: "Node not found" }, { status: 404 });
-    }
-    const now = chromeNow();
-    found.parent.children = found.parent.children.filter((child) => child.id !== payload.id);
-    found.parent.date_modified = now;
-    await writeBookmarks(bookmarks);
-    return NextResponse.json({ ok: true, bookmarks });
+    return await withBookmarkLock(async () => {
+      const bookmarks = await readBookmarks();
+      const found = findNodeAndParent(bookmarks, payload.id!);
+      if (!found) {
+        return NextResponse.json({ error: "Node not found" }, { status: 404 });
+      }
+      const now = chromeNow();
+      found.parent.children = found.parent.children.filter((child) => child.id !== payload.id);
+      found.parent.date_modified = now;
+      await writeBookmarks(bookmarks);
+      return NextResponse.json({ ok: true, bookmarks });
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Failed to delete bookmark";
     return NextResponse.json({ error: message }, { status: 500 });

--- a/src/app/api/browser/bookmarks/route.ts
+++ b/src/app/api/browser/bookmarks/route.ts
@@ -3,6 +3,7 @@ import fs from "fs/promises";
 import path from "path";
 import { NextRequest, NextResponse } from "next/server";
 import { CABINET_INTERNAL_DIR } from "@/lib/storage/path-utils";
+import { safeFetch, readTextCapped } from "@/lib/net/ssrf-guard";
 
 export const dynamic = "force-dynamic";
 
@@ -279,7 +280,17 @@ function normalizeName(value: string | undefined, fallback: string): string {
 function normalizeUrl(value: string): string {
   const trimmed = value.trim();
   if (!trimmed) return "about:blank";
-  if (/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(trimmed) || trimmed.startsWith("//")) return trimmed;
+  if (trimmed.toLowerCase() === "about:blank") return "about:blank";
+  // Protocol-relative → assume https.
+  if (trimmed.startsWith("//")) return `https:${trimmed}`;
+  const schemeMatch = /^([a-zA-Z][a-zA-Z\d+.-]*):/.exec(trimmed);
+  if (schemeMatch) {
+    const scheme = schemeMatch[1].toLowerCase();
+    // Only allow web schemes; reject file:, javascript:, data:, etc. so a
+    // dangerous URL can't be persisted and later navigated to.
+    if (scheme === "http" || scheme === "https") return trimmed;
+    return "about:blank";
+  }
   return `https://${trimmed}`;
 }
 
@@ -320,27 +331,24 @@ function extractTitleFromHtml(html: string): string | null {
   return cleaned.length > 0 ? cleaned : null;
 }
 
+// Cap the HTML we read while sniffing a <title> — it lives in <head>, so a
+// few hundred KB is plenty and protects against a hostile/huge response.
+const TITLE_FETCH_MAX_BYTES = 512 * 1024;
+
 async function resolveBookmarkTitle(nextUrl: string): Promise<string | null> {
-  let parsed: URL;
   try {
-    parsed = new URL(nextUrl);
-  } catch {
-    return null;
-  }
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    return null;
-  }
-  try {
-    const response = await fetch(parsed.toString(), {
+    // SSRF guard: http(s) only, no private/loopback hosts (re-validated across
+    // redirects), with a timeout and a bounded read so this server-side fetch
+    // of a user-supplied URL can't be abused.
+    const { response } = await safeFetch(nextUrl, {
       method: "GET",
-      redirect: "follow",
-      cache: "no-store",
+      timeoutMs: 8000,
       headers: {
         accept: "text/html,application/xhtml+xml;q=0.9,*/*;q=0.8",
       },
     });
-    if (!response.ok) return null;
-    const html = await response.text();
+    if (response.status < 200 || response.status >= 300) return null;
+    const html = await readTextCapped(response, TITLE_FETCH_MAX_BYTES);
     return extractTitleFromHtml(html);
   } catch {
     return null;
@@ -367,8 +375,16 @@ export async function POST(request: NextRequest) {
       const targetFolder = findFolderById(bookmarks, payload.parentId);
       const nextUrl = normalizeUrl(payload.url);
       const requestedName = payload.name?.trim();
-      const fetchedTitle = await resolveBookmarkTitle(nextUrl);
-      const nextName = fetchedTitle ?? (requestedName && requestedName.length > 0 ? requestedName : nextUrl);
+      // Honor a user-supplied name verbatim; only fetch the page title when the
+      // user didn't provide one (avoids clobbering edits and skips the network
+      // round-trip when it's unnecessary).
+      let nextName: string;
+      if (requestedName && requestedName.length > 0) {
+        nextName = requestedName;
+      } else {
+        const fetchedTitle = await resolveBookmarkTitle(nextUrl);
+        nextName = fetchedTitle ?? nextUrl;
+      }
       const node: BookmarkUrlNode = {
         id: getNextId(bookmarks),
         name: nextName,

--- a/src/app/api/browser/bookmarks/route.ts
+++ b/src/app/api/browser/bookmarks/route.ts
@@ -3,7 +3,7 @@ import fs from "fs/promises";
 import path from "path";
 import { NextRequest, NextResponse } from "next/server";
 import { CABINET_INTERNAL_DIR } from "@/lib/storage/path-utils";
-import { safeFetch, readTextCapped } from "@/lib/net/ssrf-guard";
+import { safeFetch } from "@/lib/net/ssrf-guard";
 
 export const dynamic = "force-dynamic";
 
@@ -312,6 +312,11 @@ function normalizeUrl(value: string): string {
   if (trimmed.toLowerCase() === "about:blank") return "about:blank";
   // Protocol-relative → assume https.
   if (trimmed.startsWith("//")) return `https:${trimmed}`;
+  // host:port (e.g. localhost:3000, 127.0.0.1:8080) — the colon is a port
+  // separator, not a URL scheme, so keep the target and prefix https.
+  if (/^[a-zA-Z0-9.-]+:\d+(?:[/?#]|$)/.test(trimmed)) {
+    return `https://${trimmed}`;
+  }
   const schemeMatch = /^([a-zA-Z][a-zA-Z\d+.-]*):/.exec(trimmed);
   if (schemeMatch) {
     const scheme = schemeMatch[1].toLowerCase();
@@ -369,15 +374,18 @@ async function resolveBookmarkTitle(nextUrl: string): Promise<string | null> {
     // SSRF guard: http(s) only, no private/loopback hosts (re-validated across
     // redirects), with a timeout and a bounded read so this server-side fetch
     // of a user-supplied URL can't be abused.
-    const { response } = await safeFetch(nextUrl, {
+    const result = await safeFetch(nextUrl, {
       method: "GET",
       timeoutMs: 8000,
       headers: {
         accept: "text/html,application/xhtml+xml;q=0.9,*/*;q=0.8",
       },
     });
-    if (response.status < 200 || response.status >= 300) return null;
-    const html = await readTextCapped(response, TITLE_FETCH_MAX_BYTES);
+    if (result.status < 200 || result.status >= 300) {
+      result.dispose();
+      return null;
+    }
+    const html = await result.readText(TITLE_FETCH_MAX_BYTES);
     return extractTitleFromHtml(html);
   } catch {
     return null;

--- a/src/app/api/browser/frame-check/route.ts
+++ b/src/app/api/browser/frame-check/route.ts
@@ -1,0 +1,102 @@
+import { NextRequest, NextResponse } from "next/server";
+
+function parseFrameAncestors(csp: string): string[] | null {
+  const directives = csp
+    .split(";")
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const directive = directives.find((part) => part.toLowerCase().startsWith("frame-ancestors"));
+  if (!directive) return null;
+  return directive
+    .split(/\s+/)
+    .slice(1)
+    .map((token) => token.trim())
+    .filter(Boolean);
+}
+
+function allowsAppOrigin(tokens: string[], appOrigin: string): boolean {
+  if (tokens.includes("*")) return true;
+  const app = new URL(appOrigin);
+  for (const token of tokens) {
+    const normalized = token.replace(/^"|"$/g, "");
+    if (normalized === "'none'") return false;
+    if (normalized === "'self'") continue;
+    if (normalized.startsWith("http://") || normalized.startsWith("https://")) {
+      try {
+        const allowed = new URL(normalized);
+        if (allowed.origin === app.origin) return true;
+      } catch {
+      }
+    }
+  }
+  return false;
+}
+
+function xfoBlocksEmbedding(xfo: string, targetOrigin: string, appOrigin: string): boolean {
+  const value = xfo.trim().toLowerCase();
+  if (!value) return false;
+  if (value === "deny") return true;
+  if (value === "sameorigin") return targetOrigin !== appOrigin;
+  if (value.startsWith("allow-from")) {
+    const parts = xfo.split(/\s+/);
+    const allowedOrigin = parts.slice(1).join(" ").trim();
+    if (!allowedOrigin) return true;
+    try {
+      return new URL(allowedOrigin).origin !== appOrigin;
+    } catch {
+      return true;
+    }
+  }
+  return false;
+}
+
+export async function GET(request: NextRequest) {
+  const rawUrl = request.nextUrl.searchParams.get("url") || "";
+  let target: URL;
+  try {
+    target = new URL(rawUrl);
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid-url" }, { status: 400 });
+  }
+  if (target.protocol !== "http:" && target.protocol !== "https:") {
+    return NextResponse.json({ ok: false, error: "invalid-protocol" }, { status: 400 });
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(target.toString(), {
+      method: "HEAD",
+      redirect: "follow",
+      cache: "no-store",
+    });
+  } catch {
+    return NextResponse.json({ ok: true, blocked: false, unreachable: true });
+  }
+
+  const finalUrl = response.url || target.toString();
+  const finalOrigin = (() => {
+    try {
+      return new URL(finalUrl).origin;
+    } catch {
+      return target.origin;
+    }
+  })();
+
+  const appOrigin = request.nextUrl.origin;
+  const xfo = response.headers.get("x-frame-options") || "";
+  const csp = response.headers.get("content-security-policy") || "";
+
+  let blocked = false;
+  if (xfoBlocksEmbedding(xfo, finalOrigin, appOrigin)) {
+    blocked = true;
+  }
+
+  if (!blocked && csp) {
+    const frameAncestors = parseFrameAncestors(csp);
+    if (frameAncestors) {
+      blocked = !allowsAppOrigin(frameAncestors, appOrigin);
+    }
+  }
+
+  return NextResponse.json({ ok: true, blocked, unreachable: false });
+}

--- a/src/app/api/browser/frame-check/route.ts
+++ b/src/app/api/browser/frame-check/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { safeFetch, SsrfError } from "@/lib/net/ssrf-guard";
 
 function parseFrameAncestors(csp: string): string[] | null {
   const directives = csp
@@ -62,18 +63,22 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ ok: false, error: "invalid-protocol" }, { status: 400 });
   }
 
+  // SSRF guard: reject loopback/private/link-local hosts (re-validated across
+  // redirects) and bound the probe with a timeout so a slow host can't hang it.
   let response: Response;
+  let fetchedUrl: string;
   try {
-    response = await fetch(target.toString(), {
-      method: "HEAD",
-      redirect: "follow",
-      cache: "no-store",
-    });
-  } catch {
+    const result = await safeFetch(target.toString(), { method: "HEAD", timeoutMs: 8000 });
+    response = result.response;
+    fetchedUrl = result.finalUrl;
+  } catch (error) {
+    if (error instanceof SsrfError) {
+      return NextResponse.json({ ok: false, error: error.code }, { status: 400 });
+    }
     return NextResponse.json({ ok: true, blocked: false, unreachable: true });
   }
 
-  const finalUrl = response.url || target.toString();
+  const finalUrl = response.url || fetchedUrl;
   const finalOrigin = (() => {
     try {
       return new URL(finalUrl).origin;

--- a/src/app/api/browser/frame-check/route.ts
+++ b/src/app/api/browser/frame-check/route.ts
@@ -63,22 +63,27 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ ok: false, error: "invalid-protocol" }, { status: 400 });
   }
 
-  // SSRF guard: reject loopback/private/link-local hosts (re-validated across
-  // redirects) and bound the probe with a timeout so a slow host can't hang it.
-  let response: Response;
-  let fetchedUrl: string;
+  // SSRF guard: reject loopback/private/link-local hosts (validated at the
+  // socket lookup + across redirects) and bound the probe with a timeout so a
+  // slow host can't hang it.
+  let status: number;
+  let headers: import("node:http").IncomingHttpHeaders;
+  let finalUrl: string;
   try {
     const result = await safeFetch(target.toString(), { method: "HEAD", timeoutMs: 8000 });
-    response = result.response;
-    fetchedUrl = result.finalUrl;
+    status = result.status;
+    headers = result.headers;
+    finalUrl = result.finalUrl;
+    // HEAD has no body to read; release the socket.
+    result.dispose();
   } catch (error) {
     if (error instanceof SsrfError) {
       return NextResponse.json({ ok: false, error: error.code }, { status: 400 });
     }
     return NextResponse.json({ ok: true, blocked: false, unreachable: true });
   }
+  void status;
 
-  const finalUrl = response.url || fetchedUrl;
   const finalOrigin = (() => {
     try {
       return new URL(finalUrl).origin;
@@ -87,9 +92,13 @@ export async function GET(request: NextRequest) {
     }
   })();
 
+  const headerValue = (name: string): string => {
+    const v = headers[name];
+    return Array.isArray(v) ? v.join(", ") : v || "";
+  };
   const appOrigin = request.nextUrl.origin;
-  const xfo = response.headers.get("x-frame-options") || "";
-  const csp = response.headers.get("content-security-policy") || "";
+  const xfo = headerValue("x-frame-options");
+  const csp = headerValue("content-security-policy");
 
   let blocked = false;
   if (xfoBlocksEmbedding(xfo, finalOrigin, appOrigin)) {

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -19,6 +19,7 @@ import { markdownToHtml } from "@/lib/markdown/to-html";
 import { htmlToMarkdown } from "@/lib/markdown/to-markdown";
 import { slugifyPageName } from "@/lib/markdown/wiki-links";
 import { detectEmbed } from "@/lib/embeds/detect";
+import { openUrlInAppropriateContext } from "@/lib/runtime/open-url";
 import { cellAround, isInTable } from "@tiptap/pm/tables";
 import type { TreeNode } from "@/types";
 import { useLocale } from "@/i18n/use-locale";
@@ -170,6 +171,14 @@ export function KBEditor() {
     setFolderTab("page");
   }, [currentPath]);
 
+  // Guards against a freshly-mounted (content: "") editor autosaving its empty
+  // initial state over a real page. Stays false until the content effect has
+  // populated this editor instance at least once. Critical when leaving browse
+  // mode: that unmounts/remounts KBEditor while the store is already
+  // loadStatus "ok", so the loadStatus guard below wouldn't catch the spurious
+  // empty onUpdate the way it does on a cold app start.
+  const hasPopulatedRef = useRef(false);
+
   const handleUpdate = useCallback(
     ({ editor }: { editor: ReturnType<typeof useEditor> }) => {
       if (isLoadingRef.current || !editor) return;
@@ -177,6 +186,9 @@ export function KBEditor() {
       // fetch is still in flight (e.g. editor mount/normalization on a fresh
       // open) must not mark the page dirty with the empty loading state.
       if (useEditorStore.getState().loadStatus !== "ok") return;
+      // Ignore updates before this editor instance has been populated once —
+      // the initial empty-doc transaction must never overwrite stored content.
+      if (!hasPopulatedRef.current) return;
       const html = editor.getHTML();
       const md = htmlToMarkdown(html);
       useEditorStore.getState().updateContent(md);
@@ -268,9 +280,29 @@ export function KBEditor() {
             return true;
           }
 
-          // Internal links: relative paths to .md files or other KB pages
-          // Skip external URLs and API asset links (PDFs, images)
-          if (/^https?:\/\//.test(href) || href.startsWith("/api/")) return false;
+          // Internal links: relative paths to .md files or other KB pages.
+          // Skip API asset links (PDFs, images); open external URLs in built-in browser.
+          if (href.startsWith("/api/")) return false;
+          if (/^https?:\/\//.test(href) || href.startsWith("//")) {
+            event.preventDefault();
+            event.stopPropagation();
+            openUrlInAppropriateContext(href, (url) =>
+              useAppStore.getState().setAppMode("browse", url)
+            );
+            return true;
+          }
+          if (href.startsWith("file://")) {
+            event.preventDefault();
+            event.stopPropagation();
+            const pathPart = href.slice("file://".length);
+            const encoded = pathPart.includes("%20") || !pathPart.includes(" ")
+              ? href
+              : "file://" + encodeURI(pathPart);
+            openUrlInAppropriateContext(encoded, (url) =>
+              useAppStore.getState().setAppMode("browse", url)
+            );
+            return true;
+          }
           if (href.startsWith("mailto:") || href.startsWith("tel:")) return false;
 
           event.preventDefault();
@@ -421,6 +453,9 @@ export function KBEditor() {
         // image refs; currentPath is only correct for directory pages.
         const html = await markdownToHtml(content, assetBase ?? currentPath);
         editor.commands.setContent(html);
+        // This editor instance now reflects stored content, so user-driven
+        // onUpdate transactions are safe to persist (see hasPopulatedRef).
+        hasPopulatedRef.current = true;
         setRendered({ key, path: currentPath });
         // Surface a known-bad state instead of silently rendering blank: the
         // store has content but ProseMirror parsed it down to nothing —

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -5,6 +5,7 @@ import { Loader2 } from "lucide-react";
 import { Sidebar } from "@/components/sidebar/sidebar";
 import { Header } from "@/components/layout/header";
 import { KBEditor } from "@/components/editor/editor";
+import { BrowserView } from "@/components/layout/browser-view";
 import { WebsiteViewer } from "@/components/editor/website-viewer";
 import { PdfViewer } from "@/components/editor/pdf-viewer";
 import { CsvViewer } from "@/components/editor/csv-viewer";
@@ -160,6 +161,8 @@ export function AppShell() {
   const selectedPath = useTreeStore((s) => s.selectedPath);
   const driveNode = useTreeStore((s) => s.driveNode);
   const section = useAppStore((s) => s.section);
+  const appMode = useAppStore((s) => s.appMode);
+  const setAppMode = useAppStore((s) => s.setAppMode);
   const setSection = useAppStore((s) => s.setSection);
   const terminalOpen = useAppStore((s) => s.terminalOpen);
   const terminalPosition = useAppStore((s) => s.terminalPosition);
@@ -367,6 +370,14 @@ export function AppShell() {
     }, 1000);
     return () => window.clearTimeout(id);
   }, [selectedPath, section.cabinetPath]);
+
+  // Browse mode only makes sense over a page/cabinet surface; leaving those
+  // sections (settings, help, etc.) drops back to the editor.
+  useEffect(() => {
+    if (section.type !== "page" && section.type !== "cabinet" && appMode !== "edit") {
+      setAppMode("edit");
+    }
+  }, [section.type, appMode, setAppMode]);
 
   // Dynamic document.title — reflects the current section and page.
   useEffect(() => {
@@ -789,6 +800,9 @@ export function AppShell() {
     if (section.type === "settings") return <SettingsPage />;
     if (section.type === "integrations") return <IntegrationsHubPage />;
     if (section.type === "help") return <HelpPage />;
+    if ((section.type === "cabinet" || section.type === "page") && appMode === "browse") {
+      return <BrowserView />;
+    }
     if (section.type === "cabinet" && section.cabinetPath) {
       return <CabinetView cabinetPath={section.cabinetPath} />;
     }

--- a/src/components/layout/browser-view.tsx
+++ b/src/components/layout/browser-view.tsx
@@ -1808,22 +1808,26 @@ export function BrowserView() {
                   <div className="p-3 text-xs text-muted-foreground text-center">No extensions enabled</div>
                 ) : (
                   extensions.filter(ext => ext.enabled !== false).map(ext => (
-                    <div key={ext.id} className="flex items-center justify-between px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground rounded-sm cursor-pointer group">
-                      <div className="flex items-center gap-2 flex-1 overflow-hidden" onClick={(e) => handleRunExtension(ext, e)}>
+                    <div key={ext.id} className="flex items-center justify-between px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground rounded-sm group">
+                      <button
+                        type="button"
+                        onClick={(e) => handleRunExtension(ext, e)}
+                        className="flex items-center gap-2 flex-1 overflow-hidden text-left cursor-pointer focus:outline-none"
+                      >
                         {ext.iconDataUrl ? (
                           <img src={ext.iconDataUrl} alt="" className="w-4 h-4 object-contain shrink-0" />
                         ) : (
                           <Blocks className="h-4 w-4 shrink-0 text-muted-foreground" />
                         )}
                         <span className="truncate">{ext.name}</span>
-                      </div>
-                      <button 
-                        type="button" 
+                      </button>
+                      <button
+                        type="button"
                         onClick={(e) => {
                           e.stopPropagation();
                           handleToggleExtensionPin(ext);
                         }}
-                        className="opacity-0 group-hover:opacity-100 p-1 hover:bg-muted rounded text-muted-foreground"
+                        className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 p-1 hover:bg-muted rounded text-muted-foreground"
                         title={ext.pinned ? "Unpin extension" : "Pin extension"}
                       >
                         {ext.pinned ? <PinOff className="w-3.5 h-3.5" /> : <Pin className="w-3.5 h-3.5" />}

--- a/src/components/layout/browser-view.tsx
+++ b/src/components/layout/browser-view.tsx
@@ -160,7 +160,16 @@ function normalizeBookmarkNodes(nodes: BookmarkNode[]): BookmarkNode[] {
 function normalizeBookmarkUrl(value: string): string {
   const trimmed = value.trim();
   if (!trimmed) return "about:blank";
-  if (/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(trimmed) || trimmed.startsWith("//")) return trimmed;
+  if (trimmed.toLowerCase() === "about:blank") return "about:blank";
+  // Protocol-relative → assume https.
+  if (trimmed.startsWith("//")) return `https:${trimmed}`;
+  const schemeMatch = /^([a-zA-Z][a-zA-Z\d+.-]*):/.exec(trimmed);
+  if (schemeMatch) {
+    const scheme = schemeMatch[1].toLowerCase();
+    // Only allow web schemes; reject file:, javascript:, data:, etc.
+    if (scheme === "http" || scheme === "https") return trimmed;
+    return "about:blank";
+  }
   return `https://${trimmed}`;
 }
 
@@ -184,6 +193,8 @@ function toBridgeBookmarkMenuItems(nodes: BookmarkNode[]): BrowserBookmarkMenuIt
 }
 
 function getBridge(): Partial<BrowserBridge> & { runtime?: "electron" } {
+  // Guard for SSR / non-browser environments where `window` is undefined.
+  if (typeof window === "undefined") return {};
   return (window as unknown as { CabinetDesktop?: Partial<BrowserBridge> & { runtime?: "electron" } })
     .CabinetDesktop ?? {};
 }
@@ -636,6 +647,29 @@ export function BrowserView() {
   const { t } = useLocale();
   const url = useAppStore((s) => s.browseUrl);
   const setAppMode = useAppStore((s) => s.setAppMode);
+
+  // Sandbox for the fallback iframe. `allow-same-origin` is only safe for
+  // *cross-origin* pages: there it just lets the external site use its own
+  // origin, and it can't reach our app. For a page served from our OWN origin,
+  // `allow-same-origin` + `allow-scripts` would let it script the host app and
+  // escape the sandbox, so we omit it for same-origin/unknown URLs.
+  const iframeSandbox = (() => {
+    const base = "allow-scripts allow-forms allow-modals allow-top-navigation-by-user-activation";
+    try {
+      if (url && typeof window !== "undefined") {
+        const u = new URL(url, window.location.origin);
+        if (
+          (u.protocol === "http:" || u.protocol === "https:") &&
+          u.origin !== window.location.origin
+        ) {
+          return `${base} allow-same-origin`;
+        }
+      }
+    } catch {
+      // fall through to the restrictive sandbox
+    }
+    return base;
+  })();
   const initialSessionRef = useRef<BrowserSessionState>(loadBrowserSessionState());
   const [addressValue, setAddressValue] = useState(toAddressBarValue(url ?? initialSessionRef.current.url ?? ""));
   const [browserMode, setBrowserMode] = useState<"initializing" | "electron" | "iframe">(() => {
@@ -1815,7 +1849,7 @@ export function BrowserView() {
                   setIframeLoadedToken(iframeLoadTokenRef.current);
                 }}
                 className="h-full w-full border-0 bg-white"
-                sandbox="allow-same-origin allow-scripts allow-forms allow-modals allow-top-navigation-by-user-activation"
+                sandbox={iframeSandbox}
               />
               {iframeFailure ? (
                 <div className="absolute inset-0 flex items-center justify-center bg-background/85 p-6 text-center">

--- a/src/components/layout/browser-view.tsx
+++ b/src/components/layout/browser-view.tsx
@@ -1,0 +1,2066 @@
+"use client";
+
+import { type ReactNode, useEffect, useRef, useState } from "react";
+import {
+  Bookmark,
+  BookMarked,
+  ChevronLeft,
+  Pencil,
+  ChevronRight,
+  ExternalLink,
+  Folder,
+  Globe,
+  Icon,
+  Plus,
+  RefreshCw,
+  Tags,
+  Trash2,
+  Blocks,
+  Pin,
+  PinOff,
+} from "lucide-react";
+import type { IconNode } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Header } from "@/components/layout/header";
+import { useAppStore } from "@/stores/app-store";
+import { useLocale } from "@/i18n/use-locale";
+
+type BrowserViewBounds = { x: number; y: number; width: number; height: number };
+type BrowserViewNavResult = {
+  ok: boolean;
+  skipped?: boolean;
+  error?: string;
+  loadedUrl?: string;
+  primaryUrl?: string;
+  fallbackUrl?: string | null;
+  primaryError?: string;
+  fallbackError?: string;
+};
+type BrowserBookmarkMenuItem = {
+  id: string;
+  name: string;
+  type: "url" | "folder";
+  url?: string;
+  children?: BrowserBookmarkMenuItem[];
+};
+
+type BrowserBridge = {
+  runtime: "electron";
+  createBrowserView: (url: string) => Promise<{ ok: boolean; viewId?: string }>;
+  loadBrowserViewUrl: (viewId: string, url: string) => Promise<BrowserViewNavResult>;
+  setBrowserViewBounds: (viewId: string, bounds: BrowserViewBounds) => Promise<{ ok: boolean }>;
+  setBrowserViewVisible: (viewId: string, visible: boolean) => Promise<{ ok: boolean }>;
+  browserViewGoBack: (viewId: string) => Promise<BrowserViewNavResult>;
+  browserViewGoForward: (viewId: string) => Promise<BrowserViewNavResult>;
+  browserViewReload: (viewId: string) => Promise<BrowserViewNavResult>;
+  showBrowserBookmarksMenu: (payload: {
+    x: number;
+    y: number;
+    items: BrowserBookmarkMenuItem[];
+  }) => Promise<{ ok: boolean; cancelled?: boolean; id?: string; url?: string }>;
+  onBrowserViewNavigated: (
+    listener: (payload: { viewId?: string; url?: string }) => void
+  ) => () => void;
+  onBrowserViewLoadFailed: (
+    listener: (payload: {
+      viewId?: string;
+      requestedUrl?: string;
+      primaryUrl?: string;
+      fallbackUrl?: string;
+      primaryError?: string;
+      fallbackError?: string;
+      errorCode?: number;
+      errorDescription?: string;
+      validatedUrl?: string;
+    }) => void
+  ) => () => void;
+  destroyBrowserView: (viewId: string) => Promise<{ ok: boolean }>;
+  getExtensions?: () => Promise<BrowserExtension[]>;
+  updateExtension?: (id: string, updates: Partial<BrowserExtension>) => Promise<{ ok: boolean }>;
+  showExtensionPopup?: (payload: { extensionId: string; x: number; y: number }) => Promise<{ ok: boolean }>;
+};
+
+type BrowserExtension = {
+  id: string;
+  name: string;
+  version: string;
+  path: string;
+  description: string;
+  enabled?: boolean;
+  pinned?: boolean;
+  iconDataUrl?: string | null;
+  popupHtml?: string | null;
+};
+
+type BrowserSessionState = {
+  history: string[];
+  index: number;
+  url: string | null;
+};
+
+type BookmarkUrlNode = {
+  id: string;
+  name: string;
+  type: "url";
+  url: string;
+  date_added: string;
+  date_last_used: string;
+  tags: string[];
+};
+
+type BookmarkFolderNode = {
+  id: string;
+  name: string;
+  type: "folder";
+  date_added: string;
+  date_modified: string;
+  children: BookmarkNode[];
+};
+
+type BookmarkNode = BookmarkUrlNode | BookmarkFolderNode;
+
+type BookmarkFile = {
+  checksum: string;
+  roots: {
+    bookmark_bar: BookmarkFolderNode;
+    other: BookmarkFolderNode;
+  };
+  version: number;
+};
+
+type BookmarkFolderOption = {
+  id: string;
+  label: string;
+};
+
+const BROWSER_SESSION_STORAGE_KEY = "cabinet.browser.session";
+
+function normalizeBookmarkNodes(nodes: BookmarkNode[]): BookmarkNode[] {
+  return [...nodes].sort((a, b) => {
+    if (a.type !== b.type) {
+      return a.type === "folder" ? -1 : 1;
+    }
+    return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+  });
+}
+
+function normalizeBookmarkUrl(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return "about:blank";
+  if (/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(trimmed) || trimmed.startsWith("//")) return trimmed;
+  return `https://${trimmed}`;
+}
+
+function toBridgeBookmarkMenuItems(nodes: BookmarkNode[]): BrowserBookmarkMenuItem[] {
+  return normalizeBookmarkNodes(nodes).map((node) => {
+    if (node.type === "folder") {
+      return {
+        id: node.id,
+        name: node.name,
+        type: "folder",
+        children: toBridgeBookmarkMenuItems(node.children),
+      };
+    }
+    return {
+      id: node.id,
+      name: node.name,
+      type: "url",
+      url: node.url,
+    };
+  });
+}
+
+function getBridge(): Partial<BrowserBridge> & { runtime?: "electron" } {
+  return (window as unknown as { CabinetDesktop?: Partial<BrowserBridge> & { runtime?: "electron" } })
+    .CabinetDesktop ?? {};
+}
+
+const TAG_CLOUD_DATA_URL_PREFIX = "data:text/html;cabinet-tag-cloud=1;charset=utf-8,";
+
+function isTagCloudDataUrl(value: string | null | undefined): boolean {
+  if (!value) return false;
+  return value.startsWith(TAG_CLOUD_DATA_URL_PREFIX);
+}
+
+function normalizeEnteredUrl(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith("/") || trimmed.startsWith("./") || trimmed.startsWith("../")) {
+    if (typeof window !== "undefined") {
+      try {
+        return new URL(trimmed, window.location.origin).toString();
+      } catch {
+        return trimmed;
+      }
+    }
+    return trimmed;
+  }
+  if (/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(trimmed) || trimmed.startsWith("//")) return trimmed;
+  return `https://${trimmed}`;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+type TagBookmarkEntry = {
+  name: string;
+  url: string;
+};
+
+type TagCloudEntry = {
+  key: string;
+  label: string;
+  bookmarks: TagBookmarkEntry[];
+};
+
+function collectBookmarkTagEntries(nodes: BookmarkNode[]): TagCloudEntry[] {
+  const tagsMap = new Map<string, TagCloudEntry>();
+  const walk = (items: BookmarkNode[]) => {
+    for (const node of items) {
+      if (node.type === "folder") {
+        walk(node.children);
+        continue;
+      }
+      const bookmarkName = node.name.trim() || node.url;
+      const bookmarkUrl = node.url.trim();
+      if (!bookmarkUrl) continue;
+      for (const rawTag of node.tags) {
+        const label = rawTag.trim();
+        if (!label) continue;
+        const key = label.toLocaleLowerCase();
+        const existing = tagsMap.get(key);
+        if (!existing) {
+          tagsMap.set(key, {
+            key,
+            label,
+            bookmarks: [{ name: bookmarkName, url: bookmarkUrl }],
+          });
+          continue;
+        }
+        const duplicate = existing.bookmarks.some((bookmark) => bookmark.url === bookmarkUrl && bookmark.name === bookmarkName);
+        if (!duplicate) {
+          existing.bookmarks.push({ name: bookmarkName, url: bookmarkUrl });
+        }
+      }
+    }
+  };
+  walk(nodes);
+  const entries = Array.from(tagsMap.values()).map((entry) => ({
+    ...entry,
+    bookmarks: [...entry.bookmarks].sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" })),
+  }));
+  return entries.sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: "base" }));
+}
+
+function buildTagCloudHtml(entries: TagCloudEntry[]): string {
+  const tagAnchors = entries
+    .map((entry) => `  <a class="tag" href="#" data-tag-key="${escapeHtml(entry.key)}">${escapeHtml(entry.label)}</a>`)
+    .join("\n");
+  const tagsPayload = JSON.stringify(
+    entries.map((entry) => ({
+      key: entry.key,
+      label: entry.label,
+      bookmarks: entry.bookmarks,
+    }))
+  ).replaceAll("</", "<\\/");
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Bookmark Tags</title>
+<style>
+:root {
+  --tag-bg-sat: 72%;
+  --tag-bg-light: 68%;
+  --tag-text: rgba(255,255,255,0.92);
+  --tag-shadow:
+    0 2px 6px rgba(72, 76, 160, 0.18),
+    0 10px 18px rgba(72, 76, 160, 0.08);
+  --tag-highlight:
+    inset 0 1px 1px rgba(255,255,255,0.45),
+    inset 0 -1px 1px rgba(255,255,255,0.08);
+  --tag-blur: blur(10px);
+  --cloud-bg: #efedf7;
+}
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 24px;
+  background: var(--cloud-bg);
+  box-sizing: border-box;
+}
+.tag-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  width: min(95%, 1200px);
+  padding: 32px;
+  border-radius: 28px;
+  background:
+    radial-gradient(
+      circle at top left,
+      rgba(248, 238, 255, 0.9),
+      rgb(224, 216, 255)
+    );
+  font-family:
+    Inter,
+    SF Pro Display,
+    system-ui,
+    sans-serif;
+}
+.tag {
+  --hue: 240;
+  --sat-multiplier: 1;
+  --lightness: var(--tag-bg-light);
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 22px;
+  border: 2px solid transparent;
+  border-radius: 999px;
+  color: var(--tag-text);
+  text-decoration: none;
+  white-space: nowrap;
+  font-size: 0.95rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  backdrop-filter: var(--tag-blur);
+  background:
+    linear-gradient(
+      145deg,
+      hsla(
+        var(--hue),
+        calc(var(--tag-bg-sat) * var(--sat-multiplier)),
+        calc(var(--lightness) + 6%),
+        0.92
+      ),
+      hsla(
+        var(--hue),
+        calc(var(--tag-bg-sat) * var(--sat-multiplier)),
+        var(--lightness),
+        0.95
+      )
+    );
+  box-shadow:
+    var(--tag-shadow),
+    var(--tag-highlight);
+  transition:
+    transform 160ms ease,
+    box-shadow 160ms ease,
+    filter 160ms ease;
+}
+.tag::before {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border-radius: inherit;
+  background:
+    linear-gradient(
+      to bottom,
+      rgba(255,255,255,0.22),
+      rgba(255,255,255,0.02)
+    );
+  pointer-events: none;
+}
+.tag:hover {
+  transform: translateY(-2px);
+  filter: saturate(1.08);
+  box-shadow:
+    0 6px 16px rgba(72, 76, 160, 0.22),
+    0 14px 30px rgba(72, 76, 160, 0.14),
+    var(--tag-highlight);
+}
+.tag:nth-child(8n + 1) { --hue: 225; }
+.tag:nth-child(8n + 2) { --hue: 232; }
+.tag:nth-child(8n + 3) { --hue: 238; }
+.tag:nth-child(8n + 4) { --hue: 245; }
+.tag:nth-child(8n + 5) { --hue: 252; }
+.tag:nth-child(8n + 6) { --hue: 258; }
+.tag:nth-child(8n + 7) { --hue: 235; }
+.tag:nth-child(8n + 8) { --hue: 248; }
+.tag:nth-child(3n) {
+  --sat-multiplier: 0.92;
+}
+.tag:nth-child(5n) {
+  --lightness: 72%;
+}
+.tag:nth-child(7n) {
+  --lightness: 64%;
+}
+.tag[data-weight="high"] {
+  font-weight: 600;
+  padding-inline: 26px;
+  --lightness: 60%;
+}
+.tag[data-weight="low"] {
+  opacity: 0.72;
+  --sat-multiplier: 0.72;
+}
+.tag.is-selected {
+  border: 2px solid #6d28d9;
+}
+.tag-cloud.is-filtering {
+  opacity: 0.55;
+}
+.tag-results {
+  margin-top: 16px;
+  width: min(95%, 1200px);
+  padding: 20px;
+  border-radius: 20px;
+  background: rgba(255,255,255,0.7);
+  backdrop-filter: blur(6px);
+  font-family:
+    Inter,
+    SF Pro Display,
+    system-ui,
+    sans-serif;
+}
+.tag-results-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+  font-size: 0.95rem;
+  color: rgba(50, 54, 110, 0.95);
+}
+.tag-results-close {
+  border: 0;
+  border-radius: 999px;
+  padding: 8px 14px;
+  background: rgba(72, 76, 160, 0.12);
+  color: rgba(36, 38, 93, 0.95);
+  cursor: pointer;
+}
+.tag-results-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.tag-result-link {
+  color: rgba(48, 52, 128, 0.96);
+  text-decoration: none;
+  font-size: 0.92rem;
+  padding: 8px 10px;
+  border-radius: 10px;
+  background: rgba(255,255,255,0.62);
+}
+.tag-result-link:hover {
+  background: rgba(255,255,255,0.88);
+}
+.tag-results-empty {
+  color: rgba(70, 74, 138, 0.7);
+  font-size: 0.9rem;
+}
+</style>
+</head>
+<body>
+<div class="tag-cloud" id="tagCloud">
+${tagAnchors}
+</div>
+<div class="tag-results" id="tagResults" hidden>
+  <div class="tag-results-header">
+    <span id="tagResultsTitle"></span>
+    <button type="button" id="tagResultsClose" class="tag-results-close">Close</button>
+  </div>
+  <div id="tagResultsBody" class="tag-results-body"></div>
+</div>
+<script id="tag-data" type="application/json">${tagsPayload}</script>
+<script>
+function stringToHue(str) {
+  let hash = 0;
+
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+  }
+
+  return 220 + (Math.abs(hash) % 40);
+}
+
+const tagsData = (() => {
+  const el = document.getElementById("tag-data");
+  if (!el) return [];
+  try {
+    return JSON.parse(el.textContent || "[]");
+  } catch {
+    return [];
+  }
+})();
+
+const tagCloud = document.getElementById("tagCloud");
+const resultsPanel = document.getElementById("tagResults");
+const resultsTitle = document.getElementById("tagResultsTitle");
+const resultsBody = document.getElementById("tagResultsBody");
+const resultsClose = document.getElementById("tagResultsClose");
+let selectedTag = null;
+
+document.querySelectorAll(".tag").forEach((element) => {
+  const text = (element.textContent || "").trim();
+  element.style.setProperty("--hue", String(stringToHue(text)));
+  element.addEventListener("click", (event) => {
+    event.preventDefault();
+    if (selectedTag) {
+      selectedTag.classList.remove("is-selected");
+    }
+    element.classList.add("is-selected");
+    selectedTag = element;
+    const tagKey = element.getAttribute("data-tag-key") || "";
+    const match = tagsData.find((entry) => String(entry.key || "") === tagKey);
+    if (!match) return;
+    const bookmarks = Array.isArray(match.bookmarks) ? match.bookmarks : [];
+    resultsTitle.textContent = String(match.label || "Tag") + " (" + String(bookmarks.length) + ")";
+    resultsBody.innerHTML = "";
+    if (bookmarks.length === 0) {
+      const empty = document.createElement("div");
+      empty.className = "tag-results-empty";
+      empty.textContent = "No bookmarks";
+      resultsBody.appendChild(empty);
+    } else {
+      bookmarks.forEach((bookmark) => {
+        const link = document.createElement("a");
+        link.className = "tag-result-link";
+        link.href = String(bookmark.url || "about:blank");
+        link.textContent = String(bookmark.name || bookmark.url || "Untitled");
+        link.title = String(bookmark.url || "");
+        resultsBody.appendChild(link);
+      });
+    }
+    resultsPanel.hidden = false;
+    tagCloud.classList.add("is-filtering");
+  });
+});
+
+resultsClose.addEventListener("click", () => {
+  resultsPanel.hidden = true;
+  tagCloud.classList.remove("is-filtering");
+  if (selectedTag) {
+    selectedTag.classList.remove("is-selected");
+    selectedTag = null;
+  }
+});
+</script>
+</body>
+</html>`;
+}
+
+const folderBookmarkIconNode: IconNode = [
+  ["path", { d: "M12 6v8l3-3 3 3V6", key: "v0froi" }],
+  [
+    "path",
+    {
+      d: "M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2z",
+      key: "1wvlfi",
+    },
+  ],
+];
+
+function normalizeSessionUrl(value: string | null | undefined): string {
+  const trimmed = (value || "about:blank").trim();
+  return trimmed || "about:blank";
+}
+
+function toAddressBarValue(value: string | null | undefined): string {
+  const normalized = normalizeSessionUrl(value);
+  return isTagCloudDataUrl(normalized) ? "" : normalized;
+}
+
+function loadBrowserSessionState(): BrowserSessionState {
+  if (typeof window === "undefined") {
+    return { history: ["about:blank"], index: 0, url: "about:blank" };
+  }
+  try {
+    const raw = window.sessionStorage.getItem(BROWSER_SESSION_STORAGE_KEY);
+    if (!raw) {
+      return { history: ["about:blank"], index: 0, url: "about:blank" };
+    }
+    const parsed = JSON.parse(raw) as {
+      history?: unknown;
+      index?: unknown;
+      url?: unknown;
+    };
+    const history = Array.isArray(parsed.history)
+      ? parsed.history.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+      : [];
+    const cleanedHistory = history.length > 0 ? history.map((entry) => normalizeSessionUrl(entry)) : ["about:blank"];
+    const nextIndex =
+      typeof parsed.index === "number" && Number.isFinite(parsed.index)
+        ? Math.max(0, Math.min(cleanedHistory.length - 1, Math.floor(parsed.index)))
+        : cleanedHistory.length - 1;
+    const nextUrl =
+      typeof parsed.url === "string" && parsed.url.trim().length > 0
+        ? normalizeSessionUrl(parsed.url)
+        : cleanedHistory[nextIndex] || "about:blank";
+    return {
+      history: cleanedHistory,
+      index: nextIndex,
+      url: nextUrl,
+    };
+  } catch {
+    return { history: ["about:blank"], index: 0, url: "about:blank" };
+  }
+}
+
+function persistBrowserSessionState(state: BrowserSessionState): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(BROWSER_SESSION_STORAGE_KEY, JSON.stringify(state));
+  } catch {}
+}
+
+export function BrowserView() {
+  const { t } = useLocale();
+  const url = useAppStore((s) => s.browseUrl);
+  const setAppMode = useAppStore((s) => s.setAppMode);
+  const initialSessionRef = useRef<BrowserSessionState>(loadBrowserSessionState());
+  const [addressValue, setAddressValue] = useState(toAddressBarValue(url ?? initialSessionRef.current.url ?? ""));
+  const [browserMode, setBrowserMode] = useState<"initializing" | "electron" | "iframe">(() => {
+    const bridge = getBridge();
+    return bridge.createBrowserView && bridge.destroyBrowserView ? "initializing" : "iframe";
+  });
+  const [initAttempt, setInitAttempt] = useState(0);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const bookmarksMenuRef = useRef<HTMLDivElement | null>(null);
+  const bookmarksTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const iframeLoadTokenRef = useRef(0);
+  const iframeLoadedTokenRef = useRef(0);
+  const [iframeLoadedToken, setIframeLoadedToken] = useState(0);
+  const iframeHistoryRef = useRef<string[]>(initialSessionRef.current.history);
+  const iframeHistoryIndexRef = useRef<number>(initialSessionRef.current.index);
+  const iframeNavActionRef = useRef<"back" | "forward" | null>(null);
+  const suppressNextElectronLoadRef = useRef(false);
+  const [iframeReloadKey, setIframeReloadKey] = useState(0);
+  const viewIdRef = useRef<string | null>(null);
+  const updateBoundsRef = useRef<() => void>(() => {});
+  const [iframeFailure, setIframeFailure] = useState<string | null>(null);
+  const [electronFailure, setElectronFailure] = useState<string | null>(null);
+  const [iframePolicyBlocked, setIframePolicyBlocked] = useState(false);
+  const [bookmarks, setBookmarks] = useState<BookmarkFile | null>(null);
+  const [bookmarksLoading, setBookmarksLoading] = useState(false);
+  const [managerOpen, setManagerOpen] = useState(false);
+  const [bookmarksMenuOpen, setBookmarksMenuOpen] = useState(false);
+  const [bookmarksMenuPosition, setBookmarksMenuPosition] = useState<{ top: number; left: number; maxHeight: number } | null>(null);
+  const [managerEditDialogOpen, setManagerEditDialogOpen] = useState(false);
+  const [managerEditNodeId, setManagerEditNodeId] = useState<string | null>(null);
+  const [managerEditNodeType, setManagerEditNodeType] = useState<"url" | "folder">("url");
+  const [managerEditTitle, setManagerEditTitle] = useState("");
+  const [managerEditUrl, setManagerEditUrl] = useState("");
+  const [managerEditTags, setManagerEditTags] = useState("");
+  const [managerEditParentId, setManagerEditParentId] = useState("1");
+  const [bookmarksBarVisible, setBookmarksBarVisible] = useState(true);
+  const [bookmarkDialogOpen, setBookmarkDialogOpen] = useState(false);
+  const [bookmarkTitle, setBookmarkTitle] = useState("");
+  const [bookmarkUrl, setBookmarkUrl] = useState("");
+  const [bookmarkTags, setBookmarkTags] = useState("");
+  const [bookmarkParentId, setBookmarkParentId] = useState("1");
+  const bookmarkTitleRequestRef = useRef(0);
+  const [extensions, setExtensions] = useState<BrowserExtension[]>([]);
+
+  useEffect(() => {
+    if (url == null) return;
+    setAddressValue(toAddressBarValue(url));
+  }, [url]);
+
+  useEffect(() => {
+    const bridge = getBridge();
+    if (bridge.getExtensions) {
+      bridge.getExtensions().then(setExtensions);
+    }
+  }, []);
+
+  const fetchBookmarks = async () => {
+    setBookmarksLoading(true);
+    try {
+      const response = await fetch("/api/browser/bookmarks", { method: "GET", cache: "no-store" });
+      if (!response.ok) return;
+      const data = (await response.json()) as BookmarkFile;
+      setBookmarks(data);
+    } finally {
+      setBookmarksLoading(false);
+    }
+  };
+
+  const resolveCurrentPageTitle = async (currentUrl: string): Promise<string> => {
+    if (browserMode === "iframe") {
+      try {
+        const iframeTitle = iframeRef.current?.contentDocument?.title?.trim();
+        if (iframeTitle) return iframeTitle;
+      } catch {}
+    }
+    try {
+      const response = await fetch("/api/browser/bookmarks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "resolveTitle", url: currentUrl }),
+      });
+      if (!response.ok) return "";
+      const data = (await response.json()) as { title?: string | null };
+      return typeof data.title === "string" ? data.title : "";
+    } catch {
+      return "";
+    }
+  };
+
+  const openBookmarkDialog = async () => {
+    if (!url || url === "about:blank") return;
+    const currentUrl = addressValue || url;
+    const requestId = bookmarkTitleRequestRef.current + 1;
+    bookmarkTitleRequestRef.current = requestId;
+    setBookmarkUrl(currentUrl);
+    setBookmarkTitle("");
+    setBookmarkTags("");
+    setBookmarkParentId(bookmarks?.roots.bookmark_bar.id ?? "1");
+    setBookmarkDialogOpen(true);
+    const nextTitle = await resolveCurrentPageTitle(currentUrl);
+    if (bookmarkTitleRequestRef.current !== requestId) return;
+    setBookmarkTitle(nextTitle);
+  };
+
+  const saveBookmarkFromDialog = async () => {
+    const normalizedUrl = normalizeBookmarkUrl(bookmarkUrl);
+    const tags = bookmarkTags
+      .split(",")
+      .map((tag) => tag.trim())
+      .filter((tag) => tag.length > 0);
+    const response = await fetch("/api/browser/bookmarks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        action: "addBookmark",
+        name: bookmarkTitle,
+        url: normalizedUrl,
+        parentId: bookmarkParentId,
+        tags,
+      }),
+    });
+    if (!response.ok) return;
+    const data = (await response.json()) as { bookmarks?: BookmarkFile };
+    if (data.bookmarks) setBookmarks(data.bookmarks);
+    setBookmarkDialogOpen(false);
+  };
+
+  const openManagerEditDialog = (node: BookmarkNode, parentId: string) => {
+    setManagerEditNodeId(node.id);
+    setManagerEditNodeType(node.type);
+    setManagerEditTitle(node.name);
+    setManagerEditUrl(node.type === "url" ? node.url : "");
+    setManagerEditTags(node.type === "url" ? node.tags.join(", ") : "");
+    setManagerEditParentId(parentId);
+    setManagerOpen(false);
+    setManagerEditDialogOpen(true);
+  };
+
+  const saveManagerEditDialog = async () => {
+    if (!managerEditNodeId) return;
+    const response = await fetch("/api/browser/bookmarks", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: managerEditNodeId,
+        name: managerEditTitle,
+        ...(managerEditNodeType === "url"
+          ? {
+              url: normalizeBookmarkUrl(managerEditUrl),
+              tags: managerEditTags
+                .split(",")
+                .map((tag) => tag.trim())
+                .filter((tag) => tag.length > 0),
+              parentId: managerEditParentId,
+            }
+          : {}),
+      }),
+    });
+    if (!response.ok) return;
+    const data = (await response.json()) as { bookmarks?: BookmarkFile };
+    if (data.bookmarks) setBookmarks(data.bookmarks);
+    setManagerEditDialogOpen(false);
+    setManagerEditNodeId(null);
+    setManagerOpen(true);
+  };
+
+  const markBookmarkUsed = async (id: string) => {
+    const response = await fetch("/api/browser/bookmarks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "markUsed", id }),
+    });
+    if (!response.ok) return;
+    const data = (await response.json()) as { bookmarks?: BookmarkFile };
+    if (data.bookmarks) setBookmarks(data.bookmarks);
+  };
+
+  const openBookmarkUrl = async (node: BookmarkUrlNode) => {
+    await markBookmarkUsed(node.id);
+    setBookmarksMenuOpen(false);
+    setAppMode("browse", node.url);
+    setAddressValue(toAddressBarValue(node.url));
+  };
+
+  const setElectronOverlayVisibility = async (visible: boolean) => {
+    if (browserMode !== "electron") return;
+    const bridge = getBridge();
+    const viewId = viewIdRef.current;
+    const setBrowserViewVisible = bridge.setBrowserViewVisible;
+    if (!viewId || !setBrowserViewVisible) return;
+    try {
+      const result = await setBrowserViewVisible(viewId, visible);
+      if (visible) {
+        updateBoundsRef.current();
+      }
+      if (visible && !result?.ok) {
+        setInitAttempt((value) => value + 1);
+      }
+    } catch {
+      if (visible) {
+        setInitAttempt((value) => value + 1);
+      }
+    }
+  };
+
+  const openBookmarksNativeMenu = async () => {
+    const trigger = bookmarksTriggerRef.current;
+    if (!trigger) return;
+    const bridge = getBridge();
+    const showBrowserBookmarksMenu = bridge.showBrowserBookmarksMenu;
+    if (!showBrowserBookmarksMenu) {
+      setBookmarksMenuOpen((open) => !open);
+      return;
+    }
+    if (!bookmarks) {
+      return;
+    }
+
+    const rect = trigger.getBoundingClientRect();
+    const x = Math.max(0, Math.round(rect.right - 4));
+    const y = Math.max(0, Math.round(rect.bottom + 6));
+    const items = toBridgeBookmarkMenuItems([
+      ...bookmarks.roots.bookmark_bar.children,
+      ...bookmarks.roots.other.children,
+    ]);
+
+    const result = await showBrowserBookmarksMenu({ x, y, items });
+    if (!result?.ok || result.cancelled) return;
+    if (typeof result.id === "string") {
+      await markBookmarkUsed(result.id);
+    }
+    if (typeof result.url === "string" && result.url.trim().length > 0) {
+      setAppMode("browse", result.url);
+      setAddressValue(toAddressBarValue(result.url));
+    }
+  };
+
+  const openTagsCloud = () => {
+    const entries = bookmarks
+      ? collectBookmarkTagEntries([
+          bookmarks.roots.bookmark_bar,
+          bookmarks.roots.other,
+        ])
+      : [];
+    const html = buildTagCloudHtml(entries);
+    const dataUrl = `${TAG_CLOUD_DATA_URL_PREFIX}${encodeURIComponent(html)}`;
+    setAppMode("browse", dataUrl);
+    setAddressValue("");
+  };
+
+  const handleToggleExtensionPin = async (ext: BrowserExtension) => {
+    const bridge = getBridge();
+    const newPinned = !ext.pinned;
+    if (bridge.updateExtension) {
+      await bridge.updateExtension(ext.id, { pinned: newPinned });
+      setExtensions(prev => prev.map(e => e.id === ext.id ? { ...e, pinned: newPinned } : e));
+    }
+  };
+
+  const handleRunExtension = async (ext: BrowserExtension, event: React.MouseEvent) => {
+    const bridge = getBridge();
+    if (bridge.showExtensionPopup) {
+      const rect = event.currentTarget.getBoundingClientRect();
+      await bridge.showExtensionPopup({
+        extensionId: ext.id,
+        x: Math.round(rect.left),
+        y: Math.round(rect.bottom + 8),
+      });
+    }
+  };
+
+  const createFolder = async () => {
+    const response = await fetch("/api/browser/bookmarks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "createFolder", name: "New Folder" }),
+    });
+    if (!response.ok) return;
+    const data = (await response.json()) as { bookmarks?: BookmarkFile };
+    if (data.bookmarks) setBookmarks(data.bookmarks);
+  };
+
+  const deleteNode = async (id: string) => {
+    const response = await fetch("/api/browser/bookmarks", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id }),
+    });
+    if (!response.ok) return;
+    const data = (await response.json()) as { bookmarks?: BookmarkFile };
+    if (data.bookmarks) setBookmarks(data.bookmarks);
+  };
+
+  const navigateBack = () => {
+    const applyAppHistoryBack = () => {
+      const nextIndex = iframeHistoryIndexRef.current - 1;
+      const target = nextIndex >= 0 ? iframeHistoryRef.current[nextIndex] : null;
+      // No earlier real page to return to (we're at the first browsed page, and
+      // index 0 is the empty session seed). Rather than dead-ending on
+      // about:blank, fall back to the KB article we came from by exiting browse
+      // mode — this is the "back to the article" affordance.
+      if (nextIndex < 0 || !target || target === "about:blank") {
+        iframeNavActionRef.current = null;
+        setAppMode("edit");
+        return;
+      }
+      iframeHistoryIndexRef.current = nextIndex;
+      iframeNavActionRef.current = "back";
+      setAppMode("browse", target);
+    };
+    if (browserMode === "electron") {
+      const viewId = viewIdRef.current;
+      const bridge = getBridge();
+      if (viewId && bridge.browserViewGoBack) {
+        iframeNavActionRef.current = "back";
+        void bridge.browserViewGoBack(viewId)
+          .then((result) => {
+            if (result?.ok && !result.skipped) return;
+            iframeNavActionRef.current = null;
+            applyAppHistoryBack();
+          })
+          .catch(() => {
+            iframeNavActionRef.current = null;
+            applyAppHistoryBack();
+          });
+        return;
+      }
+      applyAppHistoryBack();
+      return;
+    }
+    if (browserMode === "iframe") {
+      try {
+        iframeRef.current?.contentWindow?.history.back();
+        return;
+      } catch {
+        applyAppHistoryBack();
+      }
+    }
+  };
+
+  const navigateForward = () => {
+    const applyAppHistoryForward = () => {
+      const nextIndex = iframeHistoryIndexRef.current + 1;
+      if (nextIndex >= iframeHistoryRef.current.length) return;
+      iframeHistoryIndexRef.current = nextIndex;
+      iframeNavActionRef.current = "forward";
+      setAppMode("browse", iframeHistoryRef.current[nextIndex] || "about:blank");
+    };
+    if (browserMode === "electron") {
+      const viewId = viewIdRef.current;
+      const bridge = getBridge();
+      if (viewId && bridge.browserViewGoForward) {
+        iframeNavActionRef.current = "forward";
+        void bridge.browserViewGoForward(viewId)
+          .then((result) => {
+            if (result?.ok && !result.skipped) return;
+            iframeNavActionRef.current = null;
+            applyAppHistoryForward();
+          })
+          .catch(() => {
+            iframeNavActionRef.current = null;
+            applyAppHistoryForward();
+          });
+        return;
+      }
+      applyAppHistoryForward();
+      return;
+    }
+    if (browserMode === "iframe") {
+      applyAppHistoryForward();
+    }
+  };
+
+  const reloadPage = () => {
+    const applyReloadFallback = () => {
+      setIframeReloadKey((k) => k + 1);
+    };
+    if (browserMode === "electron") {
+      const viewId = viewIdRef.current;
+      const bridge = getBridge();
+      if (!viewId) {
+        applyReloadFallback();
+        return;
+      }
+      if (bridge.browserViewReload) {
+        void bridge.browserViewReload(viewId)
+          .then((result) => {
+            if (result?.ok && !result.skipped) return;
+            if (bridge.loadBrowserViewUrl) {
+              void bridge.loadBrowserViewUrl(viewId, "__cabinet_nav_reload__")
+                .then((fallbackResult) => {
+                  if (fallbackResult?.ok && !fallbackResult.skipped) return;
+                  applyReloadFallback();
+                })
+                .catch(() => {
+                  applyReloadFallback();
+                });
+              return;
+            }
+            applyReloadFallback();
+          })
+          .catch(() => {
+            if (bridge.loadBrowserViewUrl) {
+              void bridge.loadBrowserViewUrl(viewId, "__cabinet_nav_reload__")
+                .then((fallbackResult) => {
+                  if (fallbackResult?.ok && !fallbackResult.skipped) return;
+                  applyReloadFallback();
+                })
+                .catch(() => {
+                  applyReloadFallback();
+                });
+              return;
+            }
+            applyReloadFallback();
+          });
+        return;
+      }
+      if (bridge.loadBrowserViewUrl) {
+        void bridge.loadBrowserViewUrl(viewId, "__cabinet_nav_reload__")
+          .then((result) => {
+            if (result?.ok && !result.skipped) return;
+            applyReloadFallback();
+          })
+          .catch(() => {
+            applyReloadFallback();
+          });
+        return;
+      }
+      applyReloadFallback();
+      return;
+    }
+    if (browserMode === "iframe") {
+      applyReloadFallback();
+    }
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    let retries = 0;
+    const maxRetries = 20;
+    let retryTimer: number | null = null;
+
+    const cleanup = () => {
+      if (retryTimer !== null) {
+        window.clearTimeout(retryTimer);
+        retryTimer = null;
+      }
+    };
+
+    const failToIframe = () => {
+      setBrowserMode("iframe");
+    };
+
+    const hasElectronBrowserBridge = () => {
+      const bridge = getBridge();
+      return !!bridge.createBrowserView && !!bridge.destroyBrowserView;
+    };
+
+    const attemptInit = () => {
+      if (cancelled) return;
+      const bridge = getBridge();
+      if (!hasElectronBrowserBridge()) {
+        retries += 1;
+        if (retries >= maxRetries) {
+          failToIframe();
+          return;
+        }
+        retryTimer = window.setTimeout(attemptInit, 100);
+        return;
+      }
+      const createBrowserView = bridge.createBrowserView;
+      const destroyBrowserView = bridge.destroyBrowserView;
+      const loadBrowserViewUrl = bridge.loadBrowserViewUrl;
+      if (!createBrowserView || !destroyBrowserView) {
+        failToIframe();
+        return;
+      }
+      void createBrowserView(useAppStore.getState().browseUrl || "about:blank")
+        .then((result) => {
+          if (cancelled) {
+            // We unmounted while the view was being created — the cleanup ran
+            // before viewIdRef was set, so destroy the now-orphaned view here
+            // to avoid leaking a whole WebContentsView (a Chromium renderer).
+            if (result?.ok && result.viewId && destroyBrowserView) {
+              void destroyBrowserView(result.viewId);
+            }
+            return;
+          }
+          if (!result?.ok || !result.viewId) {
+            failToIframe();
+            return;
+          }
+          setBrowserMode("electron");
+          setElectronFailure(null);
+          viewIdRef.current = result.viewId;
+          updateBoundsRef.current();
+          const activeUrl = useAppStore.getState().browseUrl || "about:blank";
+          if (loadBrowserViewUrl) {
+            void loadBrowserViewUrl(result.viewId, activeUrl)
+              .then((navResult) => {
+                if (!navResult?.ok) {
+                  setElectronFailure(navResult?.primaryError || navResult?.error || "load-failed");
+                }
+              })
+              .catch(() => {
+                setElectronFailure("load-failed");
+              });
+          }
+        })
+        .catch(() => {
+          if (!cancelled) failToIframe();
+        });
+    };
+
+    const existing = viewIdRef.current;
+    if (existing) {
+      const bridge = getBridge();
+      const destroyBrowserView = bridge.destroyBrowserView;
+      const setBrowserViewVisible = bridge.setBrowserViewVisible;
+      viewIdRef.current = null;
+      if (setBrowserViewVisible) {
+        void setBrowserViewVisible(existing, false).catch(() => {});
+      }
+      if (destroyBrowserView) {
+        void destroyBrowserView(existing);
+      }
+    }
+
+    setBrowserMode(hasElectronBrowserBridge() ? "initializing" : "iframe");
+    attemptInit();
+
+    return () => {
+      cancelled = true;
+      cleanup();
+      const bridge = getBridge();
+      const destroyBrowserView = bridge.destroyBrowserView;
+      const setBrowserViewVisible = bridge.setBrowserViewVisible;
+      const current = viewIdRef.current;
+      viewIdRef.current = null;
+      if (current && setBrowserViewVisible) {
+        void setBrowserViewVisible(current, false).catch(() => {});
+      }
+      if (current && destroyBrowserView) {
+        void destroyBrowserView(current);
+      }
+    };
+  }, [initAttempt]);
+
+  useEffect(() => {
+    const bridge = getBridge();
+    const subscribe = bridge.onBrowserViewLoadFailed;
+    if (!subscribe) return;
+    const unsubscribe = subscribe((payload) => {
+      const activeViewId = viewIdRef.current;
+      if (!activeViewId || payload?.viewId !== activeViewId) return;
+      const detail = [
+        payload?.errorDescription,
+        payload?.validatedUrl,
+        payload?.primaryError,
+        payload?.fallbackError,
+      ]
+        .filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+        .join(" | ");
+      setElectronFailure(detail || "load-failed");
+    });
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+
+  useEffect(() => {
+    const bridge = getBridge();
+    const subscribe = bridge.onBrowserViewNavigated;
+    if (!subscribe) return;
+    const unsubscribe = subscribe((payload) => {
+      const activeViewId = viewIdRef.current;
+      if (!activeViewId || payload?.viewId !== activeViewId) return;
+      const nextUrl = normalizeSessionUrl(payload?.url || "about:blank");
+      const history = iframeHistoryRef.current;
+      const currentIndex = iframeHistoryIndexRef.current;
+      const navAction = iframeNavActionRef.current;
+      if (navAction === "back" || navAction === "forward") {
+        iframeNavActionRef.current = null;
+        let nextIndex = navAction === "back" ? Math.max(0, currentIndex - 1) : Math.min(history.length - 1, currentIndex + 1);
+        if (history[nextIndex] !== nextUrl) {
+          const start = navAction === "back" ? Math.max(0, currentIndex - 1) : Math.min(history.length - 1, currentIndex + 1);
+          const end = navAction === "back" ? 0 : history.length - 1;
+          const step = navAction === "back" ? -1 : 1;
+          let matchedIndex = -1;
+          for (let i = start; navAction === "back" ? i >= end : i <= end; i += step) {
+            if (history[i] === nextUrl) {
+              matchedIndex = i;
+              break;
+            }
+          }
+          if (matchedIndex >= 0) {
+            nextIndex = matchedIndex;
+          } else {
+            const nextHistory = currentIndex >= 0 ? history.slice(0, currentIndex + 1) : [];
+            nextHistory.push(nextUrl);
+            iframeHistoryRef.current = nextHistory;
+            nextIndex = nextHistory.length - 1;
+          }
+        }
+        iframeHistoryIndexRef.current = nextIndex;
+        const nextHistory = iframeHistoryRef.current;
+        persistBrowserSessionState({ history: nextHistory, index: nextIndex, url: nextUrl });
+        setAddressValue(toAddressBarValue(nextUrl));
+        if (useAppStore.getState().browseUrl !== nextUrl) {
+          suppressNextElectronLoadRef.current = true;
+          setAppMode("browse", nextUrl);
+        }
+        return;
+      }
+      if (currentIndex >= 0 && history[currentIndex] === nextUrl) {
+        persistBrowserSessionState({ history, index: currentIndex, url: nextUrl });
+        setAddressValue(toAddressBarValue(nextUrl));
+        return;
+      }
+      const nextHistory = currentIndex >= 0 ? history.slice(0, currentIndex + 1) : [];
+      nextHistory.push(nextUrl);
+      iframeHistoryRef.current = nextHistory;
+      iframeHistoryIndexRef.current = nextHistory.length - 1;
+      persistBrowserSessionState({
+        history: nextHistory,
+        index: iframeHistoryIndexRef.current,
+        url: nextUrl,
+      });
+      setAddressValue(toAddressBarValue(nextUrl));
+      if (useAppStore.getState().browseUrl !== nextUrl) {
+        suppressNextElectronLoadRef.current = true;
+        setAppMode("browse", nextUrl);
+      }
+    });
+    return () => {
+      unsubscribe();
+    };
+  }, [setAppMode]);
+
+  useEffect(() => {
+    const bridge = getBridge();
+    const viewId = viewIdRef.current;
+    if (!bridge.createBrowserView || !bridge.destroyBrowserView || !viewId || browserMode !== "electron") {
+      return;
+    }
+    if (suppressNextElectronLoadRef.current) {
+      suppressNextElectronLoadRef.current = false;
+      return;
+    }
+    const loadBrowserViewUrl = bridge.loadBrowserViewUrl;
+    if (!loadBrowserViewUrl) return;
+    void loadBrowserViewUrl(viewId, url || "about:blank")
+      .then((result) => {
+        if (!result?.ok) {
+          setElectronFailure(result?.primaryError || result?.error || "load-failed");
+        } else {
+          setElectronFailure(null);
+        }
+      })
+      .catch(() => {
+        setElectronFailure("load-failed");
+      });
+  }, [url, browserMode]);
+
+  useEffect(() => {
+    const bridge = getBridge();
+    if (!bridge.createBrowserView || !bridge.destroyBrowserView || browserMode !== "electron") return;
+    const setBrowserViewBounds = bridge.setBrowserViewBounds;
+    if (!setBrowserViewBounds) return;
+    const updateBounds = () => {
+      const viewId = viewIdRef.current;
+      const el = containerRef.current;
+      if (!viewId || !el) return;
+      const rect = el.getBoundingClientRect();
+      const x = Math.max(0, Math.round(rect.left));
+      const y = Math.max(0, Math.round(rect.top));
+      const width = Math.max(0, Math.round(rect.width));
+      const height = Math.max(0, Math.round(rect.height));
+      if (width < 64 || height < 64) return;
+      void setBrowserViewBounds(viewId, { x, y, width, height });
+    };
+    updateBoundsRef.current = updateBounds;
+    const ro = new ResizeObserver(updateBounds);
+    const el = containerRef.current;
+    if (el) ro.observe(el);
+    window.addEventListener("resize", updateBounds);
+    updateBounds();
+    const timer = window.setTimeout(updateBounds, 120);
+    return () => {
+      window.clearTimeout(timer);
+      updateBoundsRef.current = () => {};
+      ro.disconnect();
+      window.removeEventListener("resize", updateBounds);
+    };
+  }, [browserMode]);
+
+  const isDialogOpen = managerOpen || bookmarkDialogOpen || managerEditDialogOpen;
+
+  useEffect(() => {
+    const bridge = getBridge();
+    const viewId = viewIdRef.current;
+    if (!bridge.createBrowserView || !bridge.destroyBrowserView || !viewId || browserMode !== "electron") {
+      return;
+    }
+    const setBrowserViewVisible = bridge.setBrowserViewVisible;
+    if (!setBrowserViewVisible) return;
+    const shouldShow = !isDialogOpen;
+    if (shouldShow) {
+      updateBoundsRef.current();
+    }
+    void setBrowserViewVisible(viewId, shouldShow)
+      .then((result) => {
+        if (shouldShow) {
+          window.setTimeout(() => {
+            updateBoundsRef.current();
+          }, 24);
+        }
+        if (shouldShow && !result?.ok) {
+          setInitAttempt((value) => value + 1);
+        }
+      })
+      .catch(() => {
+        if (shouldShow) {
+          setInitAttempt((value) => value + 1);
+        }
+      });
+  }, [browserMode, isDialogOpen]);
+
+  useEffect(() => {
+    if (browserMode !== "iframe") {
+      setIframePolicyBlocked(false);
+      return;
+    }
+    if (!url || url === "about:blank") {
+      setIframePolicyBlocked(false);
+      return;
+    }
+    let cancelled = false;
+    const check = async () => {
+      try {
+        const res = await fetch(`/api/browser/frame-check?url=${encodeURIComponent(url)}`, {
+          method: "GET",
+          cache: "no-store",
+        });
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!cancelled) {
+          setIframePolicyBlocked(data?.blocked === true);
+        }
+      } catch {
+        if (!cancelled) {
+          setIframePolicyBlocked(false);
+        }
+      }
+    };
+    void check();
+    return () => {
+      cancelled = true;
+    };
+  }, [browserMode, url]);
+
+  useEffect(() => {
+    if (browserMode !== "iframe") {
+      setIframeFailure(null);
+      return;
+    }
+    if (!url || url === "about:blank") {
+      setIframeFailure(null);
+      return;
+    }
+    const loadToken = iframeLoadTokenRef.current;
+    const timer = window.setTimeout(() => {
+      if (iframePolicyBlocked) {
+        setIframeFailure("blocked-or-failed");
+        return;
+      }
+      if (iframeLoadedTokenRef.current < loadToken) {
+        setIframeFailure("blocked-or-failed");
+        return;
+      }
+      const iframe = iframeRef.current;
+      if (!iframe) {
+        setIframeFailure("blocked-or-failed");
+        return;
+      }
+      try {
+        const href = iframe.contentWindow?.location?.href || "";
+        const doc = iframe.contentDocument;
+        const title = (doc?.title || "").toLowerCase();
+        const bodyText = (doc?.body?.innerText || "").toLowerCase();
+        const hasConnectionErrorText =
+          bodyText.includes("refused to connect") ||
+          bodyText.includes("can't be reached") ||
+          bodyText.includes("cannot be reached") ||
+          bodyText.includes("connection") && bodyText.includes("failed");
+        if (
+          href === "about:blank" ||
+          href.startsWith("chrome-error://") ||
+          title.includes("error") ||
+          hasConnectionErrorText
+        ) {
+          setIframeFailure("blocked-or-failed");
+          return;
+        }
+      } catch {
+        setIframeFailure(null);
+        return;
+      }
+      setIframeFailure(null);
+    }, 2500);
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [browserMode, url, iframeLoadedToken, iframePolicyBlocked]);
+
+  useEffect(() => {
+    void fetchBookmarks();
+  }, []);
+
+  useEffect(() => {
+    if (!bookmarksMenuOpen) {
+      setBookmarksMenuPosition(null);
+      return;
+    }
+    const updatePosition = () => {
+      const trigger = bookmarksTriggerRef.current;
+      if (!trigger) return;
+      const rect = trigger.getBoundingClientRect();
+      const menuWidth = 320;
+      const left = Math.max(8, Math.min(window.innerWidth - menuWidth - 8, rect.right - menuWidth));
+      const top = Math.max(8, rect.bottom + 6);
+      const maxHeight = Math.max(120, window.innerHeight - top - 8);
+      setBookmarksMenuPosition({ top, left, maxHeight });
+    };
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node | null;
+      const menu = bookmarksMenuRef.current;
+      const trigger = bookmarksTriggerRef.current;
+      if (menu?.contains(target) || trigger?.contains(target)) return;
+      setBookmarksMenuOpen(false);
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setBookmarksMenuOpen(false);
+      }
+    };
+    updatePosition();
+    window.addEventListener("resize", updatePosition);
+    window.addEventListener("scroll", updatePosition, true);
+    window.addEventListener("pointerdown", handlePointerDown);
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("resize", updatePosition);
+      window.removeEventListener("scroll", updatePosition, true);
+      window.removeEventListener("pointerdown", handlePointerDown);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [bookmarksMenuOpen]);
+
+  const allTopLevelNodes = bookmarks
+    ? normalizeBookmarkNodes([
+        ...bookmarks.roots.bookmark_bar.children,
+        ...bookmarks.roots.other.children,
+      ])
+    : [];
+
+  const bookmarkBarNodes = bookmarks
+    ? normalizeBookmarkNodes(bookmarks.roots.bookmark_bar.children).filter(
+        (node): node is BookmarkUrlNode => node.type === "url"
+      )
+    : [];
+
+  const bookmarkFolderOptions: BookmarkFolderOption[] = (() => {
+    if (!bookmarks) return [];
+    const options: BookmarkFolderOption[] = [];
+    const pushFolderOptions = (nodes: BookmarkNode[], parentLabel: string) => {
+      for (const node of normalizeBookmarkNodes(nodes)) {
+        if (node.type !== "folder") continue;
+        const label = `${parentLabel} / ${node.name}`;
+        options.push({ id: node.id, label });
+        pushFolderOptions(node.children, label);
+      }
+    };
+    options.push({ id: bookmarks.roots.bookmark_bar.id, label: bookmarks.roots.bookmark_bar.name });
+    pushFolderOptions(bookmarks.roots.bookmark_bar.children, bookmarks.roots.bookmark_bar.name);
+    options.push({ id: bookmarks.roots.other.id, label: bookmarks.roots.other.name });
+    pushFolderOptions(bookmarks.roots.other.children, bookmarks.roots.other.name);
+    return options;
+  })();
+
+  const renderDropdownNodes = (nodes: BookmarkNode[], depth = 0): ReactNode => {
+    return normalizeBookmarkNodes(nodes).map((node) => {
+      if (node.type === "folder") {
+        return (
+          <div key={node.id} className="space-y-1">
+            <div
+              className="flex items-center gap-2 px-2 py-1 text-xs font-medium text-muted-foreground"
+              style={{ marginLeft: `${depth * 10}px` }}
+            >
+              <Folder className="h-3.5 w-3.5" />
+              <span className="truncate">{node.name}</span>
+            </div>
+            {node.children.length > 0 ? (
+              renderDropdownNodes(node.children, depth + 1)
+            ) : (
+              <div className="px-2 py-1 text-xs text-muted-foreground" style={{ marginLeft: `${(depth + 1) * 10}px` }}>
+                Empty
+              </div>
+            )}
+          </div>
+        );
+      }
+      return (
+        <button
+          key={node.id}
+          type="button"
+          onClick={() => {
+            void openBookmarkUrl(node);
+          }}
+          className="flex w-full items-center rounded px-2 py-1.5 text-left text-sm text-foreground hover:bg-muted"
+          style={{ marginLeft: `${depth * 10}px` }}
+        >
+          <span className="truncate">{node.name}</span>
+        </button>
+      );
+    });
+  };
+
+  const renderManagerNodes = (nodes: BookmarkNode[], parentId: string, depth = 0): ReactNode => {
+    return normalizeBookmarkNodes(nodes).map((node) => {
+      return (
+        <div key={node.id} className="space-y-1">
+          <div className="flex items-center gap-2 rounded border border-border/70 px-2 py-1">
+            <div style={{ marginLeft: `${depth * 14}px` }} className="flex items-center gap-1.5 min-w-0 flex-1">
+              <span className="truncate text-xs text-foreground">{node.name}</span>
+            </div>
+            <button
+              type="button"
+              className="inline-flex h-7 w-7 items-center justify-center rounded border border-border hover:bg-muted"
+              onClick={() => {
+                openManagerEditDialog(node, parentId);
+              }}
+              title="Edit"
+              aria-label="Edit"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+            </button>
+            <button
+              type="button"
+              className="inline-flex h-7 w-7 items-center justify-center rounded border border-border text-destructive hover:bg-destructive/10"
+              onClick={() => {
+                void deleteNode(node.id);
+              }}
+              title="Delete"
+              aria-label="Delete"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          </div>
+          {node.type === "folder" && node.children.length > 0 ? renderManagerNodes(node.children, node.id, depth + 1) : null}
+        </div>
+      );
+    });
+  };
+
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden">
+      <Header />
+      <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
+        <div className="grid grid-cols-[1fr_minmax(0,720px)_1fr] items-center gap-3 border-b border-border/70 bg-background/80 px-4 py-2 text-sm text-muted-foreground">
+          <div className="flex items-center gap-2 truncate">
+            <button
+              type="button"
+              onClick={() => setBookmarksBarVisible((visible) => !visible)}
+              className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-foreground hover:border-border hover:bg-muted"
+              aria-label={bookmarksBarVisible ? "Hide bookmarks bar" : "Show bookmarks bar"}
+              title={bookmarksBarVisible ? "Hide bookmarks bar" : "Show bookmarks bar"}
+            >
+              <Globe className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onClick={navigateBack}
+              className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-foreground hover:border-border hover:bg-muted"
+              aria-label={t("editor:browser.back")}
+              title={t("editor:browser.back")}
+            >
+              <ChevronLeft className="h-3.5 w-3.5" />
+            </button>
+            <button
+              type="button"
+              onClick={navigateForward}
+              className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-foreground hover:border-border hover:bg-muted"
+              aria-label={t("editor:browser.forward")}
+              title={t("editor:browser.forward")}
+            >
+              <ChevronRight className="h-3.5 w-3.5" />
+            </button>
+            <button
+              type="button"
+              onClick={reloadPage}
+              className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-foreground hover:border-border hover:bg-muted"
+              aria-label={t("editor:browser.reload")}
+              title={t("editor:browser.reload")}
+            >
+              <RefreshCw className="h-3.5 w-3.5" />
+            </button>
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              value={addressValue}
+              onChange={(event) => setAddressValue(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key !== "Enter") return;
+                event.preventDefault();
+                const nextUrl = normalizeEnteredUrl(addressValue);
+                setAppMode("browse", nextUrl);
+                setAddressValue(toAddressBarValue(nextUrl));
+              }}
+              placeholder={t("editor:browser.noUrl")}
+              className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground shadow-sm outline-none ring-offset-background focus:ring-2 focus:ring-ring"
+            />
+              <button
+                type="button"
+                onClick={openBookmarkDialog}
+                className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-transparent text-foreground hover:border-border hover:bg-muted"
+                title="Save bookmark"
+                aria-label="Save bookmark"
+              >
+              <Bookmark className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                void setElectronOverlayVisibility(false).then(() => {
+                  setManagerOpen(true);
+                });
+              }}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-transparent text-foreground hover:border-border hover:bg-muted"
+              title="Bookmark manager"
+              aria-label="Bookmark manager"
+            >
+              <BookMarked className="h-4 w-4" />
+            </button>
+            <button
+              ref={bookmarksTriggerRef}
+              type="button"
+              onClick={() => {
+                void openBookmarksNativeMenu();
+              }}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-transparent text-foreground hover:border-border hover:bg-muted"
+              title="Bookmarks"
+              aria-label="Bookmarks"
+              aria-expanded={bookmarksMenuOpen}
+            >
+              <Icon iconNode={folderBookmarkIconNode} className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onClick={openTagsCloud}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-transparent text-foreground hover:border-border hover:bg-muted"
+              title="Tags"
+              aria-label="Tags"
+            >
+              <Tags className="h-4 w-4" />
+            </button>
+            
+            {/* Pinned Extensions */}
+            {extensions.filter(ext => ext.enabled !== false && ext.pinned).map(ext => (
+              <button
+                key={ext.id}
+                type="button"
+                onClick={(e) => handleRunExtension(ext, e)}
+                className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-transparent text-foreground hover:border-border hover:bg-muted"
+                title={ext.name}
+                aria-label={ext.name}
+              >
+                {ext.iconDataUrl ? (
+                  <img src={ext.iconDataUrl} alt="" className="w-4 h-4 object-contain" />
+                ) : (
+                  <Blocks className="h-4 w-4" />
+                )}
+              </button>
+            ))}
+
+            {/* Extensions Dropdown */}
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-transparent text-foreground hover:border-border hover:bg-muted cursor-pointer"
+                title="Extensions"
+                aria-label="Extensions"
+              >
+                <Blocks className="h-4 w-4" />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-64">
+                {extensions.filter(ext => ext.enabled !== false).length === 0 ? (
+                  <div className="p-3 text-xs text-muted-foreground text-center">No extensions enabled</div>
+                ) : (
+                  extensions.filter(ext => ext.enabled !== false).map(ext => (
+                    <div key={ext.id} className="flex items-center justify-between px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground rounded-sm cursor-pointer group">
+                      <div className="flex items-center gap-2 flex-1 overflow-hidden" onClick={(e) => handleRunExtension(ext, e)}>
+                        {ext.iconDataUrl ? (
+                          <img src={ext.iconDataUrl} alt="" className="w-4 h-4 object-contain shrink-0" />
+                        ) : (
+                          <Blocks className="h-4 w-4 shrink-0 text-muted-foreground" />
+                        )}
+                        <span className="truncate">{ext.name}</span>
+                      </div>
+                      <button 
+                        type="button" 
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleToggleExtensionPin(ext);
+                        }}
+                        className="opacity-0 group-hover:opacity-100 p-1 hover:bg-muted rounded text-muted-foreground"
+                        title={ext.pinned ? "Unpin extension" : "Pin extension"}
+                      >
+                        {ext.pinned ? <PinOff className="w-3.5 h-3.5" /> : <Pin className="w-3.5 h-3.5" />}
+                      </button>
+                    </div>
+                  ))
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+          <div className="flex justify-end gap-2">
+            {url ? (
+              <a
+                href={url}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-foreground hover:bg-muted"
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+                {t("editor:browser.openExternally")}
+              </a>
+            ) : null}
+          </div>
+        </div>
+        {bookmarksBarVisible ? (
+          <div className="border-b border-border/70 bg-background/80 px-4 py-1.5">
+            <div className="flex items-center gap-1.5 overflow-x-auto">
+              {bookmarkBarNodes.length > 0 ? (
+                bookmarkBarNodes.map((node) => (
+                  <button
+                    key={node.id}
+                    type="button"
+                    onClick={() => {
+                      void openBookmarkUrl(node);
+                    }}
+                    className="inline-flex h-7 max-w-55 shrink-0 items-center rounded-md border border-transparent px-2 text-xs text-foreground hover:border-border hover:bg-muted"
+                    title={node.name}
+                    aria-label={node.name}
+                  >
+                    <span className="truncate">{node.name}</span>
+                  </button>
+                ))
+              ) : (
+                <div className="px-1 text-xs text-muted-foreground">No bookmarks in Bookmarks bar</div>
+              )}
+            </div>
+          </div>
+        ) : null}
+        <div ref={containerRef} className="relative flex-1 min-h-0">
+          {browserMode === "iframe" ? (
+            <>
+              <iframe
+                key={`${url || "about:blank"}:${iframeReloadKey}`}
+                ref={iframeRef}
+                title={t("editor:browser.openExternally")}
+                src={url || "about:blank"}
+                onLoad={() => {
+                  iframeLoadedTokenRef.current = iframeLoadTokenRef.current;
+                  setIframeLoadedToken(iframeLoadTokenRef.current);
+                }}
+                className="h-full w-full border-0 bg-white"
+                sandbox="allow-same-origin allow-scripts allow-forms allow-modals allow-top-navigation-by-user-activation"
+              />
+              {iframeFailure ? (
+                <div className="absolute inset-0 flex items-center justify-center bg-background/85 p-6 text-center">
+                  <div className="max-w-md rounded border border-border bg-background px-4 py-3 text-sm text-muted-foreground">
+                    <div>This page can’t be rendered in an iframe.</div>
+                    <div className="mt-1">Use “Open externally”.</div>
+                  </div>
+                </div>
+              ) : null}
+            </>
+          ) : (
+            <>
+              <div className="h-full w-full bg-white" />
+              {electronFailure ? (
+                <div className="absolute inset-0 flex items-center justify-center bg-background/85 p-6 text-center">
+                  <div className="max-w-xl rounded border border-border bg-background px-4 py-3 text-sm text-muted-foreground">
+                    <div>This page failed to load.</div>
+                    <div className="mt-1 break-all">{electronFailure}</div>
+                  </div>
+                </div>
+              ) : null}
+            </>
+          )}
+        </div>
+      </div>
+      {bookmarksMenuOpen && bookmarksMenuPosition ? (
+        <div
+          ref={bookmarksMenuRef}
+          className="fixed z-120 w-[320px] rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10"
+          style={{ top: bookmarksMenuPosition.top, left: bookmarksMenuPosition.left }}
+        >
+          <div className="overflow-auto" style={{ maxHeight: `${bookmarksMenuPosition.maxHeight}px` }}>
+            {bookmarksLoading ? (
+              <div className="px-2 py-1.5 text-sm text-muted-foreground">Loading...</div>
+            ) : allTopLevelNodes.length > 0 ? (
+              renderDropdownNodes(allTopLevelNodes)
+            ) : (
+              <div className="px-2 py-1.5 text-sm text-muted-foreground">No bookmarks</div>
+            )}
+          </div>
+        </div>
+      ) : null}
+      <Dialog open={bookmarkDialogOpen} onOpenChange={setBookmarkDialogOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Bookmark</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <div className="text-xs text-muted-foreground">Title</div>
+              <input
+                value={bookmarkTitle}
+                onChange={(event) => setBookmarkTitle(event.target.value)}
+                className="h-9 w-full rounded border border-border bg-background px-3 text-sm text-foreground"
+              />
+            </div>
+            <div className="space-y-1">
+              <div className="text-xs text-muted-foreground">URL</div>
+              <input
+                value={bookmarkUrl}
+                onChange={(event) => setBookmarkUrl(event.target.value)}
+                className="h-9 w-full rounded border border-border bg-background px-3 text-sm text-foreground"
+              />
+            </div>
+            <div className="space-y-1">
+              <div className="text-xs text-muted-foreground">Tags</div>
+              <input
+                value={bookmarkTags}
+                onChange={(event) => setBookmarkTags(event.target.value)}
+                placeholder="tag1, tag2"
+                className="h-9 w-full rounded border border-border bg-background px-3 text-sm text-foreground"
+              />
+            </div>
+            <div className="space-y-1">
+              <div className="text-xs text-muted-foreground">Folder</div>
+              <select
+                value={bookmarkParentId}
+                onChange={(event) => setBookmarkParentId(event.target.value)}
+                className="h-9 w-full rounded border border-border bg-background px-3 text-sm text-foreground"
+              >
+                {bookmarkFolderOptions.map((option) => (
+                  <option key={option.id} value={option.id}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+          <DialogFooter className="gap-2">
+            <button
+              type="button"
+              className="inline-flex h-8 items-center rounded border border-border px-2 text-xs hover:bg-muted"
+              onClick={() => {
+                setBookmarkDialogOpen(false);
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="inline-flex h-8 items-center rounded border border-border px-2 text-xs hover:bg-muted"
+              onClick={() => {
+                void saveBookmarkFromDialog();
+              }}
+            >
+              Save
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <Dialog open={managerEditDialogOpen} onOpenChange={(open) => {
+        setManagerEditDialogOpen(open);
+        if (!open) {
+          setManagerEditNodeId(null);
+          setManagerOpen(true);
+        }
+      }}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Edit bookmark</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <div className="text-xs text-muted-foreground">Title</div>
+              <input
+                value={managerEditTitle}
+                onChange={(event) => setManagerEditTitle(event.target.value)}
+                className="h-9 w-full rounded border border-border bg-background px-3 text-sm text-foreground"
+              />
+            </div>
+            {managerEditNodeType === "url" ? (
+              <>
+                <div className="space-y-1">
+                  <div className="text-xs text-muted-foreground">URL</div>
+                  <input
+                    value={managerEditUrl}
+                    onChange={(event) => setManagerEditUrl(event.target.value)}
+                    className="h-9 w-full rounded border border-border bg-background px-3 text-sm text-foreground"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <div className="text-xs text-muted-foreground">Tags</div>
+                  <input
+                    value={managerEditTags}
+                    onChange={(event) => setManagerEditTags(event.target.value)}
+                    placeholder="tag1, tag2"
+                    className="h-9 w-full rounded border border-border bg-background px-3 text-sm text-foreground"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <div className="text-xs text-muted-foreground">Folder</div>
+                  <select
+                    value={managerEditParentId}
+                    onChange={(event) => setManagerEditParentId(event.target.value)}
+                    className="h-9 w-full rounded border border-border bg-background px-3 text-sm text-foreground"
+                  >
+                    {bookmarkFolderOptions.map((option) => (
+                      <option key={option.id} value={option.id}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </>
+            ) : null}
+          </div>
+          <DialogFooter className="gap-2">
+            <button
+              type="button"
+              className="inline-flex h-8 items-center rounded border border-border px-2 text-xs hover:bg-muted"
+              onClick={() => {
+                setManagerEditDialogOpen(false);
+                setManagerEditNodeId(null);
+                setManagerOpen(true);
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="inline-flex h-8 items-center rounded border border-border px-2 text-xs hover:bg-muted"
+              onClick={() => {
+                void saveManagerEditDialog();
+              }}
+            >
+              Save
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <Dialog open={managerOpen} onOpenChange={setManagerOpen}>
+        <DialogContent className="max-w-3xl">
+          <DialogHeader>
+            <DialogTitle>Bookmark manager</DialogTitle>
+            <DialogDescription>Manage bookmarks and folders</DialogDescription>
+          </DialogHeader>
+          <div className="max-h-[60vh] space-y-2 overflow-auto pr-1">
+            {bookmarks ? (
+              <>
+                <div className="space-y-1">
+                  <div className="text-xs font-medium text-muted-foreground">Bookmarks bar</div>
+                  {bookmarks.roots.bookmark_bar.children.length > 0 ? (
+                    renderManagerNodes(bookmarks.roots.bookmark_bar.children, bookmarks.roots.bookmark_bar.id)
+                  ) : (
+                    <div className="rounded border border-dashed border-border px-2 py-2 text-xs text-muted-foreground">Empty</div>
+                  )}
+                </div>
+                <div className="space-y-1">
+                  <div className="text-xs font-medium text-muted-foreground">Other bookmarks</div>
+                  {bookmarks.roots.other.children.length > 0 ? (
+                    renderManagerNodes(bookmarks.roots.other.children, bookmarks.roots.other.id)
+                  ) : (
+                    <div className="rounded border border-dashed border-border px-2 py-2 text-xs text-muted-foreground">Empty</div>
+                  )}
+                </div>
+              </>
+            ) : (
+              <div className="rounded border border-dashed border-border px-2 py-2 text-xs text-muted-foreground">
+                {bookmarksLoading ? "Loading..." : "No data"}
+              </div>
+            )}
+          </div>
+          <DialogFooter className="gap-2 sm:justify-between">
+            <button
+              type="button"
+              className="inline-flex h-8 items-center gap-1 rounded border border-border px-2 text-xs hover:bg-muted"
+              onClick={() => {
+                void createFolder();
+              }}
+            >
+              <Plus className="h-3.5 w-3.5" />
+              New folder
+            </button>
+            <button
+              type="button"
+              className="inline-flex h-8 items-center rounded border border-border px-2 text-xs hover:bg-muted"
+              onClick={() => {
+                setManagerOpen(false);
+              }}
+            >
+              Done
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/components/layout/browser-view.tsx
+++ b/src/components/layout/browser-view.tsx
@@ -163,6 +163,11 @@ function normalizeBookmarkUrl(value: string): string {
   if (trimmed.toLowerCase() === "about:blank") return "about:blank";
   // Protocol-relative → assume https.
   if (trimmed.startsWith("//")) return `https:${trimmed}`;
+  // host:port (e.g. localhost:3000, 127.0.0.1:8080) — the colon is a port
+  // separator, not a URL scheme, so keep the target and prefix https.
+  if (/^[a-zA-Z0-9.-]+:\d+(?:[/?#]|$)/.test(trimmed)) {
+    return `https://${trimmed}`;
+  }
   const schemeMatch = /^([a-zA-Z][a-zA-Z\d+.-]*):/.exec(trimmed);
   if (schemeMatch) {
     const scheme = schemeMatch[1].toLowerCase();
@@ -683,7 +688,6 @@ export function BrowserView() {
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const iframeLoadTokenRef = useRef(0);
   const iframeLoadedTokenRef = useRef(0);
-  const [iframeLoadedToken, setIframeLoadedToken] = useState(0);
   const iframeHistoryRef = useRef<string[]>(initialSessionRef.current.history);
   const iframeHistoryIndexRef = useRef<number>(initialSessionRef.current.index);
   const iframeNavActionRef = useRef<"back" | "forward" | null>(null);
@@ -1521,7 +1525,11 @@ export function BrowserView() {
     return () => {
       window.clearTimeout(timer);
     };
-  }, [browserMode, url, iframeReloadKey, iframeLoadedToken, iframePolicyBlocked]);
+    // NOTE: deliberately not depending on the load-completion signal — the
+    // timer reads iframeLoadedTokenRef directly. Re-running on load completion
+    // would bump the load token again and flag a false failure on a page that
+    // actually loaded fine.
+  }, [browserMode, url, iframeReloadKey, iframePolicyBlocked]);
 
   useEffect(() => {
     void fetchBookmarks();
@@ -1886,7 +1894,6 @@ export function BrowserView() {
                 src={url || "about:blank"}
                 onLoad={() => {
                   iframeLoadedTokenRef.current = iframeLoadTokenRef.current;
-                  setIframeLoadedToken(iframeLoadTokenRef.current);
                 }}
                 className="h-full w-full border-0 bg-white"
                 sandbox={iframeSandbox}

--- a/src/components/layout/browser-view.tsx
+++ b/src/components/layout/browser-view.tsx
@@ -718,7 +718,38 @@ export function BrowserView() {
   useEffect(() => {
     if (url == null) return;
     setAddressValue(toAddressBarValue(url));
-  }, [url]);
+
+    // In iframe mode there's no Electron navigation event to record history
+    // from (that's owned by onBrowserViewNavigated in electron mode), so track
+    // it here. Without this, iframeHistoryRef never grows and Back/Forward
+    // can't replay earlier pages.
+    if (browserMode !== "iframe") return;
+    const normalized = normalizeSessionUrl(url);
+    const navAction = iframeNavActionRef.current;
+    if (navAction === "back" || navAction === "forward") {
+      // Back/forward already moved the index; just clear the pending action.
+      iframeNavActionRef.current = null;
+      persistBrowserSessionState({
+        history: iframeHistoryRef.current,
+        index: iframeHistoryIndexRef.current,
+        url: normalized,
+      });
+      return;
+    }
+    const history = iframeHistoryRef.current;
+    const currentIndex = iframeHistoryIndexRef.current;
+    if (currentIndex >= 0 && history[currentIndex] === normalized) return;
+    // Genuine navigation: drop any forward entries and push the new URL.
+    const nextHistory = currentIndex >= 0 ? history.slice(0, currentIndex + 1) : [];
+    nextHistory.push(normalized);
+    iframeHistoryRef.current = nextHistory;
+    iframeHistoryIndexRef.current = nextHistory.length - 1;
+    persistBrowserSessionState({
+      history: nextHistory,
+      index: iframeHistoryIndexRef.current,
+      url: normalized,
+    });
+  }, [url, browserMode]);
 
   useEffect(() => {
     const bridge = getBridge();
@@ -1442,6 +1473,11 @@ export function BrowserView() {
       setIframeFailure(null);
       return;
     }
+    // Bump the token for each load attempt so the timeout below can tell
+    // whether *this* load fired onLoad. onLoad copies this value into
+    // iframeLoadedTokenRef; if it never does, loadedToken stays behind and we
+    // flag a failure.
+    iframeLoadTokenRef.current += 1;
     const loadToken = iframeLoadTokenRef.current;
     const timer = window.setTimeout(() => {
       if (iframePolicyBlocked) {
@@ -1485,7 +1521,7 @@ export function BrowserView() {
     return () => {
       window.clearTimeout(timer);
     };
-  }, [browserMode, url, iframeLoadedToken, iframePolicyBlocked]);
+  }, [browserMode, url, iframeReloadKey, iframeLoadedToken, iframePolicyBlocked]);
 
   useEffect(() => {
     void fetchBookmarks();

--- a/src/components/layout/viewer-toolbar.tsx
+++ b/src/components/layout/viewer-toolbar.tsx
@@ -65,11 +65,14 @@ export function ViewerToolbar({
     if (sourceNode?.type === "website" || sourceNode?.type === "app") {
       return `${assetUrl}/index.html`;
     }
-    if (sourceNode?.type === "directory" || sourceNode?.type === "cabinet") {
-      return `${assetUrl}/index.md`;
-    }
+    // Check the markdown file case before directory/cabinet: a `<name>.md` page
+    // can carry sub-pages and so be typed "directory", but its content still
+    // lives at `<name>.md`, not an `index.md` inside the folder.
     if (sourceNode?.type === "file" || lower.endsWith(".md")) {
       return `${assetUrl}.md`;
+    }
+    if (sourceNode?.type === "directory" || sourceNode?.type === "cabinet") {
+      return `${assetUrl}/index.md`;
     }
     return assetUrl;
   }, [sourcePath, sourceNode?.type]);

--- a/src/components/layout/viewer-toolbar.tsx
+++ b/src/components/layout/viewer-toolbar.tsx
@@ -1,11 +1,16 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useMemo, type ReactNode } from "react";
+import { Archive, Globe } from "lucide-react";
 import { HeaderActions } from "@/components/layout/header-actions";
 import { VersionHistory } from "@/components/editor/version-history";
 import { ReturnToChip } from "@/components/layout/return-to-chip";
 import { ViewerBreadcrumb } from "@/components/layout/viewer-breadcrumb";
 import { NewTaskButton } from "@/components/composer/new-task-button";
+import { useAppStore } from "@/stores/app-store";
+import { useTreeStore } from "@/stores/tree-store";
+import { useLocale } from "@/i18n/use-locale";
+import { findNodeByPath } from "@/lib/cabinets/tree";
 import { cn } from "@/lib/utils";
 
 /**
@@ -27,6 +32,7 @@ export function ViewerToolbar({
   leading,
   children,
   className,
+  showModeButtons = true,
 }: {
   path?: string;
   badge?: string;
@@ -36,7 +42,66 @@ export function ViewerToolbar({
   leading?: ReactNode;
   children?: ReactNode;
   className?: string;
+  showModeButtons?: boolean;
 }) {
+  const { t } = useLocale();
+  const appMode = useAppStore((s) => s.appMode);
+  const setAppMode = useAppStore((s) => s.setAppMode);
+  const nodes = useTreeStore((s) => s.nodes);
+  const selectedPath = useTreeStore((s) => s.selectedPath);
+  const sourcePath = path || selectedPath;
+  const sourceNode = useMemo(
+    () => (sourcePath ? findNodeByPath(nodes, sourcePath) : null),
+    [nodes, sourcePath]
+  );
+
+  // Map the current file to an in-app browser URL: websites/apps open their
+  // index.html, directories/cabinets their index.md, markdown its <name>.md,
+  // everything else the raw asset.
+  const browseModeUrl = useMemo(() => {
+    if (!sourcePath) return null;
+    const assetUrl = `/api/assets/${sourcePath.split("/").map(encodeURIComponent).join("/")}`;
+    const lower = sourcePath.toLowerCase();
+    if (sourceNode?.type === "website" || sourceNode?.type === "app") {
+      return `${assetUrl}/index.html`;
+    }
+    if (sourceNode?.type === "directory" || sourceNode?.type === "cabinet") {
+      return `${assetUrl}/index.md`;
+    }
+    if (sourceNode?.type === "file" || lower.endsWith(".md")) {
+      return `${assetUrl}.md`;
+    }
+    return assetUrl;
+  }, [sourcePath, sourceNode?.type]);
+
+  // The Globe (enter-browse) button only makes sense for web-renderable
+  // content — i.e. bundled websites/apps, which open their index.html. Markdown
+  // articles and other files render in their own viewers, and their raw asset
+  // URL isn't browsable (e.g. .md downloads as octet-stream), so no button.
+  const isBrowsable = sourceNode?.type === "website" || sourceNode?.type === "app";
+
+  const modeButtons = !showModeButtons ? null : appMode === "browse" ? (
+    // Always offer the exit affordance while browsing, regardless of which node
+    // is selected (you may have entered browse from a link in a markdown page).
+    <button
+      aria-label={t("editor:header.editMode")}
+      title={t("editor:header.editMode")}
+      onClick={() => setAppMode("edit")}
+      className="inline-flex items-center justify-center rounded-md h-7 w-7 hover:bg-accent hover:text-accent-foreground transition-colors cursor-pointer"
+    >
+      <Archive className="h-4 w-4" />
+    </button>
+  ) : isBrowsable ? (
+    <button
+      aria-label={t("editor:header.browseMode")}
+      title={t("editor:header.browseMode")}
+      onClick={() => setAppMode("browse", browseModeUrl)}
+      className="inline-flex items-center justify-center rounded-md h-7 w-7 hover:bg-accent hover:text-accent-foreground transition-colors cursor-pointer"
+    >
+      <Globe className="h-4 w-4" />
+    </button>
+  ) : null;
+
   return (
     <div
       className={cn(
@@ -64,6 +129,7 @@ export function ViewerToolbar({
         {children}
         {/* File History on every viewer, not just the markdown editor. */}
         {path ? <VersionHistory path={path} /> : null}
+        {modeButtons}
         <HeaderActions />
         <NewTaskButton />
       </div>

--- a/src/components/sidebar/tree-node.tsx
+++ b/src/components/sidebar/tree-node.tsx
@@ -349,7 +349,9 @@ function TreeNodeImpl({
         : // Sibling Pattern: a `<name>.md` page can carry sub-pages and so be
           // typed "directory", but its content still lives at `<name>.md`, not
           // an `index.md` inside the folder — match the markdown name first.
-          node.name.toLowerCase().endsWith(".md")
+          // Markdown pages are typed "file" with the extension stripped from
+          // the path, so they also resolve to `<name>.md`.
+          node.type === "file" || node.name.toLowerCase().endsWith(".md")
           ? `${assetUrl}.md`
           : node.type === "directory" || node.type === "cabinet"
             ? `${assetUrl}/index.md`

--- a/src/components/sidebar/tree-node.tsx
+++ b/src/components/sidebar/tree-node.tsx
@@ -141,6 +141,8 @@ function TreeNodeImpl({
   const dragGhostRef = useRef<HTMLDivElement | null>(null);
   const loadPage = useEditorStore((s) => s.loadPage);
   const setSection = useAppStore((s) => s.setSection);
+  const appMode = useAppStore((s) => s.appMode);
+  const setAppMode = useAppStore((s) => s.setAppMode);
   const [subPageOpen, setSubPageOpen] = useState(false);
   const [subPageTitle, setSubPageTitle] = useState("");
   const [creating, setCreating] = useState(false);
@@ -336,6 +338,25 @@ function TreeNodeImpl({
     // is the explicit affordance for switching into the cabinet view.
     if (node.type === "file" || node.type === "directory" || node.type === "cabinet") {
       loadPage(node.path);
+    }
+
+    // While browsing, clicking a tree row keeps you in browse mode and loads
+    // that file's in-app browser URL rather than dropping back to the editor.
+    const assetUrl = `/api/assets/${node.path.split("/").map(encodeURIComponent).join("/")}`;
+    const browseFileUrl =
+      node.type === "website" || node.type === "app"
+        ? `${assetUrl}/index.html`
+        : // Sibling Pattern: a `<name>.md` page can carry sub-pages and so be
+          // typed "directory", but its content still lives at `<name>.md`, not
+          // an `index.md` inside the folder — match the markdown name first.
+          node.name.toLowerCase().endsWith(".md")
+          ? `${assetUrl}.md`
+          : node.type === "directory" || node.type === "cabinet"
+            ? `${assetUrl}/index.md`
+            : assetUrl;
+
+    if (appMode === "browse") {
+      setAppMode("browse", browseFileUrl);
     }
 
     setSection(

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1071,7 +1071,16 @@
       "copyAsHtml": "Copy as HTML",
       "downloadMarkdown": "Download .md",
       "downloadPdf": "Download PDF",
-      "copiedForLlmToast": "Copied {{size}} of Markdown for LLM"
+      "copiedForLlmToast": "Copied {{size}} of Markdown for LLM",
+      "browseMode": "Open in browser",
+      "editMode": "Back to editor"
+    },
+    "browser": {
+      "noUrl": "Built-in browser ready. Click a link in a page to open it here.",
+      "openExternally": "Open externally",
+      "back": "Back",
+      "forward": "Forward",
+      "reload": "Reload"
     },
     "toolbar": {
       "heading1": "Heading 1",

--- a/src/lib/net/ssrf-guard.ts
+++ b/src/lib/net/ssrf-guard.ts
@@ -1,4 +1,6 @@
-import dns from "node:dns/promises";
+import http from "node:http";
+import https from "node:https";
+import dns from "node:dns";
 import net from "node:net";
 
 /**
@@ -7,9 +9,16 @@ import net from "node:net";
  * Without this, a user could point the in-app browser's bookmark-title fetch or
  * the frame-check probe at `http://169.254.169.254/…` (cloud metadata),
  * `http://127.0.0.1:…` (local services) or other internal hosts and have the
- * server make the request on their behalf. We reject any URL whose hostname
- * resolves to a loopback/private/link-local address, follow redirects manually
- * so each hop is re-validated, and bound every request with a timeout.
+ * server make the request on their behalf.
+ *
+ * Defenses:
+ *  - reject non-http(s) URLs and literal private/reserved IPs up front;
+ *  - resolve + re-validate the host *inside the socket lookup* so a hostname
+ *    that passed an earlier check can't rebind to a private IP at connect time
+ *    (DNS-rebinding);
+ *  - follow redirects manually, re-validating each hop and draining the
+ *    intermediate response so sockets aren't leaked;
+ *  - bound every request with a timeout and cap how much body we read.
  */
 
 export class SsrfError extends Error {
@@ -19,26 +28,37 @@ export class SsrfError extends Error {
   }
 }
 
-/** True for loopback, private, link-local, CGNAT, multicast and reserved IPs. */
+/**
+ * True for loopback, private, link-local, CGNAT, benchmarking, documentation,
+ * multicast and other reserved/non-public addresses (IPv4 and IPv6).
+ */
 export function isPrivateAddress(ip: string): boolean {
   const kind = net.isIP(ip);
   if (kind === 4) {
-    const [a, b] = ip.split(".").map(Number);
-    if (a === 0 || a === 10 || a === 127) return true;
+    const [a, b, c] = ip.split(".").map(Number);
+    if (a === 0 || a === 10 || a === 127) return true; // this-host / private / loopback
     if (a === 169 && b === 254) return true; // link-local
     if (a === 172 && b >= 16 && b <= 31) return true; // private
     if (a === 192 && b === 168) return true; // private
-    if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT
-    if (a >= 224) return true; // multicast / reserved
+    if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT (100.64.0.0/10)
+    if (a === 198 && (b === 18 || b === 19)) return true; // benchmarking (198.18.0.0/15)
+    if (a === 192 && b === 0 && c === 0) return true; // IETF protocol assignments
+    if (a === 192 && b === 0 && c === 2) return true; // TEST-NET-1
+    if (a === 198 && b === 51 && c === 100) return true; // TEST-NET-2
+    if (a === 203 && b === 0 && c === 113) return true; // TEST-NET-3
+    if (a === 192 && b === 88 && c === 99) return true; // 6to4 relay anycast
+    if (a >= 224) return true; // multicast (224/4) + reserved (240/4) + broadcast
     return false;
   }
   if (kind === 6) {
     const lower = ip.toLowerCase();
-    if (lower === "::1" || lower === "::") return true;
+    if (lower === "::1" || lower === "::") return true; // loopback / unspecified
     if (lower.startsWith("fe80")) return true; // link-local
     if (lower.startsWith("fc") || lower.startsWith("fd")) return true; // unique local
+    if (lower.startsWith("ff")) return true; // multicast (ff00::/8)
+    if (lower.startsWith("2001:db8")) return true; // documentation
     const mapped = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/.exec(lower);
-    if (mapped) return isPrivateAddress(mapped[1]);
+    if (mapped) return isPrivateAddress(mapped[1]); // IPv4-mapped
     return false;
   }
   // Not a recognizable IP literal — treat as unsafe.
@@ -46,10 +66,11 @@ export function isPrivateAddress(ip: string): boolean {
 }
 
 /**
- * Validate that `rawUrl` is an http(s) URL whose host does not resolve to a
- * non-public address. Returns the parsed URL or throws an {@link SsrfError}.
+ * Validate the static parts of a URL (protocol + any literal IP host). Hostname
+ * DNS resolution is deferred to {@link guardedLookup} so the address that is
+ * actually connected to is the one we validate. Throws an {@link SsrfError}.
  */
-export async function assertPublicHttpUrl(rawUrl: string): Promise<URL> {
+export function assertPublicHttpUrl(rawUrl: string): URL {
   let url: URL;
   try {
     url = new URL(rawUrl);
@@ -63,22 +84,37 @@ export async function assertPublicHttpUrl(rawUrl: string): Promise<URL> {
   if (!hostname || hostname.toLowerCase() === "localhost") {
     throw new SsrfError("private-address");
   }
-  if (net.isIP(hostname)) {
-    if (isPrivateAddress(hostname)) throw new SsrfError("private-address");
-    return url;
-  }
-  let records: { address: string }[];
-  try {
-    records = await dns.lookup(hostname, { all: true });
-  } catch {
-    throw new SsrfError("dns-failed");
-  }
-  if (records.length === 0) throw new SsrfError("dns-failed");
-  for (const record of records) {
-    if (isPrivateAddress(record.address)) throw new SsrfError("private-address");
+  if (net.isIP(hostname) && isPrivateAddress(hostname)) {
+    throw new SsrfError("private-address");
   }
   return url;
 }
+
+// Socket-level lookup that resolves the host and rejects the connection if ANY
+// resolved address is non-public. Used for every request so a hostname can't
+// rebind to a private IP between validation and connect (DNS-rebinding).
+const guardedLookup: net.LookupFunction = (hostname, options, callback) => {
+  const wantsAll = typeof options === "object" && options?.all === true;
+  dns.lookup(hostname, { all: true }, (err, addresses) => {
+    if (err) {
+      (callback as (e: Error | null) => void)(err);
+      return;
+    }
+    const list = addresses as dns.LookupAddress[];
+    for (const entry of list) {
+      if (isPrivateAddress(entry.address)) {
+        (callback as (e: Error | null) => void)(new SsrfError("private-address"));
+        return;
+      }
+    }
+    if (wantsAll) {
+      (callback as unknown as (e: Error | null, a: dns.LookupAddress[]) => void)(null, list);
+    } else {
+      const first = list[0];
+      callback(null, first.address, first.family);
+    }
+  });
+};
 
 export interface SafeFetchOptions {
   method?: string;
@@ -90,75 +126,95 @@ export interface SafeFetchOptions {
 }
 
 export interface SafeFetchResult {
-  response: Response;
+  status: number;
+  headers: http.IncomingHttpHeaders;
   /** The final URL after any (validated) redirects. */
   finalUrl: string;
+  /** Read the body as text, capped at `maxBytes`, then release the socket. */
+  readText: (maxBytes: number) => Promise<string>;
+  /** Release the socket without reading the body (e.g. for HEAD probes). */
+  dispose: () => void;
+}
+
+function requestOnce(
+  url: URL,
+  opts: { method: string; headers?: Record<string, string>; timeoutMs: number }
+): Promise<http.IncomingMessage> {
+  return new Promise((resolve, reject) => {
+    const mod = url.protocol === "https:" ? https : http;
+    const req = mod.request(
+      url,
+      { method: opts.method, headers: opts.headers, lookup: guardedLookup },
+      (res) => resolve(res)
+    );
+    req.on("error", reject);
+    req.setTimeout(opts.timeoutMs, () => {
+      req.destroy(new SsrfError("timeout"));
+    });
+    req.end();
+  });
+}
+
+function readStreamCapped(stream: http.IncomingMessage, maxBytes: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      stream.destroy();
+      resolve(Buffer.concat(chunks).subarray(0, maxBytes).toString("utf-8"));
+    };
+    stream.on("data", (chunk: Buffer) => {
+      if (settled) return;
+      chunks.push(chunk);
+      total += chunk.length;
+      if (total >= maxBytes) finish();
+    });
+    stream.on("end", finish);
+    stream.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      reject(err);
+    });
+  });
 }
 
 /**
- * Fetch a user-supplied URL with SSRF validation, manual + re-validated
- * redirects, and a hard timeout. Throws {@link SsrfError} when the target (or
- * any redirect hop) is not a public http(s) address.
+ * Fetch a user-supplied URL with SSRF validation (including at the socket
+ * lookup), manual + re-validated redirects, and a hard timeout. Throws
+ * {@link SsrfError} when the target — or any redirect hop — isn't a public
+ * http(s) address.
  */
 export async function safeFetch(rawUrl: string, options: SafeFetchOptions = {}): Promise<SafeFetchResult> {
   const { method = "GET", headers, timeoutMs = 8000, maxRedirects = 5 } = options;
-  let current = await assertPublicHttpUrl(rawUrl);
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    for (let hop = 0; hop <= maxRedirects; hop++) {
-      const response = await fetch(current.toString(), {
-        method,
-        headers,
-        redirect: "manual",
-        cache: "no-store",
-        signal: controller.signal,
-      });
-      const location = response.headers.get("location");
-      if (response.status >= 300 && response.status < 400 && location) {
-        const next = new URL(location, current);
-        current = await assertPublicHttpUrl(next.toString());
-        continue;
-      }
-      return { response, finalUrl: current.toString() };
-    }
-    throw new SsrfError("too-many-redirects");
-  } finally {
-    clearTimeout(timer);
-  }
-}
+  let current = assertPublicHttpUrl(rawUrl);
 
-/** Read a response body as text, capped at `maxBytes` to avoid memory blowups. */
-export async function readTextCapped(response: Response, maxBytes: number): Promise<string> {
-  const body = response.body;
-  if (!body) return "";
-  const reader = body.getReader();
-  const chunks: Uint8Array[] = [];
-  let total = 0;
-  try {
-    for (;;) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      if (value) {
-        chunks.push(value);
-        total += value.length;
-        if (total >= maxBytes) break;
-      }
-    }
-  } finally {
-    await reader.cancel().catch(() => {});
-  }
-  return new TextDecoder("utf-8").decode(concatChunks(chunks, Math.min(total, maxBytes)));
-}
+  for (let hop = 0; hop <= maxRedirects; hop++) {
+    const res = await requestOnce(current, { method, headers, timeoutMs });
+    const status = res.statusCode ?? 0;
+    const location = res.headers.location;
 
-function concatChunks(chunks: Uint8Array[], limit: number): Uint8Array {
-  const out = new Uint8Array(limit);
-  let offset = 0;
-  for (const chunk of chunks) {
-    if (offset >= limit) break;
-    const slice = chunk.subarray(0, Math.min(chunk.length, limit - offset));
-    out.set(slice, offset);
-    offset += slice.length;
+    if (status >= 300 && status < 400 && location) {
+      // Drain + close the intermediate response so the socket isn't leaked.
+      res.resume();
+      res.destroy();
+      current = assertPublicHttpUrl(new URL(location, current).toString());
+      continue;
+    }
+
+    return {
+      status,
+      headers: res.headers,
+      finalUrl: current.toString(),
+      readText: (maxBytes: number) => readStreamCapped(res, maxBytes),
+      dispose: () => {
+        res.resume();
+        res.destroy();
+      },
+    };
   }
-  return out;
+
+  throw new SsrfError("too-many-redirects");
 }

--- a/src/lib/net/ssrf-guard.ts
+++ b/src/lib/net/ssrf-guard.ts
@@ -1,0 +1,164 @@
+import dns from "node:dns/promises";
+import net from "node:net";
+
+/**
+ * Server-side SSRF protection for fetches that target user-supplied URLs.
+ *
+ * Without this, a user could point the in-app browser's bookmark-title fetch or
+ * the frame-check probe at `http://169.254.169.254/…` (cloud metadata),
+ * `http://127.0.0.1:…` (local services) or other internal hosts and have the
+ * server make the request on their behalf. We reject any URL whose hostname
+ * resolves to a loopback/private/link-local address, follow redirects manually
+ * so each hop is re-validated, and bound every request with a timeout.
+ */
+
+export class SsrfError extends Error {
+  constructor(public readonly code: string) {
+    super(code);
+    this.name = "SsrfError";
+  }
+}
+
+/** True for loopback, private, link-local, CGNAT, multicast and reserved IPs. */
+export function isPrivateAddress(ip: string): boolean {
+  const kind = net.isIP(ip);
+  if (kind === 4) {
+    const [a, b] = ip.split(".").map(Number);
+    if (a === 0 || a === 10 || a === 127) return true;
+    if (a === 169 && b === 254) return true; // link-local
+    if (a === 172 && b >= 16 && b <= 31) return true; // private
+    if (a === 192 && b === 168) return true; // private
+    if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT
+    if (a >= 224) return true; // multicast / reserved
+    return false;
+  }
+  if (kind === 6) {
+    const lower = ip.toLowerCase();
+    if (lower === "::1" || lower === "::") return true;
+    if (lower.startsWith("fe80")) return true; // link-local
+    if (lower.startsWith("fc") || lower.startsWith("fd")) return true; // unique local
+    const mapped = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/.exec(lower);
+    if (mapped) return isPrivateAddress(mapped[1]);
+    return false;
+  }
+  // Not a recognizable IP literal — treat as unsafe.
+  return true;
+}
+
+/**
+ * Validate that `rawUrl` is an http(s) URL whose host does not resolve to a
+ * non-public address. Returns the parsed URL or throws an {@link SsrfError}.
+ */
+export async function assertPublicHttpUrl(rawUrl: string): Promise<URL> {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new SsrfError("invalid-url");
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new SsrfError("invalid-protocol");
+  }
+  const hostname = url.hostname.replace(/^\[/, "").replace(/\]$/, "");
+  if (!hostname || hostname.toLowerCase() === "localhost") {
+    throw new SsrfError("private-address");
+  }
+  if (net.isIP(hostname)) {
+    if (isPrivateAddress(hostname)) throw new SsrfError("private-address");
+    return url;
+  }
+  let records: { address: string }[];
+  try {
+    records = await dns.lookup(hostname, { all: true });
+  } catch {
+    throw new SsrfError("dns-failed");
+  }
+  if (records.length === 0) throw new SsrfError("dns-failed");
+  for (const record of records) {
+    if (isPrivateAddress(record.address)) throw new SsrfError("private-address");
+  }
+  return url;
+}
+
+export interface SafeFetchOptions {
+  method?: string;
+  headers?: Record<string, string>;
+  /** Abort after this many ms (default 8000). */
+  timeoutMs?: number;
+  /** Max redirect hops to follow, each re-validated (default 5). */
+  maxRedirects?: number;
+}
+
+export interface SafeFetchResult {
+  response: Response;
+  /** The final URL after any (validated) redirects. */
+  finalUrl: string;
+}
+
+/**
+ * Fetch a user-supplied URL with SSRF validation, manual + re-validated
+ * redirects, and a hard timeout. Throws {@link SsrfError} when the target (or
+ * any redirect hop) is not a public http(s) address.
+ */
+export async function safeFetch(rawUrl: string, options: SafeFetchOptions = {}): Promise<SafeFetchResult> {
+  const { method = "GET", headers, timeoutMs = 8000, maxRedirects = 5 } = options;
+  let current = await assertPublicHttpUrl(rawUrl);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    for (let hop = 0; hop <= maxRedirects; hop++) {
+      const response = await fetch(current.toString(), {
+        method,
+        headers,
+        redirect: "manual",
+        cache: "no-store",
+        signal: controller.signal,
+      });
+      const location = response.headers.get("location");
+      if (response.status >= 300 && response.status < 400 && location) {
+        const next = new URL(location, current);
+        current = await assertPublicHttpUrl(next.toString());
+        continue;
+      }
+      return { response, finalUrl: current.toString() };
+    }
+    throw new SsrfError("too-many-redirects");
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Read a response body as text, capped at `maxBytes` to avoid memory blowups. */
+export async function readTextCapped(response: Response, maxBytes: number): Promise<string> {
+  const body = response.body;
+  if (!body) return "";
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) {
+        chunks.push(value);
+        total += value.length;
+        if (total >= maxBytes) break;
+      }
+    }
+  } finally {
+    await reader.cancel().catch(() => {});
+  }
+  return new TextDecoder("utf-8").decode(concatChunks(chunks, Math.min(total, maxBytes)));
+}
+
+function concatChunks(chunks: Uint8Array[], limit: number): Uint8Array {
+  const out = new Uint8Array(limit);
+  let offset = 0;
+  for (const chunk of chunks) {
+    if (offset >= limit) break;
+    const slice = chunk.subarray(0, Math.min(chunk.length, limit - offset));
+    out.set(slice, offset);
+    offset += slice.length;
+  }
+  return out;
+}

--- a/src/lib/runtime/open-url.ts
+++ b/src/lib/runtime/open-url.ts
@@ -20,7 +20,15 @@ export function openUrlInAppropriateContext(
   // file:// URLs can't be loaded in a browser view or window.open —
   // Electron blocks them. Use shell.openPath to open with the OS default app.
   if (url.startsWith("file://")) {
-    const filePath = decodeURIComponent(url.slice("file://".length));
+    const rawPath = url.slice("file://".length);
+    // decodeURIComponent throws on malformed percent-encoding — fall back to the
+    // raw path instead of crashing the click handler.
+    let filePath: string;
+    try {
+      filePath = decodeURIComponent(rawPath);
+    } catch {
+      filePath = rawPath;
+    }
     if (isElectron && bridge.openLocalFile) {
       void bridge.openLocalFile(filePath);
       return;
@@ -48,6 +56,8 @@ export function openUrlInAppropriateContext(
   if (isElectron) {
     openInBrowseMode(url);
   } else {
-    window.open(url, "_blank");
+    // noopener,noreferrer prevents the opened page from reaching back via
+    // window.opener and navigating/altering this app.
+    window.open(url, "_blank", "noopener,noreferrer");
   }
 }

--- a/src/lib/runtime/open-url.ts
+++ b/src/lib/runtime/open-url.ts
@@ -1,0 +1,53 @@
+"use client";
+
+interface CabinetDesktopBridge {
+  runtime?: "electron";
+  openLocalFile?: (path: string) => Promise<{ ok: boolean; error?: string }>;
+}
+
+function getBridge(): CabinetDesktopBridge {
+  return (window as unknown as { CabinetDesktop?: CabinetDesktopBridge })
+    .CabinetDesktop ?? {};
+}
+
+export function openUrlInAppropriateContext(
+  url: string,
+  openInBrowseMode: (url: string) => void
+): void {
+  const bridge = getBridge();
+  const isElectron = bridge.runtime === "electron";
+
+  // file:// URLs can't be loaded in a browser view or window.open —
+  // Electron blocks them. Use shell.openPath to open with the OS default app.
+  if (url.startsWith("file://")) {
+    const filePath = decodeURIComponent(url.slice("file://".length));
+    if (isElectron && bridge.openLocalFile) {
+      void bridge.openLocalFile(filePath);
+      return;
+    }
+    // In browser mode, there's no way to open local files — show a toast
+    // with the file path and a "Copy path" action so the user can open it
+    // manually in Finder/File Explorer.
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(
+        new CustomEvent("cabinet:toast", {
+          detail: {
+            kind: "info",
+            message: `Local file: ${filePath}`,
+            actionLabel: "Copy path",
+            onAction: () => {
+              navigator.clipboard?.writeText(filePath).catch(() => {});
+            },
+          },
+        })
+      );
+    }
+    return;
+  }
+
+  if (isElectron) {
+    openInBrowseMode(url);
+  } else {
+    window.open(url, "_blank");
+  }
+}

--- a/src/stores/app-store.ts
+++ b/src/stores/app-store.ts
@@ -146,6 +146,11 @@ interface AppState {
   defaultEffort: string | null;
   providersLoading: boolean;
   providersLoaded: boolean;
+  /** Top-level app surface: the page editor, or the in-app browser. */
+  appMode: "edit" | "browse";
+  /** URL shown in browse mode; null until a link/bookmark sets it. */
+  browseUrl: string | null;
+  setAppMode: (mode: "edit" | "browse", url?: string | null) => void;
   loadProviders: () => Promise<void>;
   /**
    * Hydrate one provider's real, entitlement-gated model list from
@@ -258,6 +263,13 @@ export const useAppStore = create<AppState>((set, get) => ({
   defaultEffort: null,
   providersLoading: false,
   providersLoaded: false,
+  appMode: "edit",
+  browseUrl: null,
+  setAppMode: (mode, url) =>
+    set((state) => ({
+      appMode: mode,
+      browseUrl: url !== undefined ? url : state.browseUrl,
+    })),
 
   loadProviders: async () => {
     const { providersLoading, providersLoaded } = get();


### PR DESCRIPTION
Native WebContentsView-backed in-app browser (with iframe fallback on the web build). External links in KB articles, the viewer-toolbar Globe button (websites/apps only), and tree-node clicks while browsing all open here; X-Frame-Options sites load in the desktop app.

- Verbatim from PR #96: browser-view.tsx, open-url.ts, api/browser/{bookmarks, frame-check} (bookmarks path adapted DATA_PARENT_DIR -> CABINET_INTERNAL_DIR).
- Electron: new browser-views.cjs module (WebContentsView IPC handlers, kb-auth cookie sync for /api/assets, native bookmarks menu) wired into main.cjs/preload.cjs; forge.config.cjs ships the new .cjs files.
- Store/app-shell/editor/viewer-toolbar/tree-node: browse-mode entry points (canvas/latex/extensions parts of PR #96 deliberately excluded).

Fixes found during testing:
- editor: guard against a freshly-remounted (content:"") editor autosaving empty content over a real page when returning from browse mode (data loss).
- browser-view: back button returns to the KB article instead of about:blank.
- browser-view: destroy WebContentsView orphaned by a create/unmount race (memory leak, esp. dev StrictMode).
- viewer-toolbar: Globe button only on website/app nodes (raw .md isn't browsable); exit button stays unconditional in browse mode.
- browser-preload: drop dead chromewebstore install hook (no IPC exposed to web pages); UA spoof only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added “browse mode” for viewing websites and in-app pages, with local file opening and back/forward/reload controls (native embedded view with a safe iframe fallback).
  * Introduced persistent, folder-based bookmarks with a native bookmarks menu and tag-cloud browsing.
  * Added URL embedding safety checks before showing external content.
  * Improved external link handling and quick switching between edit and browse modes from the viewer toolbar and sidebar.
* **Bug Fixes**
  * Prevented the editor’s initial render from overwriting saved page content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->