### PR TITLE
Fix/small fixes

### DIFF
--- a/src/app/api/system/open-data-dir/route.ts
+++ b/src/app/api/system/open-data-dir/route.ts
@@ -1,9 +1,27 @@
 import { spawn } from "child_process";
+import { existsSync } from "fs";
 import path from "path";
 import { NextResponse } from "next/server";
 import { DATA_DIR } from "@/lib/storage/path-utils";
 
 export const dynamic = "force-dynamic";
+
+// Tree node paths for Markdown pages drop the `.md` extension (see
+// tree-builder: `path: vPath.replace(/\.md$/, "")`), so the virtual path
+// often has no matching file on disk. Map it back to the real entry —
+// `<page>.md`, or `<page>/index.md` for container pages — so `open -R`
+// has something to reveal. Falls back to the original path (and finally
+// its parent) so directories and real-extension files keep working.
+function resolveOnDisk(resolved: string): string {
+  if (existsSync(resolved)) return resolved;
+  const withMd = `${resolved}.md`;
+  if (existsSync(withMd)) return withMd;
+  const indexMd = path.join(resolved, "index.md");
+  if (existsSync(indexMd)) return indexMd;
+  const parent = path.dirname(resolved);
+  if (existsSync(parent)) return parent;
+  return resolved;
+}
 
 function getOpenCommand(targetPath: string, reveal?: boolean): { command: string; args: string[] } {
   switch (process.platform) {
@@ -28,10 +46,10 @@ export async function POST(request: Request) {
     const body = await request.json().catch(() => null);
     if (body?.subpath) {
       const resolved = path.resolve(DATA_DIR, body.subpath);
-      if (!resolved.startsWith(DATA_DIR)) {
+      if (resolved !== DATA_DIR && !resolved.startsWith(DATA_DIR + path.sep)) {
         return NextResponse.json({ error: "Invalid path" }, { status: 400 });
       }
-      targetPath = resolved;
+      targetPath = resolveOnDisk(resolved);
     }
 
     // Reveal in Finder when opening a specific subpath

--- a/src/app/api/system/open-data-dir/route.ts
+++ b/src/app/api/system/open-data-dir/route.ts
@@ -49,7 +49,13 @@ export async function POST(request: Request) {
       if (resolved !== DATA_DIR && !resolved.startsWith(DATA_DIR + path.sep)) {
         return NextResponse.json({ error: "Invalid path" }, { status: 400 });
       }
-      targetPath = resolveOnDisk(resolved);
+      // resolveOnDisk can fall back to a parent directory, so re-check that the
+      // final on-disk target is still inside DATA_DIR before opening it.
+      const onDisk = resolveOnDisk(resolved);
+      if (onDisk !== DATA_DIR && !onDisk.startsWith(DATA_DIR + path.sep)) {
+        return NextResponse.json({ error: "Invalid path" }, { status: 400 });
+      }
+      targetPath = onDisk;
     }
 
     // Reveal in Finder when opening a specific subpath

--- a/src/app/api/system/open-data-dir/route.ts
+++ b/src/app/api/system/open-data-dir/route.ts
@@ -13,11 +13,16 @@ export const dynamic = "force-dynamic";
 // has something to reveal. Falls back to the original path (and finally
 // its parent) so directories and real-extension files keep working.
 function resolveOnDisk(resolved: string): string {
-  if (existsSync(resolved)) return resolved;
+  // Prefer the virtual Markdown targets first: a page can have a same-named
+  // sibling directory (sub-pages), so checking `existsSync(resolved)` up front
+  // would reveal that folder instead of the page's own `<page>.md`. `.md` and
+  // `<page>/index.md` (container pages) take priority; only then fall back to
+  // the bare path (real directories / real-extension files) and its parent.
   const withMd = `${resolved}.md`;
   if (existsSync(withMd)) return withMd;
   const indexMd = path.join(resolved, "index.md");
   if (existsSync(indexMd)) return indexMd;
+  if (existsSync(resolved)) return resolved;
   const parent = path.dirname(resolved);
   if (existsSync(parent)) return parent;
   return resolved;

--- a/src/components/sidebar/tree-view.tsx
+++ b/src/components/sidebar/tree-view.tsx
@@ -832,17 +832,24 @@ export function TreeView() {
                     {activeCabinet ? "Add cabinet data" : "Add your first page"}
                   </button>
                 ) : (
-                  visibleTreeNodes.map((node, index) => (
-                    <TreeNode
-                      key={node.path}
-                      node={node}
-                      depth={1}
-                      contextCabinetPath={activeCabinet?.path || null}
-                      siblings={visibleTreeNodes}
-                      onMoveToRequest={requestMoveTo}
-                      animationDelayMs={index * 22}
-                    />
-                  ))
+                  // Each row carries its own context menu (rename, copy path,
+                  // Open in Finder, delete). Without this stopPropagation a
+                  // right-click on a row bubbles to the data-drawer trigger
+                  // above and opens *that* menu instead — same fix the Drive
+                  // section uses below.
+                  <div onContextMenu={(e) => e.stopPropagation()}>
+                    {visibleTreeNodes.map((node, index) => (
+                      <TreeNode
+                        key={node.path}
+                        node={node}
+                        depth={1}
+                        contextCabinetPath={activeCabinet?.path || null}
+                        siblings={visibleTreeNodes}
+                        onMoveToRequest={requestMoveTo}
+                        animationDelayMs={index * 22}
+                      />
+                    ))}
+                  </div>
                 )}
                 {/* Mounted Drive folders flow inline right after the cabinet
                     files. Rendered inside SidebarSearch so they sit with the

--- a/src/hooks/use-task-file-sync.ts
+++ b/src/hooks/use-task-file-sync.ts
@@ -38,8 +38,14 @@ export function useTaskFileSync(): void {
       const editor = useEditorStore.getState();
       const openPath = editor.currentPath;
 
-      // Highlight everything except the page the user is already looking at.
-      useTreeStore.getState().markChanged(treePaths.filter((p) => p !== openPath));
+      // Mark every file the task touched with the "new content" dot —
+      // including the page currently open in the editor. The editor agent's
+      // whole job is editing the open page, so excluding it (the previous
+      // behavior) meant the most common task never surfaced any change
+      // indicator. The dot is the persistent signal; opening/refocusing the
+      // file clears it (selectPage → clearChanged). We still reload the open
+      // page in place below so its content stays fresh.
+      useTreeStore.getState().markChanged(treePaths);
       // `fresh` busts the server tree cache: agents write straight to disk, so
       // a plain reload could serve the pre-write snapshot and the new files
       // wouldn't show until the user hit refresh.

--- a/src/lib/agents/conversation-store.ts
+++ b/src/lib/agents/conversation-store.ts
@@ -278,14 +278,17 @@ function makeSummaryFromOutput(output: string): string | undefined {
 }
 
 /**
- * Strip the trailing "Attached files (read with the Read tool...)" section
- * appended to adapter prompts by `buildAttachmentContext`. Defensive: even
- * once attachmentPaths are stored on meta/turns, old conversations may
- * still have the block baked into the extracted user request.
+ * Strip the context blocks the prompt builder appends after the user's
+ * message — the inlined mention content ("Referenced pages:\n…", from
+ * `buildMentionContext`) and the attachment hints ("Attached files (read
+ * with the Read tool…)", from `buildAttachmentContext`). Both are surfaced
+ * separately in the task UI (mention chips / attachment list), so without
+ * this the whole file contents leak into the displayed user message.
+ * Cuts at whichever marker appears first.
  */
-function stripAttachmentTrailer(text: string): string {
+function stripContextTrailers(text: string): string {
   const idx = text.search(
-    /\n*\s*Attached files \(read with the Read tool/i
+    /\n*\s*(?:Referenced pages:|Attached files \(read with the Read tool)/i
   );
   if (idx === -1) return text;
   return text.slice(0, idx).trimEnd();
@@ -298,13 +301,13 @@ export function extractConversationRequest(prompt: string): string {
   for (const marker of markers) {
     const index = normalized.lastIndexOf(marker);
     if (index !== -1) {
-      return stripAttachmentTrailer(
+      return stripContextTrailers(
         normalized.slice(index + marker.length).trim()
       );
     }
   }
 
-  return stripAttachmentTrailer(normalized.trim());
+  return stripContextTrailers(normalized.trim());
 }
 
 // Agents sometimes cram multiple files onto one ARTIFACT: line (e.g.

--- a/src/lib/agents/conversation-store.ts
+++ b/src/lib/agents/conversation-store.ts
@@ -287,8 +287,11 @@ function makeSummaryFromOutput(output: string): string | undefined {
  * Cuts at whichever marker appears first.
  */
 function stripContextTrailers(text: string): string {
+  // Anchor to the start of a line (multiline `^`) so we only strip a real
+  // appended trailer block and never truncate at a "Referenced pages:" that
+  // happens to appear mid-sentence in the user's own text.
   const idx = text.search(
-    /\n*\s*(?:Referenced pages:|Attached files \(read with the Read tool)/i
+    /^[ \t]*(?:Referenced pages:|Attached files \(read with the Read tool)/im
   );
   if (idx === -1) return text;
   return text.slice(0, idx).trimEnd();


### PR DESCRIPTION
few small fixes 
 
- [ ] When using a file as input for the task - do not copy all of it into the task window. 
- [ ] Right click on a link in the file tree + open in finder do not work
- [ ] green dot on updated KB file in a task

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved opening of virtual/markdown-derived locations by resolving them to the correct on-disk target more reliably.
  * Hardened open-request path validation to prevent invalid or out-of-scope targets.
  * Prevented right-clicks on individual data tree items from triggering the parent drawer context menu.
  * Updated task sync to mark all touched artifacts as changed, including the currently open page.
  * Improved copied conversation context parsing by trimming referenced-page and attachment trailers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->