### PR TITLE
Feat/slack integration

### DIFF
--- a/electron/browser-views.cjs
+++ b/electron/browser-views.cjs
@@ -332,6 +332,22 @@ function registerHandlers() {
     }
   });
 
+  // Open a URL in the user's SYSTEM default browser (not the in-app browse
+  // view). Used for OAuth sign-in, where the embedded browser lacks the user's
+  // provider session and some providers reject webviews. Restricted to http(s)
+  // so a hostile link can't trigger file:/// or custom-scheme handlers.
+  ipcMain.handle("cabinet:open-external", async (event, payload) => {
+    if (!isMainRendererSender(event)) return { ok: false, error: "unauthorized" };
+    const url = typeof payload?.url === "string" ? payload.url : "";
+    if (!/^https?:\/\//i.test(url)) return { ok: false, error: "blocked" };
+    try {
+      await shell.openExternal(url);
+      return { ok: true };
+    } catch (error) {
+      return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  });
+
   ipcMain.handle("cabinet:create-browser-view", async (event, payload) => {
     if (!isMainRendererSender(event)) return { ok: false, error: "unauthorized" };
     const win = liveMainWindow();

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -91,6 +91,12 @@ contextBridge.exposeInMainWorld("CabinetDesktop", {
    */
   openLocalFile: (filePath) => ipcRenderer.invoke("cabinet:open-local-file", { path: filePath }),
   /**
+   * Open an http(s) URL in the user's SYSTEM default browser (never the in-app
+   * browse view). Used for OAuth sign-in, where the embedded browser lacks the
+   * user's provider session and some providers block webviews.
+   */
+  openExternal: (url) => ipcRenderer.invoke("cabinet:open-external", { url }),
+  /**
    * The OS keyboard / input languages, most-preferred first, plus the
    * Electron app + system locale. Used on the first onboarding screen to
    * localize Cabinet out of the box. Renderer maps these BCP-47 tags onto a

--- a/src/app/api/agents/config/mcp-catalog/connect/route.ts
+++ b/src/app/api/agents/config/mcp-catalog/connect/route.ts
@@ -8,7 +8,14 @@ import {
 } from "@/lib/agents/mcp-config-writer";
 import { resolveAuthBackend } from "@/lib/agents/deployment-mode";
 import { getSelectedEnvironments } from "@/lib/agents/integration-environments";
-import { isValidKey, upsertCabinetEnv, getCabinetEnvSnapshot } from "@/lib/runtime/cabinet-env";
+import {
+  isValidKey,
+  upsertCabinetEnv,
+  getCabinetEnvSnapshot,
+  readCabinetEnvFile,
+} from "@/lib/runtime/cabinet-env";
+import { registerConfidentialOAuthClient } from "@/lib/agents/claude-mcp-login";
+import type { CatalogEntry } from "@/lib/agents/mcp-catalog";
 
 /**
  * `/api/agents/config/mcp-catalog/connect`
@@ -31,6 +38,46 @@ async function resolveTargets(
     return requested as string[];
   }
   return await fallback();
+}
+
+/**
+ * Register one environment. For a confidential-OAuth entry (Slack) targeting
+ * Claude Code, drive `claude mcp add --client-id --client-secret` so the secret
+ * reaches the CLI keychain (a plain JSON write can't do that, and the bare entry
+ * dead-ends on "does not support dynamic client registration"). Every other
+ * case — and Claude Code before the user has saved both creds — falls back to
+ * the JSON writer.
+ */
+async function writeOrRegister(
+  pid: string,
+  entry: CatalogEntry,
+): Promise<ProviderWriteResult> {
+  if (pid === "claude-code" && entry.oauthClient && entry.url) {
+    const env = readCabinetEnvFile().values;
+    const clientId = env[entry.oauthClient.clientIdEnvKey];
+    const clientSecret = env[entry.oauthClient.clientSecretEnvKey];
+    if (clientId && clientSecret) {
+      const base = { providerId: pid, providerName: "Claude Code" };
+      try {
+        await registerConfidentialOAuthClient({
+          serverName: entry.mcpServerName,
+          url: entry.url,
+          clientId,
+          clientSecret,
+          callbackPort: entry.oauthClient.callbackPort,
+        });
+        return { ...base, ok: true, supported: true };
+      } catch (err) {
+        return {
+          ...base,
+          ok: false,
+          supported: true,
+          error: err instanceof Error ? err.message : "Registration failed",
+        };
+      }
+    }
+  }
+  return writeEntry(pid, entry);
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
@@ -109,7 +156,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const explicitSelection = Array.isArray(providers);
   const previouslyConnected = explicitSelection ? connectedProvidersForEntry(entry) : [];
 
-  const results: ProviderWriteResult[] = targets.map((pid) => writeEntry(pid, entry));
+  const results: ProviderWriteResult[] = await Promise.all(
+    targets.map((pid) => writeOrRegister(pid, entry)),
+  );
   const removedResults: ProviderWriteResult[] = previouslyConnected
     .filter((pid) => !targets.includes(pid))
     .map((pid) => removeEntry(pid, entry));

--- a/src/app/api/agents/config/mcp-catalog/connect/route.ts
+++ b/src/app/api/agents/config/mcp-catalog/connect/route.ts
@@ -65,6 +65,7 @@ async function writeOrRegister(
           clientId,
           clientSecret,
           callbackPort: entry.oauthClient.callbackPort,
+          scopes: entry.oauthClient.scopes,
         });
         return { ...base, ok: true, supported: true };
       } catch (err) {

--- a/src/components/integrations/hub/connect-panel.tsx
+++ b/src/components/integrations/hub/connect-panel.tsx
@@ -472,13 +472,23 @@ export function ConnectPanel({
       showError("Pick at least one environment.");
       return;
     }
+    if (missingRequired) {
+      showError("Enter the required credentials first.");
+      return;
+    }
     stopPolling();
     setOauthLogin({ state: "starting" });
     try {
       const reg = await fetch("/api/agents/config/mcp-catalog/connect", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id: entry.id, providers: [...targets] }),
+        body: JSON.stringify({
+          id: entry.id,
+          providers: [...targets],
+          // Confidential-client servers (Slack) need the pasted id/secret saved
+          // before sign-in so the CLI can register the OAuth client.
+          credentials: needsCreds ? creds : undefined,
+        }),
       });
       const regJson = await reg.json();
       if (!reg.ok || !regJson.ok)
@@ -803,7 +813,12 @@ export function ConnectPanel({
           ) : (
             <Button
               className="w-full"
-              disabled={targets.size === 0 || oauthLogin.state === "starting" || busy}
+              disabled={
+                targets.size === 0 ||
+                missingRequired ||
+                oauthLogin.state === "starting" ||
+                busy
+              }
               onClick={startOauthLogin}
             >
               {oauthLogin.state === "starting" || busy ? (

--- a/src/components/integrations/hub/connect-panel.tsx
+++ b/src/components/integrations/hub/connect-panel.tsx
@@ -5,6 +5,7 @@ import { Check, ChevronDown, Loader2, ExternalLink, ShieldCheck, X } from "lucid
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { showError, showSuccess } from "@/lib/ui/toast";
+import { openExternalUrl } from "@/lib/runtime/open-url";
 import type { IntegrationItem } from "@/lib/integrations/preview-catalog";
 
 /**
@@ -714,8 +715,12 @@ export function ConnectPanel({
               </p>
               <a
                 href={msLogin.url}
-                target="_blank"
-                rel="noreferrer"
+                onClick={(e) => {
+                  // OAuth must run in the system browser, not the in-app browse
+                  // view (which lacks the user's Microsoft session).
+                  e.preventDefault();
+                  if (msLogin.url) openExternalUrl(msLogin.url);
+                }}
                 className="mt-2 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-border bg-background px-3 py-2 text-[13px] font-medium text-foreground hover:bg-accent"
               >
                 Open Microsoft sign-in <ExternalLink className="h-3.5 w-3.5" />
@@ -767,8 +772,13 @@ export function ConnectPanel({
               </p>
               <a
                 href={oauthLogin.url}
-                target="_blank"
-                rel="noreferrer"
+                onClick={(e) => {
+                  // OAuth must run in the system browser, not the in-app browse
+                  // view (which lacks the user's provider session and may be
+                  // rejected as a webview).
+                  e.preventDefault();
+                  if (oauthLogin.url) openExternalUrl(oauthLogin.url);
+                }}
                 className="mt-2 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-border bg-background px-3 py-2 text-[13px] font-medium text-foreground hover:bg-accent"
               >
                 Open {item.name} sign-in <ExternalLink className="h-3.5 w-3.5" />

--- a/src/components/integrations/hub/generic-setup-art.tsx
+++ b/src/components/integrations/hub/generic-setup-art.tsx
@@ -42,8 +42,10 @@ export function stepArtFor(opts: {
   authBackend: string;
   transport: string;
   hasUrlCredential: boolean;
+  /** Space-separated OAuth scope pin, e.g. the catalog entry's `oauthClient.scopes`. */
+  scopes?: string;
 }): ((index: number) => ReactNode) | undefined {
-  const { id, label, brand, authBackend, transport, hasUrlCredential } = opts;
+  const { id, label, brand, authBackend, transport, hasUrlCredential, scopes } = opts;
 
   if (id === "discord") return (i) => <DiscordStepArt step={i} brand={brand} />;
   if (id === "telegram") return (i) => <TelegramStepArt step={i} brand={brand} />;
@@ -57,7 +59,7 @@ export function stepArtFor(opts: {
   // Multi-step official-OAuth connectors: step 0 is the generic consent screen,
   // but their later "register your own app / scopes / scope the access" steps
   // need their own tailored mocks (the steps users actually get stuck on).
-  if (id === "slack") return (i) => <SlackArt step={i} label={label} brand={brand} />;
+  if (id === "slack") return (i) => <SlackArt step={i} label={label} brand={brand} scopes={scopes} />;
   if (id === "google-workspace") return (i) => <GoogleArt step={i} label={label} brand={brand} />;
   if (id === "github") return (i) => <GithubArt step={i} label={label} brand={brand} />;
   if (id === "notion") return (i) => <NotionArt step={i} label={label} brand={brand} />;
@@ -269,8 +271,26 @@ function LinkedInArt({ step, brand }: { step: number; brand: string }) {
 
 /* ── multi-step official-OAuth connectors ───────────────────────────────── */
 
+/** Groups a space-separated scope string into rows of 2 for CheckRow display. */
+function scopeRows(scopes: string | undefined): string[] {
+  const list = (scopes ?? "").split(/\s+/).filter(Boolean);
+  const rows: string[] = [];
+  for (let i = 0; i < list.length; i += 2) rows.push(list.slice(i, i + 2).join(" · "));
+  return rows;
+}
+
 /** Slack: consent (0) → create your own app (1) → user-token scopes (2). */
-function SlackArt({ step, label, brand }: { step: number; label: string; brand: string }) {
+function SlackArt({
+  step,
+  label,
+  brand,
+  scopes,
+}: {
+  step: number;
+  label: string;
+  brand: string;
+  scopes?: string;
+}) {
   // Step 0 — create your own app (Slack has no one-click; you bring the app).
   if (step === 0) {
     return (
@@ -321,8 +341,9 @@ function SlackArt({ step, label, brand }: { step: number; label: string; brand: 
           <BtnMock brand={brand}>Add</BtnMock>
         </div>
         <div className="mt-2 space-y-1">
-          <CheckRow brand={brand}>search:read.public · chat:write</CheckRow>
-          <CheckRow brand={brand}>channels:history · users:read</CheckRow>
+          {scopeRows(scopes).map((row) => (
+            <CheckRow key={row} brand={brand}>{row}</CheckRow>
+          ))}
         </div>
         <Hint brand={brand}>
           Add the redirect URL, add the scopes (use <b>Copy</b> above), then <b>Install to Workspace</b>.

--- a/src/components/integrations/hub/generic-setup-art.tsx
+++ b/src/components/integrations/hub/generic-setup-art.tsx
@@ -271,8 +271,8 @@ function LinkedInArt({ step, brand }: { step: number; brand: string }) {
 
 /** Slack: consent (0) → create your own app (1) → user-token scopes (2). */
 function SlackArt({ step, label, brand }: { step: number; label: string; brand: string }) {
-  if (step === 0) return <OAuthConsentArt step={0} label={label} brand={brand} />;
-  if (step === 1) {
+  // Step 0 — create your own app (Slack has no one-click; you bring the app).
+  if (step === 0) {
     return (
       <MockWindow title="api.slack.com/apps" brand={brand}>
         <div className="flex items-center justify-between">
@@ -284,24 +284,71 @@ function SlackArt({ step, label, brand }: { step: number; label: string; brand: 
           <div className="h-5 w-2/3 rounded bg-muted" />
         </div>
         <Hint brand={brand}>
-          Create an app <b>From scratch</b>, pick your workspace, then open <b>OAuth &amp; Permissions</b>.
+          Create an app <b>From scratch</b> and pick your workspace.
         </Hint>
       </MockWindow>
     );
   }
+  // Step 1 — register the redirect URL and add the user-token scopes.
+  if (step === 1) {
+    return (
+      <MockWindow title="OAuth &amp; Permissions" brand={brand}>
+        <div className="text-[10px] text-muted-foreground">Redirect URLs</div>
+        <div className="mt-1 flex items-center gap-2">
+          <div className="flex-1 truncate rounded-md bg-foreground/[0.06] px-2 py-1.5 font-mono text-[10px] text-muted-foreground">
+            http://localhost:8765/callback
+          </div>
+          <BtnMock brand={brand}>Add</BtnMock>
+        </div>
+        <div className="mt-2 space-y-1">
+          <CheckRow brand={brand}>search:read.public · chat:write</CheckRow>
+          <CheckRow brand={brand}>channels:history · users:read</CheckRow>
+        </div>
+        <Hint brand={brand}>
+          Add the redirect URL, add the scopes (use <b>Copy</b> above), then <b>Install to Workspace</b>.
+        </Hint>
+      </MockWindow>
+    );
+  }
+  // Step 2 — copy the app's Client ID & Secret into the connect panel.
+  if (step === 2) {
+    return (
+      <MockWindow title="Basic Information · App Credentials" brand={brand}>
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between rounded-md bg-foreground/[0.06] px-2 py-1.5">
+            <span className="text-[10px] text-muted-foreground">Client ID</span>
+            <BtnMock brand={brand}>Copy</BtnMock>
+          </div>
+          <div className="flex items-center justify-between rounded-md bg-foreground/[0.06] px-2 py-1.5">
+            <span className="text-[10px] text-muted-foreground">Client Secret</span>
+            <BtnMock brand={brand}>Show · Copy</BtnMock>
+          </div>
+        </div>
+        <Hint brand={brand}>
+          Paste both into the <b>Connect</b> panel — kept in .cabinet.env, never in plain config.
+        </Hint>
+      </MockWindow>
+    );
+  }
+  // Step 3 — approve in the browser (only after the app credentials are saved).
   return (
-    <MockWindow title="OAuth &amp; Permissions · User Token Scopes" brand={brand}>
-      <div className="space-y-1">
-        <CheckRow brand={brand}>search:read.public</CheckRow>
-        <CheckRow brand={brand}>chat:write</CheckRow>
-        <CheckRow brand={brand}>channels:history · channels:read</CheckRow>
-        <CheckRow brand={brand}>files:read · users:read</CheckRow>
-      </div>
-      <div className="mt-2">
-        <BtnMock brand={brand}>+ Add an OAuth Scope</BtnMock>
+    <MockWindow title={`Authorize · ${label}`} brand={brand}>
+      <div className="flex flex-col items-center text-center">
+        <Avatar brand={brand}>{label.charAt(0)}</Avatar>
+        <div className="mt-2 text-[11px] text-foreground">
+          <b>Cabinet</b> wants to access your <b>{label}</b> account
+        </div>
+        <div className="mt-2 w-full space-y-1 text-left">
+          <CheckRow brand={brand}>Read your {label} data</CheckRow>
+          <CheckRow brand={brand}>Act on your behalf</CheckRow>
+        </div>
+        <div className="mt-3 flex w-full items-center justify-center gap-2">
+          <BtnMock brand={brand}>Authorize</BtnMock>
+          <BtnMock>Cancel</BtnMock>
+        </div>
       </div>
       <Hint brand={brand}>
-        Add the user-token scopes (use the <b>Copy</b> button above), then <b>Install to Workspace</b>.
+        Once your app&apos;s credentials are saved, Cabinet opens this in your browser to approve.
       </Hint>
     </MockWindow>
   );

--- a/src/components/integrations/hub/generic-setup-art.tsx
+++ b/src/components/integrations/hub/generic-setup-art.tsx
@@ -289,8 +289,28 @@ function SlackArt({ step, label, brand }: { step: number; label: string; brand: 
       </MockWindow>
     );
   }
-  // Step 1 — register the redirect URL and add the user-token scopes.
+  // Step 1 — turn on MCP server access for the app (required, easy to miss).
   if (step === 1) {
+    return (
+      <MockWindow title="Agents &amp; AI Apps · App Assistant" brand={brand}>
+        <div className="flex items-center justify-between rounded-md bg-foreground/[0.06] px-2 py-1.5">
+          <span className="text-[10px] text-foreground">MCP server access</span>
+          <span
+            className="rounded-full px-2 py-0.5 text-[10px] font-medium"
+            style={{ background: `${brand}1f`, color: brand }}
+          >
+            On
+          </span>
+        </div>
+        <Hint brand={brand}>
+          Turn this on, or Slack rejects every connection with &ldquo;App is not enabled
+          for Slack MCP server access.&rdquo;
+        </Hint>
+      </MockWindow>
+    );
+  }
+  // Step 2 — register the redirect URL and add the user-token scopes.
+  if (step === 2) {
     return (
       <MockWindow title="OAuth &amp; Permissions" brand={brand}>
         <div className="text-[10px] text-muted-foreground">Redirect URLs</div>
@@ -310,8 +330,8 @@ function SlackArt({ step, label, brand }: { step: number; label: string; brand: 
       </MockWindow>
     );
   }
-  // Step 2 — copy the app's Client ID & Secret into the connect panel.
-  if (step === 2) {
+  // Step 3 — copy the app's Client ID & Secret into the connect panel.
+  if (step === 3) {
     return (
       <MockWindow title="Basic Information · App Credentials" brand={brand}>
         <div className="space-y-1.5">
@@ -330,7 +350,7 @@ function SlackArt({ step, label, brand }: { step: number; label: string; brand: 
       </MockWindow>
     );
   }
-  // Step 3 — approve in the browser (only after the app credentials are saved).
+  // Step 4 — approve in the browser (only after the app credentials are saved).
   return (
     <MockWindow title={`Authorize · ${label}`} brand={brand}>
       <div className="flex flex-col items-center text-center">

--- a/src/components/integrations/hub/integration-detail-page.tsx
+++ b/src/components/integrations/hub/integration-detail-page.tsx
@@ -160,6 +160,7 @@ export function IntegrationDetailPage({
                 authBackend: entry?.authBackend ?? "",
                 transport: entry?.transport ?? "",
                 hasUrlCredential: !!entry?.urlCredentialKey,
+                scopes: entry?.oauthClient?.scopes,
               })}
             />
           ) : null}

--- a/src/lib/agents/claude-mcp-login.ts
+++ b/src/lib/agents/claude-mcp-login.ts
@@ -150,8 +150,8 @@ export function readServerAuthState(
       claudeCommand(),
       ["mcp", "get", serverName],
       { env: claudeEnv(), timeout: 8000 },
-      (err, stdout) => {
-        const out = `${stdout ?? ""}`;
+      (err, stdout, stderr) => {
+        const out = `${stdout ?? ""}\n${stderr ?? ""}`;
         // Not registered at all. `claude mcp get <name>` echoes the name back in
         // its "No MCP server named …" error, so this must be checked BEFORE the
         // name-presence fallback below — otherwise a missing server reads as

--- a/src/lib/agents/claude-mcp-login.ts
+++ b/src/lib/agents/claude-mcp-login.ts
@@ -13,13 +13,18 @@
  * PKCE state is gone. See microsoft-login.ts for the same idea on M365.
  *
  * The fix: keep ONE `claude` process alive across the human approval step. We
- * spawn it in stream-json mode (stdin stays open → process + loopback stay
- * alive), tell it to call the server's `authenticate` helper tool, and parse the
- * authorization URL it returns. When the user approves in the browser, the live
- * loopback catches the callback and Claude Code persists the token to disk — we
- * detect that via `claude mcp get <server>` flipping off "Needs authentication".
- * For remote/headless setups where the browser can't reach localhost, the user
- * can paste the callback URL and we forward it to `complete_authentication`.
+ * run `claude mcp login <server> --no-browser` inside a PTY (the CLI refuses to
+ * authenticate without a terminal), parse the authorization URL it prints, and
+ * keep the process — and its loopback on the configured callback port — alive
+ * while the user approves in the browser. The CLI's own loopback catches the
+ * callback and persists the token; we detect that via `claude mcp get <server>`
+ * flipping off "Needs authentication". For remote/headless setups where the
+ * browser can't reach localhost, the user pastes the callback URL and we write
+ * it to the CLI's "Or paste the redirect URL here:" prompt over the PTY.
+ *
+ * (Earlier this drove a headless `claude -p` agent calling a `…__authenticate`
+ * helper tool; that tool no longer exists in Claude Code ≥2.1.x, so the agent
+ * could never emit a URL and the flow timed out. `claude mcp login` replaces it.)
  *
  * Claude Code only. Other CLIs keep the deferred (first-use) flow for now.
  *
@@ -27,8 +32,10 @@
  * dev. This is a local, single-instance feature — no cross-process store needed.
  */
 
-import { spawn, execFile, type ChildProcess } from "child_process";
+import { execFile } from "child_process";
 import { randomUUID } from "crypto";
+import * as pty from "node-pty";
+import type { IPty } from "node-pty";
 import { claudeCodeProvider } from "./providers/claude-code";
 import { getRuntimePath, resolveCliCommand } from "./provider-cli";
 
@@ -38,7 +45,8 @@ interface McpLoginSession {
   id: string;
   /** The `cabinet-<id>` MCP server name as written into the CLI config. */
   serverName: string;
-  proc: ChildProcess;
+  /** The `claude mcp login` PTY child. Null for the already-authenticated fast path. */
+  term: IPty | null;
   status: McpLoginStatus;
   /** Authorization URL parsed from the `authenticate` tool result. */
   authorizeUrl?: string;
@@ -78,12 +86,7 @@ function markTerminal(
   }
   // The flow is done; release the held `claude` process (and its loopback).
   try {
-    session.proc.stdin?.end();
-  } catch {
-    /* already closed */
-  }
-  try {
-    session.proc.kill();
+    session.term?.kill();
   } catch {
     /* already gone */
   }
@@ -103,7 +106,7 @@ function sweepSessions(): void {
       }
     } else if (now - s.startedAt > LOGIN_TIMEOUT_MS + COMPLETED_TTL_MS) {
       try {
-        s.proc.kill();
+        s.term?.kill();
       } catch {
         /* already gone */
       }
@@ -119,16 +122,6 @@ function claudeCommand(): string {
 function claudeEnv(): NodeJS.ProcessEnv {
   // Match the runtime PATH the provider uses so nvm/homebrew `claude` resolves.
   return { ...process.env, PATH: getRuntimePath() };
-}
-
-/** A stream-json user turn, newline-delimited on the child's stdin. */
-function userMessage(text: string): string {
-  return (
-    JSON.stringify({
-      type: "user",
-      message: { role: "user", content: [{ type: "text", text }] },
-    }) + "\n"
-  );
 }
 
 /**
@@ -165,6 +158,10 @@ export function readServerAuthState(
         // authenticated (the panel would falsely show "Signed in").
         if (/no mcp server named/i.test(out)) return resolve("needs-auth");
         if (/needs authentication/i.test(out)) return resolve("needs-auth");
+        // Registered + has a token, but the server rejects the connection (e.g.
+        // Slack app not enabled for MCP). Not usable → don't report it as signed
+        // in; surface it as needing attention so the panel offers reconnect.
+        if (/failed to connect/i.test(out)) return resolve("needs-auth");
         if (/\bconnected\b/i.test(out)) return resolve("authenticated");
         if (err) return resolve("unknown");
         // Got a clean read with neither marker → server is configured and not
@@ -179,12 +176,13 @@ export function readServerAuthState(
  * Register a pre-configured confidential OAuth client with Claude Code for a
  * remote server whose auth server lacks Dynamic Client Registration (Slack).
  *
- * `claude mcp add --client-id --client-secret` is the only supported way to get
- * the secret into Claude Code's keychain (it can't live in config). It also
- * writes the config entry, so we remove any existing one first (`add` refuses to
- * overwrite). The secret is passed via the `MCP_CLIENT_SECRET` env var, never on
- * argv. Scope `user` matches where the JSON writer keeps cabinet servers
- * (top-level `mcpServers` in ~/.claude.json).
+ * `claude mcp add-json … --client-secret` is the only supported way to get the
+ * secret into Claude Code's keychain (it can't live in config) while ALSO
+ * setting the `oauth` block — including `scopes`, which `claude mcp add` flags
+ * can't express. It writes the config entry too, so we remove any existing one
+ * first (add refuses to overwrite). The secret is passed via `MCP_CLIENT_SECRET`,
+ * never on argv. Scope `user` matches where the JSON writer keeps cabinet
+ * servers (top-level `mcpServers` in ~/.claude.json).
  */
 export function registerConfidentialOAuthClient(opts: {
   serverName: string;
@@ -192,10 +190,15 @@ export function registerConfidentialOAuthClient(opts: {
   clientId: string;
   clientSecret: string;
   callbackPort: number;
+  /** Optional space-separated scope pin (overrides server-discovered scopes). */
+  scopes?: string;
 }): Promise<void> {
-  const { serverName, url, clientId, clientSecret, callbackPort } = opts;
+  const { serverName, url, clientId, clientSecret, callbackPort, scopes } = opts;
+  const oauth: Record<string, unknown> = { clientId, callbackPort };
+  if (scopes) oauth.scopes = scopes;
+  const json = JSON.stringify({ type: "http", url, oauth });
   return new Promise((resolve, reject) => {
-    // Best-effort remove of any prior entry so `add` doesn't error on conflict.
+    // Best-effort remove of any prior entry so add-json doesn't error on conflict.
     execFile(
       claudeCommand(),
       ["mcp", "remove", "--scope", "user", serverName],
@@ -203,21 +206,7 @@ export function registerConfidentialOAuthClient(opts: {
       () => {
         execFile(
           claudeCommand(),
-          [
-            "mcp",
-            "add",
-            "--transport",
-            "http",
-            "--scope",
-            "user",
-            "--client-id",
-            clientId,
-            "--client-secret",
-            "--callback-port",
-            String(callbackPort),
-            serverName,
-            url,
-          ],
+          ["mcp", "add-json", "--scope", "user", "--client-secret", serverName, json],
           { env: { ...claudeEnv(), MCP_CLIENT_SECRET: clientSecret }, timeout: 30_000 },
           (err, stdout, stderr) => {
             if (err) {
@@ -263,7 +252,7 @@ export async function startMcpLogin(serverName: string): Promise<McpLoginStartRe
     const session: McpLoginSession = {
       id,
       serverName,
-      proc: { kill() {}, stdin: null } as unknown as ChildProcess,
+      term: null,
       status: "success",
       startedAt: Date.now(),
       finishedAt: Date.now(),
@@ -276,31 +265,22 @@ export async function startMcpLogin(serverName: string): Promise<McpLoginStartRe
   }
 
   const id = randomUUID();
-  const authTool = `mcp__${serverName}__authenticate`;
-  const completeTool = `mcp__${serverName}__complete_authentication`;
-  const proc = spawn(
-    claudeCommand(),
-    [
-      "--dangerously-skip-permissions",
-      "-p",
-      "--input-format",
-      "stream-json",
-      "--output-format",
-      "stream-json",
-      "--verbose",
-      // Restrict to just the OAuth helpers so the model reliably calls them and
-      // can't wander off doing anything else.
-      "--allowedTools",
-      authTool,
-      completeTool,
-    ],
-    { env: claudeEnv(), stdio: ["pipe", "pipe", "pipe"] },
-  );
+  // `claude mcp login` is the supported OAuth entry point, but it refuses to run
+  // without a TTY — so drive it through a PTY. `--no-browser` makes it PRINT the
+  // authorization URL (we surface it in the panel) while still arming its own
+  // loopback on the configured callback port to catch the redirect.
+  const term = pty.spawn(claudeCommand(), ["mcp", "login", serverName, "--no-browser"], {
+    name: "xterm-color",
+    // Wide enough that the long authorize URL is never wrapped mid-line.
+    cols: 1000,
+    rows: 30,
+    env: claudeEnv() as { [key: string]: string },
+  });
 
   const session: McpLoginSession = {
     id,
     serverName,
-    proc,
+    term,
     status: "pending",
     startedAt: Date.now(),
     output: "",
@@ -318,15 +298,24 @@ export async function startMcpLogin(serverName: string): Promise<McpLoginStartRe
       }
     };
 
-    const onData = (buf: Buffer) => {
-      session.output += buf.toString();
+    term.onData((chunk) => {
+      session.output += chunk;
+      // The CLI prints a clear message when the loopback port is taken; surface
+      // it verbatim instead of letting the start time out opaquely.
+      if (!settled && /already in use/i.test(session.output)) {
+        fail(
+          "OAuth callback port is already in use — close any other sign-in in progress and try again.",
+        );
+        return;
+      }
       if (!session.authorizeUrl) {
         const url = parseAuthorizeUrl(session.output);
         if (url) {
           session.authorizeUrl = url;
           if (!settled) {
             settled = true;
-            // Start watching for the user to finish in the browser.
+            // Watch for the user to finish in the browser. The CLI's own
+            // loopback completes the token exchange; we poll the persisted token.
             session.statusPoll = setInterval(() => {
               void readServerAuthState(serverName).then((state) => {
                 if (state === "authenticated") markTerminal(session, "success");
@@ -337,17 +326,19 @@ export async function startMcpLogin(serverName: string): Promise<McpLoginStartRe
           }
         }
       }
-    };
+    });
 
-    proc.stdout?.on("data", onData);
-    proc.stderr?.on("data", onData);
-    proc.on("error", (err) => fail(err.message));
-    proc.on("exit", () => {
-      // If the process dies before we got a URL, the start failed. If it dies
-      // after, the loopback is gone — but a poll may still confirm success
-      // (token persisted), so only flip to error when not already authenticated.
+    term.onExit(({ exitCode }) => {
+      // If it dies before we got a URL, the start failed. If it dies after, the
+      // loopback is gone — but the token may already be persisted, so only flip
+      // to error when a fresh auth-state read says it isn't authenticated.
       if (!settled) {
-        fail(session.error ?? "Sign-in ended before an authorization URL was issued");
+        fail(
+          session.error ??
+            (exitCode === 0
+              ? "Sign-in ended before an authorization URL was issued"
+              : `Sign-in process exited (code ${exitCode}) before an authorization URL`),
+        );
         return;
       }
       if (session.status === "pending") {
@@ -357,17 +348,6 @@ export async function startMcpLogin(serverName: string): Promise<McpLoginStartRe
         });
       }
     });
-
-    // Kick off the flow.
-    try {
-      proc.stdin?.write(
-        userMessage(
-          `Call the ${authTool} tool now and then output ONLY the authorization URL it returns, nothing else. Do not call any other tool.`,
-        ),
-      );
-    } catch (err) {
-      fail(err instanceof Error ? err.message : "Could not write to sign-in process");
-    }
 
     setTimeout(() => {
       if (!settled) fail("Timed out waiting for the authorization URL");
@@ -391,19 +371,15 @@ export function getMcpLoginStatus(sessionId: string): {
 /**
  * Fallback for when the browser can't reach the loopback (remote/headless): the
  * user pastes the full `http://localhost:<port>/callback?code=...&state=...` URL
- * and we forward it to the server's `complete_authentication` tool on the SAME
- * live process (which still holds the in-flight PKCE state).
+ * and we deliver it to the SAME live `claude mcp login` process, which is parked
+ * at its "Or paste the redirect URL here:" prompt holding the in-flight PKCE
+ * state. A trailing CR submits the line.
  */
 export function completeMcpLogin(sessionId: string, callbackUrl: string): boolean {
   const s = sessions.get(sessionId);
-  if (!s || s.status !== "pending") return false;
-  const completeTool = `mcp__${s.serverName}__complete_authentication`;
+  if (!s || s.status !== "pending" || !s.term) return false;
   try {
-    s.proc.stdin?.write(
-      userMessage(
-        `Call the ${completeTool} tool with callback_url set to exactly: ${callbackUrl}`,
-      ),
-    );
+    s.term.write(`${callbackUrl}\r`);
   } catch {
     return false;
   }
@@ -416,12 +392,7 @@ export function cancelMcpLogin(sessionId: string): boolean {
   if (s.cleanupTimer) clearTimeout(s.cleanupTimer);
   if (s.statusPoll) clearInterval(s.statusPoll);
   try {
-    s.proc.stdin?.end();
-  } catch {
-    /* already closed */
-  }
-  try {
-    s.proc.kill();
+    s.term?.kill();
   } catch {
     /* already gone */
   }

--- a/src/lib/agents/claude-mcp-login.ts
+++ b/src/lib/agents/claude-mcp-login.ts
@@ -159,12 +159,80 @@ export function readServerAuthState(
       { env: claudeEnv(), timeout: 8000 },
       (err, stdout) => {
         const out = `${stdout ?? ""}`;
+        // Not registered at all. `claude mcp get <name>` echoes the name back in
+        // its "No MCP server named …" error, so this must be checked BEFORE the
+        // name-presence fallback below — otherwise a missing server reads as
+        // authenticated (the panel would falsely show "Signed in").
+        if (/no mcp server named/i.test(out)) return resolve("needs-auth");
         if (/needs authentication/i.test(out)) return resolve("needs-auth");
         if (/\bconnected\b/i.test(out)) return resolve("authenticated");
         if (err) return resolve("unknown");
         // Got a clean read with neither marker → server is configured and not
         // flagged as needing auth, so treat as authenticated.
         return resolve(out.includes(serverName) ? "authenticated" : "unknown");
+      },
+    );
+  });
+}
+
+/**
+ * Register a pre-configured confidential OAuth client with Claude Code for a
+ * remote server whose auth server lacks Dynamic Client Registration (Slack).
+ *
+ * `claude mcp add --client-id --client-secret` is the only supported way to get
+ * the secret into Claude Code's keychain (it can't live in config). It also
+ * writes the config entry, so we remove any existing one first (`add` refuses to
+ * overwrite). The secret is passed via the `MCP_CLIENT_SECRET` env var, never on
+ * argv. Scope `user` matches where the JSON writer keeps cabinet servers
+ * (top-level `mcpServers` in ~/.claude.json).
+ */
+export function registerConfidentialOAuthClient(opts: {
+  serverName: string;
+  url: string;
+  clientId: string;
+  clientSecret: string;
+  callbackPort: number;
+}): Promise<void> {
+  const { serverName, url, clientId, clientSecret, callbackPort } = opts;
+  return new Promise((resolve, reject) => {
+    // Best-effort remove of any prior entry so `add` doesn't error on conflict.
+    execFile(
+      claudeCommand(),
+      ["mcp", "remove", "--scope", "user", serverName],
+      { env: claudeEnv(), timeout: 15_000 },
+      () => {
+        execFile(
+          claudeCommand(),
+          [
+            "mcp",
+            "add",
+            "--transport",
+            "http",
+            "--scope",
+            "user",
+            "--client-id",
+            clientId,
+            "--client-secret",
+            "--callback-port",
+            String(callbackPort),
+            serverName,
+            url,
+          ],
+          { env: { ...claudeEnv(), MCP_CLIENT_SECRET: clientSecret }, timeout: 30_000 },
+          (err, stdout, stderr) => {
+            if (err) {
+              reject(
+                new Error(
+                  `Failed to register Slack OAuth client: ${
+                    `${stderr ?? ""}`.trim() || `${stdout ?? ""}`.trim() || err.message
+                  }`,
+                ),
+              );
+            } else {
+              resolve();
+            }
+          },
+        );
       },
     );
   });

--- a/src/lib/agents/mcp-catalog.ts
+++ b/src/lib/agents/mcp-catalog.ts
@@ -103,6 +103,20 @@ export interface CatalogEntry {
    * and is resolved by the PTY env merge at spawn.
    */
   serverEnv?: Record<string, string>;
+  /**
+   * Confidential OAuth client for remote (http) servers whose auth server does
+   * NOT support Dynamic Client Registration (e.g. Slack). The user brings their
+   * own app; we register its client id/secret with the CLI so OAuth can run
+   * without DCR. `clientId` + `callbackPort` go into the CLI config; the secret
+   * is handed to the CLI (stored in its keychain), never written into config.
+   * The user must register `http://localhost:<callbackPort>/callback` as a
+   * redirect URL on their app.
+   */
+  oauthClient?: {
+    clientIdEnvKey: string;
+    clientSecretEnvKey: string;
+    callbackPort: number;
+  };
   /** Credentials collected for `token` / `user-app` backends. */
   credentials: CatalogCredential[];
   /** Display-only: what the agent can do once connected. */
@@ -120,11 +134,21 @@ const SLACK: CatalogEntry = {
   sourceUrl: "https://docs.slack.dev/ai/slack-mcp-server",
   registryId: "slack",
   trustTier: "official",
-  authBackend: "cli-pkce",
-  fallbackAuthBackend: "user-app",
+  // Slack's auth server doesn't support Dynamic Client Registration, so the
+  // one-click `cli-pkce` flow can't work — the user must bring their own app
+  // (client id/secret). user-app is the *only* path, not a fallback.
+  authBackend: "user-app",
   transport: "http",
   mcpServerName: "cabinet-slack",
   url: "https://mcp.slack.com/mcp",
+  // Slack's MCP server doesn't support Dynamic Client Registration, so OAuth
+  // needs a pre-registered confidential client (the user's own Slack app). The
+  // user registers http://localhost:8765/callback as a redirect URL.
+  oauthClient: {
+    clientIdEnvKey: "SLACK_CLIENT_ID",
+    clientSecretEnvKey: "SLACK_CLIENT_SECRET",
+    callbackPort: 8765,
+  },
   credentials: [
     {
       envKey: "SLACK_CLIENT_ID",
@@ -132,7 +156,7 @@ const SLACK: CatalogEntry = {
       kind: "plain",
       required: true,
       placeholder: "1234567890.1234567890",
-      hint: "Only needed for the fallback flow when one-click sign-in isn't available.",
+      hint: "From your Slack app's Basic Information page. Required — Slack's MCP server needs your own app (it has no one-click sign-in).",
     },
     {
       envKey: "SLACK_CLIENT_SECRET",
@@ -140,7 +164,7 @@ const SLACK: CatalogEntry = {
       kind: "secret",
       required: true,
       placeholder: "••••••••••••••••",
-      hint: "Stored in .cabinet.env (0600). Never written into the CLI config.",
+      hint: "From the same Basic Information page. Stored in .cabinet.env (0600), never written into the CLI config.",
     },
   ],
   actions: [
@@ -151,18 +175,22 @@ const SLACK: CatalogEntry = {
   ],
   setupSteps: [
     {
-      title: "Sign in with Slack",
-      body: "Click Connect & sign in — your agent's CLI opens Slack in the browser. Approve the requested access and you're done. Most workspaces work with this one-click flow.",
-    },
-    {
-      title: "If your workspace blocks one-click",
-      body: "Some workspaces require their own Slack app. Create one, enable the listed user-token scopes, then paste its Client ID & Secret below.",
+      title: "Create your own Slack app",
+      body: "Slack's MCP server has no one-click sign-in — it requires an app you own. Open Slack's app dashboard, click Create New App → From scratch, give it a name (e.g. \"Cabinet\"), and pick your workspace.",
       href: "https://api.slack.com/apps",
     },
     {
-      title: "Scopes to enable (own-app only)",
-      body: "Add these user-token scopes so every tool works.",
+      title: "Add the redirect URL and scopes",
+      body: "In your app's OAuth & Permissions page, add the redirect URL http://localhost:8765/callback, then add these user-token scopes so every tool works. Install the app to your workspace when prompted — some workspaces need an admin to approve it.",
       copy: "search:read.public search:read.private search:read.users files:read chat:write channels:history channels:read channels:write groups:history users:read reactions:write canvases:read canvases:write",
+    },
+    {
+      title: "Paste your Client ID & Secret below",
+      body: "On the app's Basic Information page, copy the Client ID and Client Secret into the fields in the connect panel. Slack needs these because it doesn't support automatic client registration; they're stored in .cabinet.env (0600).",
+    },
+    {
+      title: "Connect & sign in",
+      body: "Click Connect & sign in. Cabinet opens Slack in your browser to approve access — once you do, your agents can use Slack and the \"does not support dynamic client registration\" error is gone.",
     },
   ],
 };

--- a/src/lib/agents/mcp-catalog.ts
+++ b/src/lib/agents/mcp-catalog.ts
@@ -116,6 +116,13 @@ export interface CatalogEntry {
     clientIdEnvKey: string;
     clientSecretEnvKey: string;
     callbackPort: number;
+    /**
+     * Pins the OAuth scopes requested at sign-in (space-separated), overriding
+     * the larger set the server would otherwise discover. Lets the user's app
+     * get away with a small, easy-to-grant scope set. Omit to request whatever
+     * the server advertises.
+     */
+    scopes?: string;
   };
   /** Credentials collected for `token` / `user-app` backends. */
   credentials: CatalogCredential[];
@@ -148,6 +155,12 @@ const SLACK: CatalogEntry = {
     clientIdEnvKey: "SLACK_CLIENT_ID",
     clientSecretEnvKey: "SLACK_CLIENT_SECRET",
     callbackPort: 8765,
+    // Pinned to a read + post + search set so a self-made app only needs these
+    // 6 user-token scopes granted — avoids the full ~26 (and sensitive ones like
+    // users:read.email that locked-down workspaces block). Widen to add files,
+    // private channels, DMs, canvases, or reactions as needed.
+    scopes:
+      "chat:write channels:read channels:history users:read search:read.public search:read.users",
   },
   credentials: [
     {
@@ -180,9 +193,14 @@ const SLACK: CatalogEntry = {
       href: "https://api.slack.com/apps",
     },
     {
+      title: "Enable MCP server access",
+      body: "Slack only allows MCP for apps that opt in. In your app settings, open Agents & AI Apps (App Assistant) and turn on MCP server access. Skip this and you'll sign in fine but every connection is rejected with \"App is not enabled for Slack MCP server access.\"",
+      href: "https://api.slack.com/apps",
+    },
+    {
       title: "Add the redirect URL and scopes",
-      body: "In your app's OAuth & Permissions page, add the redirect URL http://localhost:8765/callback, then add these user-token scopes so every tool works. Install the app to your workspace when prompted — some workspaces need an admin to approve it.",
-      copy: "search:read.public search:read.private search:read.users files:read chat:write channels:history channels:read channels:write groups:history users:read reactions:write canvases:read canvases:write",
+      body: "In OAuth & Permissions, add the redirect URL http://localhost:8765/callback (click Save URLs), then add these scopes under User Token Scopes (not Bot Token Scopes — Slack signs you in with a user token), and Install to Workspace. They let agents read public channels, search, and post.",
+      copy: "chat:write channels:read channels:history users:read search:read.public search:read.users",
     },
     {
       title: "Paste your Client ID & Secret below",

--- a/src/lib/agents/mcp-config-writer.ts
+++ b/src/lib/agents/mcp-config-writer.ts
@@ -80,7 +80,12 @@ function buildServerEntry(entry: CatalogEntry): Record<string, unknown> {
     if (entry.oauthClient) {
       const clientId = readCabinetEnvFile().values[entry.oauthClient.clientIdEnvKey];
       if (clientId) {
-        server.oauth = { clientId, callbackPort: entry.oauthClient.callbackPort };
+        const oauth: Record<string, unknown> = {
+          clientId,
+          callbackPort: entry.oauthClient.callbackPort,
+        };
+        if (entry.oauthClient.scopes) oauth.scopes = entry.oauthClient.scopes;
+        server.oauth = oauth;
       }
     }
     return server;

--- a/src/lib/agents/mcp-config-writer.ts
+++ b/src/lib/agents/mcp-config-writer.ts
@@ -75,11 +75,16 @@ function buildServerEntry(entry: CatalogEntry): Record<string, unknown> {
     // Servers whose auth server lacks Dynamic Client Registration (e.g. Slack)
     // need a pre-registered confidential client. The client id + fixed callback
     // port go into the config's `oauth` block; the secret is registered with the
-    // CLI separately (keychain), never written here. Omit the block until the
-    // user has supplied their client id, so we never write a half-formed entry.
+    // CLI separately (keychain), never written here. Require both the id and
+    // secret before writing — the connect route only calls
+    // registerConfidentialOAuthClient() (which registers the secret) when both
+    // are present, so writing the block on id-alone would persist an `oauth`
+    // config whose secret was never registered with the CLI.
     if (entry.oauthClient) {
-      const clientId = readCabinetEnvFile().values[entry.oauthClient.clientIdEnvKey];
-      if (clientId) {
+      const values = readCabinetEnvFile().values;
+      const clientId = values[entry.oauthClient.clientIdEnvKey];
+      const clientSecret = values[entry.oauthClient.clientSecretEnvKey];
+      if (clientId && clientSecret) {
         const oauth: Record<string, unknown> = {
           clientId,
           callbackPort: entry.oauthClient.callbackPort,

--- a/src/lib/agents/mcp-config-writer.ts
+++ b/src/lib/agents/mcp-config-writer.ts
@@ -71,7 +71,19 @@ function buildServerEntry(entry: CatalogEntry): Record<string, unknown> {
       url = readCabinetEnvFile().values[entry.urlCredentialKey];
     }
     if (!url) throw new Error(`Catalog entry ${entry.id} is http but has no url`);
-    return { type: "http", url };
+    const server: Record<string, unknown> = { type: "http", url };
+    // Servers whose auth server lacks Dynamic Client Registration (e.g. Slack)
+    // need a pre-registered confidential client. The client id + fixed callback
+    // port go into the config's `oauth` block; the secret is registered with the
+    // CLI separately (keychain), never written here. Omit the block until the
+    // user has supplied their client id, so we never write a half-formed entry.
+    if (entry.oauthClient) {
+      const clientId = readCabinetEnvFile().values[entry.oauthClient.clientIdEnvKey];
+      if (clientId) {
+        server.oauth = { clientId, callbackPort: entry.oauthClient.callbackPort };
+      }
+    }
+    return server;
   }
   // Dev bootstrap: a first-party server whose local build exists in the source
   // tree runs directly via `node`, instead of an npm package that may not be

--- a/src/lib/integrations/preview-catalog.ts
+++ b/src/lib/integrations/preview-catalog.ts
@@ -678,6 +678,7 @@ const LAUNCHED = new Set([
   "gmail",
   "microsoft-365",
   "notion",
+  "slack",
 ]);
 
 export const PREVIEW_INTEGRATIONS: IntegrationItem[] = RAW_INTEGRATIONS.map((i) => {

--- a/src/lib/runtime/open-url.ts
+++ b/src/lib/runtime/open-url.ts
@@ -3,6 +3,7 @@
 interface CabinetDesktopBridge {
   runtime?: "electron";
   openLocalFile?: (path: string) => Promise<{ ok: boolean; error?: string }>;
+  openExternal?: (url: string) => Promise<{ ok: boolean; error?: string }>;
 }
 
 function getBridge(): CabinetDesktopBridge {
@@ -60,4 +61,20 @@ export function openUrlInAppropriateContext(
     // window.opener and navigating/altering this app.
     window.open(url, "_blank", "noopener,noreferrer");
   }
+}
+
+/**
+ * Force an http(s) URL into the user's SYSTEM default browser, bypassing the
+ * in-app browse view. Use this for OAuth sign-in links: the embedded browser
+ * doesn't carry the user's provider session, and providers like Google/Slack
+ * often refuse to authorize inside a webview. In the web build there's no
+ * in-app browser anyway, so this is just a normal new-tab open.
+ */
+export function openExternalUrl(url: string): void {
+  const bridge = getBridge();
+  if (bridge.runtime === "electron" && bridge.openExternal) {
+    void bridge.openExternal(url);
+    return;
+  }
+  window.open(url, "_blank", "noopener,noreferrer");
 }

--- a/src/lib/runtime/open-url.ts
+++ b/src/lib/runtime/open-url.ts
@@ -71,10 +71,23 @@ export function openUrlInAppropriateContext(
  * in-app browser anyway, so this is just a normal new-tab open.
  */
 export function openExternalUrl(url: string): void {
-  const bridge = getBridge();
-  if (bridge.runtime === "electron" && bridge.openExternal) {
-    void bridge.openExternal(url);
+  let externalUrl: URL;
+  try {
+    externalUrl = new URL(url);
+  } catch {
     return;
   }
-  window.open(url, "_blank", "noopener,noreferrer");
+  // Guard both paths, not just the Electron bridge — the web build (or a
+  // missing bridge) falls through to window.open, which would otherwise let a
+  // custom protocol handler fire straight from an "OAuth" link.
+  if (externalUrl.protocol !== "http:" && externalUrl.protocol !== "https:") {
+    return;
+  }
+
+  const bridge = getBridge();
+  if (bridge.runtime === "electron" && bridge.openExternal) {
+    void bridge.openExternal(externalUrl.toString());
+    return;
+  }
+  window.open(externalUrl.toString(), "_blank", "noopener,noreferrer");
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop external links now open in the system browser (http/https only), improving OAuth sign-in flows.
  * Slack setup/sign-in is updated to a clearer multi-step guide, including pinned OAuth scopes.
  * Slack is enabled as a connectable preview integration.
* **Bug Fixes**
  * OAuth sign-in now blocks when required credentials are missing, with a clearer message.
  * Improved OAuth login handling for MCP connections (redirect/auth errors) and safer confidential OAuth client registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->