### PR TITLE
Feat/snowflake integration

### DIFF
--- a/src/app/api/agents/config/mcp-catalog/test/route.ts
+++ b/src/app/api/agents/config/mcp-catalog/test/route.ts
@@ -1,11 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import fs from "fs/promises";
 import { getCatalogEntry } from "@/lib/agents/mcp-catalog";
+import { canProbeStdio, probeStdioMcp } from "@/lib/agents/stdio-mcp-probe";
 
 /**
  * `/api/agents/config/mcp-catalog/test` — validate a credential WITHOUT
  * saving anything, so the connect drawer can show ✓/✗ before the user
- * commits. Lightweight, time-boxed checks only.
+ * commits. Time-boxed checks only: cheap API pings for token services, or a
+ * short spawn-and-handshake probe for token-auth stdio servers (see
+ * stdio-mcp-probe.ts).
  */
 
 const TIMEOUT_MS = 5000;
@@ -88,6 +91,15 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       });
     }
     return NextResponse.json(await testServiceAccountFile(p));
+  }
+
+  // Token-auth stdio servers (e.g. Snowflake's snowflake-labs-mcp) authenticate
+  // from env credentials, so we can actually connect: spawn the server, run the
+  // MCP handshake, and surface its own error (e.g. "Network policy is required")
+  // instead of letting it become a silent hang at agent-run time.
+  const entry = getCatalogEntry(id);
+  if (entry && canProbeStdio(entry)) {
+    return NextResponse.json(await probeStdioMcp(entry, creds));
   }
 
   // Slack official server is OAuth over HTTP — there is nothing to verify

--- a/src/lib/agents/mcp-catalog.ts
+++ b/src/lib/agents/mcp-catalog.ts
@@ -1088,8 +1088,14 @@ sql_statement_permissions:
       },
       {
         title: "Create a Programmatic Access Token",
-        body: "In Snowsight, open your user menu → Profile → Authentication → Programmatic access tokens and generate a PAT. Scope it to a least-privilege role (ideally read-only) so agents can't do more than you intend.",
+        body: "In Snowsight, generate a PAT for your user. Newer accounts: Governance & security → Users & roles → your user → Programmatic access tokens → Generate new token. Some accounts instead expose it under your user menu → Profile / My profile → Authentication. Scope it to a least-privilege role (ideally read-only) so agents can't do more than you intend.",
         href: "https://docs.snowflake.com/en/user-guide/programmatic-access-tokens",
+      },
+      {
+        title: "Attach a network policy (required for PAT auth)",
+        body: "A PAT can't authenticate unless its user has a network policy — otherwise connecting fails with \"Network policy is required\" and the server hangs on \"still connecting\" with no error. In a Snowsight SQL worksheet (role ACCOUNTADMIN), run the SQL below: swap YOUR_USER for your username and, for real use, replace the allow-all list with your own IP/CIDR. Skip this only if you're using a raw account password instead of a PAT.",
+        copy: "USE ROLE ACCOUNTADMIN;\nCREATE NETWORK POLICY IF NOT EXISTS cabinet_mcp_policy ALLOWED_IP_LIST = ('0.0.0.0/0');\nALTER USER YOUR_USER SET NETWORK_POLICY = cabinet_mcp_policy;",
+        href: "https://docs.snowflake.com/en/user-guide/network-policies",
       },
       {
         title: "Paste your account, user & token",

--- a/src/lib/agents/mcp-catalog.ts
+++ b/src/lib/agents/mcp-catalog.ts
@@ -1093,8 +1093,8 @@ sql_statement_permissions:
       },
       {
         title: "Attach a network policy (required for PAT auth)",
-        body: "A PAT can't authenticate unless its user has a network policy — otherwise connecting fails with \"Network policy is required\" and the server hangs on \"still connecting\" with no error. In a Snowsight SQL worksheet (role ACCOUNTADMIN), run the SQL below: swap YOUR_USER for your username and, for real use, replace the allow-all list with your own IP/CIDR. Skip this only if you're using a raw account password instead of a PAT.",
-        copy: "USE ROLE ACCOUNTADMIN;\nCREATE NETWORK POLICY IF NOT EXISTS cabinet_mcp_policy ALLOWED_IP_LIST = ('0.0.0.0/0');\nALTER USER YOUR_USER SET NETWORK_POLICY = cabinet_mcp_policy;",
+        body: "A PAT can't authenticate unless its user has a network policy — otherwise connecting fails with \"Network policy is required\" and the server hangs on \"still connecting\" with no error. In a Snowsight SQL worksheet (role ACCOUNTADMIN), run the SQL below, swapping YOUR_USER for your username and YOUR_IP for the public IP (or CIDR range) you connect from. Skip this only if you're using a raw account password instead of a PAT.",
+        copy: "USE ROLE ACCOUNTADMIN;\nCREATE NETWORK POLICY IF NOT EXISTS cabinet_mcp_policy ALLOWED_IP_LIST = ('YOUR_IP/32');\nALTER USER YOUR_USER SET NETWORK_POLICY = cabinet_mcp_policy;",
         href: "https://docs.snowflake.com/en/user-guide/network-policies",
       },
       {

--- a/src/lib/agents/mcp-catalog.ts
+++ b/src/lib/agents/mcp-catalog.ts
@@ -1055,7 +1055,7 @@ sql_statement_permissions:
         kind: "secret",
         required: true,
         placeholder: "••••••••••••••••",
-        hint: "Generate a PAT in Snowsight (Profile → Authentication) scoped to a least-privilege role. Passed as SNOWFLAKE_PASSWORD; stored in .cabinet.env (0600), never written into the CLI config. A raw password or key-pair also works — see setup.",
+        hint: "Generate a PAT in Snowsight (Profile → Authentication) scoped to a least-privilege role. Passed as SNOWFLAKE_PASSWORD; stored in .cabinet.env (0600), never written into the CLI config. A raw account password works here too.",
       },
       {
         envKey: "SNOWFLAKE_WAREHOUSE",
@@ -1099,7 +1099,7 @@ sql_statement_permissions:
       },
       {
         title: "Paste your account, user & token",
-        body: "Enter your account identifier, username, and the PAT below. They're stored in .cabinet.env (0600) and injected into the server's environment at run time — never written into the CLI config. Prefer key-pair auth? Set SNOWFLAKE_PRIVATE_KEY_FILE in .cabinet.env and leave the token blank.",
+        body: "Enter your account identifier, username, and the PAT below. They're stored in .cabinet.env (0600) and injected into the server's environment at run time — never written into the CLI config.",
       },
       {
         title: "Read-only by default",

--- a/src/lib/agents/mcp-catalog.ts
+++ b/src/lib/agents/mcp-catalog.ts
@@ -113,6 +113,15 @@ export interface CatalogEntry {
    */
   serverEnv?: Record<string, string>;
   /**
+   * stdio servers that require an auxiliary config file on disk (Snowflake's
+   * `--service-config-file`). At connect the writer materializes this file under
+   * Cabinet's data dir and substitutes its absolute path for the `${CONFIG_FILE}`
+   * token in `args`. Contents are static, secret-free policy (e.g. which tool
+   * groups + SQL statement types are permitted) — real secrets stay in
+   * `.cabinet.env` / `serverEnv`, never in this file.
+   */
+  configFile?: { name: string; contents: string };
+  /**
    * Confidential OAuth client for remote (http) servers whose auth server does
    * NOT support Dynamic Client Registration (e.g. Slack). The user brings their
    * own app; we register its client id/secret with the CLI so OAuth can run
@@ -957,7 +966,141 @@ const EXTENDED: CatalogEntry[] = [
   byoRemote({ id: "docusign", label: "DocuSign", blurb: "Envelopes, signatures, and templates.", logo: "/logos/docusign.webp", sourceUrl: "https://www.docusign.com/", tier: "community", actions: ["Send envelopes", "Check signature status", "Use templates"], where: "Use a hosted DocuSign MCP URL or self-host." }),
   byoRemote({ id: "workday", label: "Workday", blurb: "HR records, time off, and org data.", logo: "/logos/workday.svg", sourceUrl: "https://www.workday.com/", tier: "community", actions: ["Read worker & org data", "Check time off", "Look up policies"], where: "Use a hosted Workday MCP URL or self-host." }),
   byoRemote({ id: "bamboohr", label: "BambooHR", blurb: "Employees, time off, and HR data.", logo: "/logos/bamboohr.svg", sourceUrl: "https://www.bamboohr.com/", tier: "community", actions: ["Read employee data", "Check time off", "Look up directory"], where: "Use a hosted BambooHR MCP URL or self-host." }),
-  byoRemote({ id: "snowflake", label: "Snowflake", blurb: "Query your data warehouse with Cortex.", logo: "/logos/snowflake.svg", sourceUrl: "https://docs.snowflake.com/", tier: "community", actions: ["Run SQL queries", "Explore schemas", "Summarize results"], where: "Use Snowflake's Cortex MCP endpoint or a hosted URL." }),
+  {
+    id: "snowflake",
+    label: "Snowflake",
+    blurb: "Query your warehouse and Cortex AI in natural language.",
+    iconSlug: "snowflake",
+    bgImage: "/integrations/snowflake-bg.webp",
+    logo: "/logos/snowflake.webp",
+    // Snowflake's own server (Snowflake-Labs/mcp), run locally via uvx. Auth goes
+    // through the Snowflake Python Connector: we pass account/user + a Programmatic
+    // Access Token (as SNOWFLAKE_PASSWORD) via the env — no browser OAuth, so it's
+    // a plain token paste. The server REQUIRES --service-config-file, so we
+    // materialize a read-only default policy (see configFile) and pass its path.
+    sourceUrl: "https://github.com/Snowflake-Labs/mcp",
+    registryId: "snowflake",
+    trustTier: "official",
+    authBackend: "token",
+    transport: "stdio",
+    mcpServerName: "cabinet-snowflake",
+    command: "uvx",
+    args: ["snowflake-labs-mcp", "--service-config-file", "${CONFIG_FILE}"],
+    serverEnv: {
+      SNOWFLAKE_ACCOUNT: "${SNOWFLAKE_ACCOUNT}",
+      SNOWFLAKE_USER: "${SNOWFLAKE_USER}",
+      // A Programmatic Access Token is passed as the password (its documented use).
+      SNOWFLAKE_PASSWORD: "${SNOWFLAKE_PASSWORD}",
+      // Optional — dropped by the writer when left blank in .cabinet.env.
+      SNOWFLAKE_WAREHOUSE: "${SNOWFLAKE_WAREHOUSE}",
+      SNOWFLAKE_ROLE: "${SNOWFLAKE_ROLE}",
+    },
+    configFile: {
+      name: "snowflake-mcp-config.yaml",
+      contents: `# Cabinet default config for the Snowflake MCP server (Snowflake-Labs/mcp).
+#
+# Read-only by default: agents may run SELECT / DESCRIBE / USE and utility
+# commands, but INSERT / UPDATE / DELETE / DROP and other mutations are denied.
+# To let agents write, flip the relevant statement types below to true.
+#
+# No Cortex agent/search/analyst services are pre-wired — those are
+# account-specific; add them here after you create them in Snowflake.
+agent_services: []
+search_services: []
+analyst_services: []
+other_services:
+  object_manager: true    # explore databases/schemas/tables/etc.
+  query_manager: true     # run SQL, gated by sql_statement_permissions below
+  semantic_manager: true  # discover & query semantic views
+sql_statement_permissions:
+  - Select: true
+  - Describe: true
+  - Use: true
+  - Command: true
+  - Alter: false
+  - Comment: false
+  - Commit: false
+  - Create: false
+  - Delete: false
+  - Drop: false
+  - Insert: false
+  - Merge: false
+  - Rollback: false
+  - Transaction: false
+  - TruncateTable: false
+  - Update: false
+  - Unknown: false
+`,
+    },
+    credentials: [
+      {
+        envKey: "SNOWFLAKE_ACCOUNT",
+        label: "Account identifier",
+        kind: "plain",
+        required: true,
+        placeholder: "myorg-myaccount",
+        hint: "Your account identifier (e.g. myorg-myaccount), the first part of your account URL https://<account>.snowflakecomputing.com.",
+      },
+      {
+        envKey: "SNOWFLAKE_USER",
+        label: "Username",
+        kind: "plain",
+        required: true,
+        placeholder: "you@example.com",
+        hint: "The Snowflake user the token belongs to.",
+      },
+      {
+        envKey: "SNOWFLAKE_PASSWORD",
+        label: "Programmatic Access Token (PAT)",
+        kind: "secret",
+        required: true,
+        placeholder: "••••••••••••••••",
+        hint: "Generate a PAT in Snowsight (Profile → Authentication) scoped to a least-privilege role. Passed as SNOWFLAKE_PASSWORD; stored in .cabinet.env (0600), never written into the CLI config. A raw password or key-pair also works — see setup.",
+      },
+      {
+        envKey: "SNOWFLAKE_WAREHOUSE",
+        label: "Warehouse (optional)",
+        kind: "plain",
+        required: false,
+        placeholder: "COMPUTE_WH",
+        hint: "Default virtual warehouse for queries. Leave blank to use the user's default.",
+      },
+      {
+        envKey: "SNOWFLAKE_ROLE",
+        label: "Role (optional)",
+        kind: "plain",
+        required: false,
+        placeholder: "MCP_READONLY",
+        hint: "Role to run as — a least-privilege role is recommended. Leave blank for the user's default.",
+      },
+    ],
+    actions: [
+      "Run SQL queries (read-only by default)",
+      "Explore databases, schemas & tables",
+      "Query Cortex Analyst & semantic views",
+      "Summarize results",
+    ],
+    setupSteps: [
+      {
+        title: "Install uv (one-time)",
+        body: "The server runs locally through uvx, uv's tool runner (like npx, but for Python). macOS/Linux: run `curl -LsSf https://astral.sh/uv/install.sh | sh` (or `brew install uv`). Windows: `winget install --id=astral-sh.uv`. Restart Cabinet if it was already open.",
+        href: "https://docs.astral.sh/uv/getting-started/installation/",
+      },
+      {
+        title: "Create a Programmatic Access Token",
+        body: "In Snowsight, open your user menu → Profile → Authentication → Programmatic access tokens and generate a PAT. Scope it to a least-privilege role (ideally read-only) so agents can't do more than you intend.",
+        href: "https://docs.snowflake.com/en/user-guide/programmatic-access-tokens",
+      },
+      {
+        title: "Paste your account, user & token",
+        body: "Enter your account identifier, username, and the PAT below. They're stored in .cabinet.env (0600) and injected into the server's environment at run time — never written into the CLI config. Prefer key-pair auth? Set SNOWFLAKE_PRIVATE_KEY_FILE in .cabinet.env and leave the token blank.",
+      },
+      {
+        title: "Read-only by default",
+        body: "Cabinet ships a config that permits SELECT/DESCRIBE/USE and denies INSERT/UPDATE/DELETE/DROP and other writes. To let agents write, edit snowflake-mcp-config.yaml in Cabinet's data dir (data/.agents/.config) and flip the relevant statement types to true.",
+      },
+    ],
+  },
   byoRemote({ id: "bigquery", label: "BigQuery", blurb: "Query datasets in Google BigQuery.", logo: "/logos/bigquery.svg", sourceUrl: "https://cloud.google.com/bigquery", tier: "community", actions: ["Run SQL queries", "Explore datasets", "Summarize results"], where: "Use a hosted BigQuery MCP URL or self-host." }),
   byoRemote({ id: "amplitude", label: "Amplitude", blurb: "Product analytics, charts, and cohorts.", logo: "/logos/amplitude.svg", sourceUrl: "https://amplitude.com/", tier: "community", actions: ["Query charts & events", "Read cohorts", "Summarize trends"], where: "Use a hosted Amplitude MCP URL or self-host." }),
   byoRemote({ id: "airtable", label: "Airtable", blurb: "Read and write records across your bases.", logo: "/logos/airtable.svg", sourceUrl: "https://airtable.com/developers", tier: "community", actions: ["Query tables", "Create & update records", "Read schemas"], where: "Use a hosted Airtable MCP URL (Composio/Pipedream) or self-host." }),

--- a/src/lib/agents/mcp-config-writer.ts
+++ b/src/lib/agents/mcp-config-writer.ts
@@ -25,6 +25,7 @@ import path from "path";
 import { parse as parseToml, stringify as stringifyToml } from "smol-toml";
 import { getCabinetEnvSnapshot, readCabinetEnvFile } from "@/lib/runtime/cabinet-env";
 import { PROJECT_ROOT } from "@/lib/runtime/runtime-config";
+import { DATA_DIR } from "@/lib/storage/path-utils";
 import {
   MCP_PROVIDERS,
   getMcpProvider,
@@ -58,6 +59,20 @@ function resolveServerEnv(
     out[key] = val;
   }
   return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Materialize an entry's auxiliary config file (e.g. Snowflake's
+ * `--service-config-file`) to a stable, Cabinet-owned absolute path and return
+ * it. Contents are static, secret-free policy. Written only if absent so a user
+ * who hand-edits it (e.g. to allow writes) keeps their edits across reconnects.
+ */
+function materializeConfigFile(cfg: { name: string; contents: string }): string {
+  const dir = path.join(DATA_DIR, ".agents", ".config");
+  fs.mkdirSync(dir, { recursive: true });
+  const abs = path.join(dir, cfg.name);
+  if (!fs.existsSync(abs)) fs.writeFileSync(abs, cfg.contents, "utf8");
+  return abs;
 }
 
 /**
@@ -124,7 +139,12 @@ function buildServerEntry(entry: CatalogEntry): Record<string, unknown> {
     }
   }
   const out: Record<string, unknown> = { command: entry.command };
-  const args = resolveArgs(entry);
+  let args = resolveArgs(entry);
+  if (args && entry.configFile) {
+    // Materialize the aux config file and swap its absolute path in for the token.
+    const configPath = materializeConfigFile(entry.configFile);
+    args = args.map((a) => a.replaceAll("${CONFIG_FILE}", configPath));
+  }
   if (args) out.args = args;
   if (entry.serverEnv) {
     const env = resolveServerEnv(entry.serverEnv); // ${ENVKEY} placeholders, unset ones dropped

--- a/src/lib/agents/stdio-mcp-probe.ts
+++ b/src/lib/agents/stdio-mcp-probe.ts
@@ -1,0 +1,264 @@
+/**
+ * Connect-time health probe for token-authenticated STDIO MCP servers
+ * (e.g. Snowflake's snowflake-labs-mcp). Unlike the OAuth stdio login flow
+ * (stdio-mcp-login.ts), these servers authenticate purely from env credentials,
+ * so we can verify them BEFORE the user commits: spawn the server, run the MCP
+ * `initialize` handshake, and report success or the server's own error.
+ *
+ * Why it matters: servers like snowflake-labs-mcp open their upstream connection
+ * at startup. A bad credential or a missing network policy makes the process die
+ * during boot — which, at agent-run time, surfaces only as an endless "still
+ * connecting" with no error. Probing here turns that silent hang into an
+ * actionable ✗ carrying the real message (e.g. "Network policy is required").
+ *
+ * Nothing is persisted: credentials come from the request, and the required
+ * service-config file is materialized to a throwaway temp path that's deleted
+ * when the probe ends.
+ */
+
+import { spawn, type ChildProcess } from "child_process";
+import { randomUUID } from "crypto";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { readCabinetEnvFile } from "@/lib/runtime/cabinet-env";
+import { PROJECT_ROOT } from "@/lib/runtime/runtime-config";
+import { getRuntimePath } from "./provider-cli";
+import type { CatalogEntry } from "./mcp-catalog";
+
+export interface StdioProbeResult {
+  valid: boolean;
+  detail: string;
+}
+
+/** How long to wait for the handshake before giving up (uvx cold-start aware). */
+const PROBE_TIMEOUT_MS = 25_000;
+
+/**
+ * stdio servers we can meaningfully probe: local command, token auth (creds in
+ * env), and NO OAuth login step (those are handled by stdio-mcp-login and would
+ * just block waiting for a browser).
+ */
+export function canProbeStdio(entry: CatalogEntry): boolean {
+  return (
+    entry.transport === "stdio" &&
+    !!entry.command &&
+    !entry.connectAuth &&
+    !!entry.serverEnv
+  );
+}
+
+/**
+ * Child env = process env + provider runtime PATH, then the entry's serverEnv
+ * `${KEY}` placeholders resolved from saved .cabinet.env values overlaid with
+ * the just-typed credentials (so we test exactly what the user is about to save).
+ */
+function buildEnv(
+  entry: CatalogEntry,
+  credsOverride: Record<string, string>,
+): NodeJS.ProcessEnv {
+  const values = { ...readCabinetEnvFile().values };
+  for (const [k, v] of Object.entries(credsOverride)) {
+    const t = typeof v === "string" ? v.trim() : "";
+    if (t) values[k] = t;
+  }
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  env.PATH = [getRuntimePath(), process.env.PATH].filter(Boolean).join(path.delimiter);
+  for (const [k, v] of Object.entries(entry.serverEnv ?? {})) {
+    const m = /^\$\{([A-Z][A-Z0-9_]*)\}$/.exec(v);
+    if (m) {
+      const val = values[m[1]];
+      if (val) env[k] = val; // unset optional → let the server default
+    } else {
+      env[k] = v;
+    }
+  }
+  return env;
+}
+
+/**
+ * Resolve args, materializing `entry.configFile` to a temp path and swapping it
+ * in for `${CONFIG_FILE}`. Returns a cleanup that removes the temp file.
+ */
+function resolveArgsWithTempConfig(entry: CatalogEntry): {
+  args: string[];
+  cleanup: () => void;
+} {
+  let args = entry.args ? [...entry.args] : [];
+  let tmpFile: string | undefined;
+  if (entry.configFile && args.some((a) => a.includes("${CONFIG_FILE}"))) {
+    tmpFile = path.join(
+      os.tmpdir(),
+      `cabinet-probe-${randomUUID()}-${entry.configFile.name}`,
+    );
+    fs.writeFileSync(tmpFile, entry.configFile.contents, "utf8");
+    const resolved = tmpFile;
+    args = args.map((a) => a.replaceAll("${CONFIG_FILE}", resolved));
+  }
+  const cleanup = () => {
+    if (tmpFile) {
+      try {
+        fs.unlinkSync(tmpFile);
+      } catch {
+        /* best effort */
+      }
+    }
+  };
+  return { args, cleanup };
+}
+
+/** A Python traceback ends with the exception line — the most useful message. */
+function lastMeaningfulLine(text: string): string {
+  const lines = text
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter(Boolean);
+  return lines.length ? lines[lines.length - 1] : "";
+}
+
+/**
+ * Spawn the server, run `initialize`, and resolve to a pass/fail with a
+ * human-readable detail. Best-effort and self-cleaning; never throws.
+ */
+export async function probeStdioMcp(
+  entry: CatalogEntry,
+  credsOverride: Record<string, string>,
+): Promise<StdioProbeResult> {
+  if (!canProbeStdio(entry)) {
+    return { valid: true, detail: "This integration is verified at first use." };
+  }
+
+  let command = entry.command as string;
+  const { args, cleanup } = resolveArgsWithTempConfig(entry);
+  const env = buildEnv(entry, credsOverride);
+
+  // Dev bootstrap: run a first-party source build directly, matching the writer.
+  if (entry.localBuild) {
+    const local = path.join(PROJECT_ROOT, entry.localBuild);
+    if (fs.existsSync(local)) {
+      command = "node";
+      args.length = 0;
+      args.push(local);
+    }
+  }
+
+  // Redact any pasted secret that happens to echo back in server output.
+  const scrub = (s: string): string => {
+    let out = s;
+    for (const v of Object.values(credsOverride)) {
+      const t = typeof v === "string" ? v.trim() : "";
+      if (t.length >= 6) out = out.split(t).join("<redacted>");
+    }
+    return out;
+  };
+
+  return new Promise<StdioProbeResult>((resolve) => {
+    let settled = false;
+    let stdout = "";
+    let stderr = "";
+
+    let proc: ChildProcess;
+    try {
+      proc = spawn(command, args, { env, stdio: ["pipe", "pipe", "pipe"] });
+    } catch (err) {
+      cleanup();
+      resolve({
+        valid: false,
+        detail: err instanceof Error ? err.message : "Could not start the server.",
+      });
+      return;
+    }
+
+    const finish = (r: StdioProbeResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        proc.kill();
+      } catch {
+        /* already gone */
+      }
+      cleanup();
+      resolve({ valid: r.valid, detail: scrub(r.detail).slice(0, 400) });
+    };
+
+    const timer = setTimeout(() => {
+      finish({
+        valid: false,
+        detail:
+          "The server didn't respond in 25s. On its first run it may still be downloading — try again in a moment.",
+      });
+    }, PROBE_TIMEOUT_MS);
+    timer.unref?.();
+
+    // Scan stdout for the `initialize` reply (id:1). Success → serving normally;
+    // an error object → the server refused the connection.
+    const scanForReply = () => {
+      for (const line of stdout.split(/\r?\n/)) {
+        const t = line.trim();
+        if (!t.startsWith("{")) continue;
+        let msg: { id?: unknown; result?: unknown; error?: unknown };
+        try {
+          msg = JSON.parse(t);
+        } catch {
+          continue; // partial/streamed line
+        }
+        if (msg.id !== 1) continue;
+        if (msg.result && typeof msg.result === "object") {
+          const info = (msg.result as { serverInfo?: { name?: string } }).serverInfo;
+          finish({
+            valid: true,
+            detail: info?.name
+              ? `Connected — ${info.name} is responding.`
+              : "Connected — the server is responding.",
+          });
+          return;
+        }
+        if (msg.error) {
+          const em = (msg.error as { message?: string }).message;
+          finish({ valid: false, detail: em ? `Server error: ${em}` : "The server rejected the connection." });
+          return;
+        }
+      }
+    };
+
+    proc.stdout?.on("data", (b: Buffer) => {
+      stdout += b.toString();
+      scanForReply();
+    });
+    proc.stderr?.on("data", (b: Buffer) => {
+      stderr += b.toString();
+    });
+    proc.on("error", (err) => finish({ valid: false, detail: err.message }));
+    proc.on("exit", () => {
+      // Exited before answering initialize → startup/connection failure. The
+      // last stderr line is the exception (e.g. "... Network policy is required").
+      finish({
+        valid: false,
+        detail:
+          lastMeaningfulLine(stderr) ||
+          "The server exited before completing the connection.",
+      });
+    });
+
+    try {
+      proc.stdin?.write(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2024-11-05",
+            capabilities: {},
+            clientInfo: { name: "cabinet-probe", version: "1.0.0" },
+          },
+        }) + "\n",
+      );
+      proc.stdin?.write(
+        JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }) + "\n",
+      );
+    } catch {
+      finish({ valid: false, detail: "Could not talk to the server over stdio." });
+    }
+  });
+}

--- a/src/lib/agents/stdio-mcp-probe.ts
+++ b/src/lib/agents/stdio-mcp-probe.ts
@@ -142,13 +142,20 @@ export async function probeStdioMcp(
     }
   }
 
-  // Redact any pasted secret that happens to echo back in server output.
+  // Redact any secret that could echo back in server output. Cover both the
+  // just-typed creds AND the values buildEnv actually injected for secret-kind
+  // credentials — the latter may come from saved .cabinet.env, not this request.
+  const secretValues = [
+    ...entry.credentials
+      .filter((c) => c.kind === "secret")
+      .map((c) => env[c.envKey]),
+    ...Object.values(credsOverride),
+  ]
+    .map((v) => (typeof v === "string" ? v.trim() : ""))
+    .filter((v) => v.length >= 6);
   const scrub = (s: string): string => {
     let out = s;
-    for (const v of Object.values(credsOverride)) {
-      const t = typeof v === "string" ? v.trim() : "";
-      if (t.length >= 6) out = out.split(t).join("<redacted>");
-    }
+    for (const v of secretValues) out = out.split(v).join("<redacted>");
     return out;
   };
 

--- a/src/lib/integrations/preview-catalog.ts
+++ b/src/lib/integrations/preview-catalog.ts
@@ -578,10 +578,10 @@ const RAW_INTEGRATIONS: IntegrationItem[] = [
     name: "Snowflake",
     category: "data",
     logo: L("snowflake.webp"),
-    blurb: "Query your warehouse in natural language.",
+    blurb: "Query your warehouse and Cortex AI in natural language.",
     brand: "#29b5e8",
-    implemented: false,
-    actions: ["Run queries", "Summarise tables", "Build reports"],
+    implemented: true,
+    actions: ["Run queries", "Explore schemas", "Query Cortex & semantic views"],
   },
   {
     id: "bigquery",
@@ -715,6 +715,7 @@ const LAUNCHED = new Set([
   "microsoft-teams",
   "notion",
   "slack",
+  "snowflake",
 ]);
 
 export const PREVIEW_INTEGRATIONS: IntegrationItem[] = RAW_INTEGRATIONS.map((i) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added time-boxed credential validation for MCP connections, including an optional “stdio” probe for supported local STDIO servers.
  * Introduced support for integrations that reference a static on-disk config file during setup.
  * Updated Snowflake to a local, token-auth STDIO integration with revised configuration and setup guidance (including default read-only permissions).
* **Bug Fixes**
  * Improved connection validation outcomes with clearer details while redacting sensitive information.
  * Updated Snowflake’s preview status so it’s connectable from the catalog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->