### PR TITLE
fix(editor): avoid flushSync-in-lifecycle warning by keeping EditorContent mounted

### DIFF
--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -664,7 +664,7 @@ export function KBEditor() {
           </button>
         </div>
       )}
-      {onFilesTab ? (
+      {onFilesTab && (
         <div className="flex-1 overflow-y-auto">
           <div className="max-w-3xl mx-auto px-6 py-6">
             <FolderIndex
@@ -674,8 +674,13 @@ export function KBEditor() {
             />
           </div>
         </div>
-      ) : (
-      <>
+      )}
+      {/* Editor + toolbar stay MOUNTED on the Files tab / in source mode —
+          hidden via CSS, never unmounted. Unmounting made Tiptap re-run
+          createNodeViews() on the next mount, which flushSyncs a React node
+          view (e.g. a mermaid diagram) inside componentDidMount → React's
+          "flushSync was called from inside a lifecycle method" warning. */}
+      <div className={onFilesTab ? "hidden" : "flex-1 flex flex-col overflow-hidden"}>
       <EditorToolbar
         editor={editor}
         sourceMode={sourceMode}
@@ -684,7 +689,7 @@ export function KBEditor() {
         onToggleWide={toggleWideMode}
       />
 
-      {sourceMode ? (
+      {sourceMode && (
         <div className="flex-1 overflow-y-auto p-4" dir={isRtl ? "rtl" : undefined}>
           <textarea
             value={sourceText}
@@ -693,9 +698,9 @@ export function KBEditor() {
             spellCheck={false}
           />
         </div>
-      ) : (
+      )}
         <div
-          className="flex-1 relative"
+          className={sourceMode ? "hidden" : "flex-1 relative"}
           dir={isRtl ? "rtl" : undefined}
           style={{ "--editor-max-w": wideMode ? "none" : "48rem" } as React.CSSProperties}
         >
@@ -738,7 +743,6 @@ export function KBEditor() {
             </div>
           )}
         </div>
-      )}
 
       {/* Status bar */}
       <div className="flex items-center justify-between px-4 py-1 border-t border-border text-xs text-muted-foreground/60">
@@ -758,8 +762,7 @@ export function KBEditor() {
           {saveStatus === "error" && "Save failed"}
         </span>
       </div>
-      </>
-      )}
+      </div>
 
     </div>
   );


### PR DESCRIPTION
## Problem
Opening a page with a ```mermaid block and toggling **Source** mode or the **Files** tab logged a React error (surfaced by Next.js's dev overlay):

> flushSync was called from inside a lifecycle method. React cannot flush when React is already rendering.

## Root cause
Mermaid is the editor's first **content** React node view (embed/latex/image are `atom: true`). `@tiptap/react`'s `EditorContent` runs `editor.createNodeViews()` inside `componentDidMount`; constructing a React node view there calls `flushSync` (ReactRenderer constructor) — i.e. flushSync inside a lifecycle. It only bites when the doc already holds a node view at (re)mount time, which happened because toggling source mode / the Files tab **unmounted** `<EditorContent>` and remounted it with content present.

## Fix
Keep `<EditorContent>` (and the toolbar) mounted on those toggles, hidden via CSS, instead of unmounting. TipTap keeps its node views alive, so `createNodeViews()` never re-runs in a lifecycle. Behavior is unchanged.

Verified via static trace + typecheck (not a live repro — see commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the editor experience when switching between the Files tab and source mode.
  * The editor and toolbar now stay mounted, helping preserve state and avoid visual resets when changing views.
  * Updated the layout so the active editing area is shown or hidden more smoothly, with loading and status elements remaining in the correct place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->