### PR TITLE
fix(agents): unify agent spawn cwd resolution, fix scheduled ENOENT (#178)

### DIFF
--- a/scripts/migrate-rooms-v3.mjs
+++ b/scripts/migrate-rooms-v3.mjs
@@ -65,7 +65,62 @@ function move(src, dst) {
   fs.renameSync(src, dst);
 }
 
+// Find every `.agents` dir under DATA_DIR (rooms can nest, e.g. dragonstone/home).
+function findAgentsDirs(dir, out = []) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    if (!e.isDirectory()) continue;
+    if (e.name === ".agents") {
+      out.push(path.join(dir, e.name));
+      continue; // don't descend into an .agents dir; it holds slugs, not rooms
+    }
+    if (e.name === "node_modules" || e.name === ".git") continue;
+    findAgentsDirs(path.join(dir, e.name), out);
+  }
+  return out;
+}
+
+// Reset a persona's `workdir` to /data when it names a subfolder that doesn't
+// exist inside the agent's room — the flat→Rooms move left cabinetPath already
+// pointing at the (sub)room while workdir still held the old `/subfolder`, so the
+// scheduled spawn cwd double-joined into a missing dir (#178). Idempotent:
+// a legit subfolder that DOES exist, or a value already /data, is left alone.
+function backfillWorkdirs(root) {
+  let fixed = 0;
+  for (const agentsDir of findAgentsDirs(root)) {
+    const roomDir = path.dirname(agentsDir);
+    for (const slug of fs.readdirSync(agentsDir)) {
+      const file = path.join(agentsDir, slug, "persona.md");
+      if (!fs.existsSync(file)) continue;
+      const raw = fs.readFileSync(file, "utf-8");
+      const fm = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+      if (!fm) continue;
+      const wdLine = fm[1].match(/^(\s*workdir:\s*)(.+?)\s*$/m);
+      if (!wdLine) continue;
+      const value = wdLine[2].replace(/^["']|["']$/g, "").trim();
+      const sub = value.replace(/^\/+/, "");
+      if (!sub || sub === "data") continue; // already room-root
+      if (fs.existsSync(path.join(roomDir, sub))) continue; // real subfolder — keep
+      const patchedFm = fm[1].replace(wdLine[0], `${wdLine[1]}/data`);
+      fs.writeFileSync(file, raw.replace(fm[1], patchedFm), "utf-8");
+      log(`workdir ${value} -> /data for ${path.relative(root, file)}`);
+      fixed++;
+    }
+  }
+  if (fixed) log(`backfilled ${fixed} stale workdir(s).`);
+}
+
 function main() {
+  // Runs on EVERY invocation, before the home-marker short-circuit, so installs
+  // that already migrated (and never re-run the rest of this script) still get
+  // their stale workdirs cleaned when they re-run it.
+  backfillWorkdirs(DATA_DIR);
+
   const homeMarker = path.join(DATA_DIR, ".home", "home.json");
   if (fs.existsSync(homeMarker)) {
     log("already migrated (data/.home/home.json present) — no-op.");

--- a/src/lib/agents/conversation-runner.ts
+++ b/src/lib/agents/conversation-runner.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "crypto";
 import type { JobConfig, JobRun, JobPostAction } from "@/types/jobs";
 import type { ConversationMeta } from "@/types/conversations";
 import { readPage } from "../storage/page-io";
-import { DATA_DIR } from "../storage/path-utils";
+import { DATA_DIR, resolveAgentCwd } from "../storage/path-utils";
 import {
   defaultAdapterTypeForProvider,
   resolveExecutionProviderId,
@@ -420,10 +420,7 @@ export async function buildManualConversationPrompt(input: {
   const persona = await readPersona(input.agentSlug, input.cabinetPath);
   const mentionContext = await buildMentionContext(input.mentionedPaths || []);
   const baseCwd = input.cabinetPath ? path.join(DATA_DIR, input.cabinetPath) : DATA_DIR;
-  const cwd =
-    persona?.workdir && persona.workdir !== "/data"
-      ? `${DATA_DIR}/${persona.workdir.replace(/^\/+/, "")}`
-      : baseCwd;
+  const cwd = resolveAgentCwd(input.cabinetPath, persona?.workdir);
 
   // Merge persona's persisted skills with @-mentioned skills so the skill
   // index in the prompt matches the set the runner mounts via --add-dir.
@@ -508,10 +505,7 @@ export async function buildEditorConversationPrompt(input: {
   );
   const mentionContext = await buildMentionContext(combinedMentionedPaths);
   const baseCwd = input.cabinetPath ? path.join(DATA_DIR, input.cabinetPath) : DATA_DIR;
-  const cwd =
-    persona?.workdir && persona.workdir !== "/data"
-      ? `${DATA_DIR}/${persona.workdir.replace(/^\/+/, "")}`
-      : baseCwd;
+  const cwd = resolveAgentCwd(input.cabinetPath, persona?.workdir);
 
   const mergedSkillKeys = Array.from(
     new Set([...(persona?.skills ?? []), ...(input.mentionedSkills ?? [])]),
@@ -1012,12 +1006,13 @@ export async function startJobConversation(
   const defaultProviderId = getDefaultProviderId();
   const jobPrompt = substituteTemplateVars(job.prompt, job);
   const baseCwd = job.cabinetPath ? path.join(DATA_DIR, job.cabinetPath) : DATA_DIR;
-  const cwd =
+  // A job overrides cwd only when it names a non-root workdir; otherwise the
+  // persona's workdir wins (preserved from the original precedence).
+  const effectiveWorkdir =
     job.workdir && job.workdir !== "/data" && job.workdir !== "/"
-      ? path.join(baseCwd, job.workdir.replace(/^\/+/, ""))
-      : persona?.workdir && persona.workdir !== "/data" && persona.workdir !== "/"
-        ? path.join(baseCwd, persona.workdir.replace(/^\/+/, ""))
-        : baseCwd;
+      ? job.workdir
+      : persona?.workdir;
+  const cwd = resolveAgentCwd(job.cabinetPath, effectiveWorkdir);
 
   const prompt = [
     buildCabinetRequirementHeader(),
@@ -1528,10 +1523,7 @@ export async function continueConversationRun(
       ? await readPersona(meta.agentSlug, cp)
       : null;
     const legacyBaseCwd = cp ? path.join(DATA_DIR, cp) : DATA_DIR;
-    const legacyCwd =
-      legacyPersona?.workdir && legacyPersona.workdir !== "/data"
-        ? `${DATA_DIR}/${legacyPersona.workdir.replace(/^\/+/, "")}`
-        : legacyBaseCwd;
+    const legacyCwd = resolveAgentCwd(cp, legacyPersona?.workdir);
 
     // 1. Try same-process continue: stdin-inject into the existing PTY.
     const alive = await isDaemonSessionAlive(conversationId);
@@ -1650,10 +1642,7 @@ export async function continueConversationRun(
     ? await readPersona(meta.agentSlug, cp)
     : null;
   const baseCwd = cp ? path.join(DATA_DIR, cp) : DATA_DIR;
-  const cwd =
-    persona?.workdir && persona.workdir !== "/data"
-      ? `${DATA_DIR}/${persona.workdir.replace(/^\/+/, "")}`
-      : baseCwd;
+  const cwd = resolveAgentCwd(cp, persona?.workdir);
 
   // 4b. Re-mount skills for this turn so newly @-mentioned skills get
   // registered with the CLI. Each structured-adapter continuation is a fresh

--- a/src/lib/agents/heartbeat.ts
+++ b/src/lib/agents/heartbeat.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import { DATA_DIR } from "@/lib/storage/path-utils";
+import { DATA_DIR, resolveAgentCwd } from "@/lib/storage/path-utils";
 import {
   readPersona,
   readMemory,
@@ -179,10 +179,7 @@ If you did not create or modify any file this heartbeat, still emit exactly one 
 
 Now execute your heartbeat. Check your focus areas, process inbox, review goals, and take action.`;
 
-  const baseCwd = cabinetPath ? path.join(DATA_DIR, cabinetPath) : DATA_DIR;
-  const cwd = persona.workdir === "/data" || persona.workdir === "/"
-    ? baseCwd
-    : path.join(baseCwd, persona.workdir.replace(/^\/+/, ""));
+  const cwd = resolveAgentCwd(cabinetPath, persona.workdir);
   return { prompt, persona, inbox, cwd, startTime };
 }
 

--- a/src/lib/storage/path-utils.test.ts
+++ b/src/lib/storage/path-utils.test.ts
@@ -1,0 +1,40 @@
+import test, { before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+let tempRoot: string;
+let mod: typeof import("./path-utils");
+
+before(async () => {
+  tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cabinet-path-utils-test-"));
+  process.env.CABINET_DATA_DIR = tempRoot;
+  // A room with one real subfolder; the stale "/home" subfolder is absent.
+  await fs.mkdir(path.join(tempRoot, "dragonstone", "home", "reports"), { recursive: true });
+  mod = await import("./path-utils");
+});
+
+after(async () => {
+  if (tempRoot) await fs.rm(tempRoot, { recursive: true, force: true });
+});
+
+test("resolveAgentCwd resolves workdir relative to the room, with a stale-workdir fallback", () => {
+  const { resolveAgentCwd, DATA_DIR } = mod;
+  const room = path.join(DATA_DIR, "dragonstone/home");
+
+  // Root workdir values → the room folder itself.
+  assert.equal(resolveAgentCwd("dragonstone/home", "/data"), room);
+  assert.equal(resolveAgentCwd("dragonstone/home", "/"), room);
+  assert.equal(resolveAgentCwd("dragonstone/home", undefined), room);
+
+  // A real subfolder inside the room → scoped into it.
+  assert.equal(resolveAgentCwd("dragonstone/home", "/reports"), path.join(room, "reports"));
+
+  // Stale pre-Rooms workdir (#178): the double-joined dir doesn't exist, so
+  // fall back to the room root instead of a missing cwd (the ENOENT bug).
+  assert.equal(resolveAgentCwd("dragonstone/home", "/home"), room);
+
+  // No cabinet → DATA_DIR root.
+  assert.equal(resolveAgentCwd(undefined, "/data"), DATA_DIR);
+});

--- a/src/lib/storage/path-utils.ts
+++ b/src/lib/storage/path-utils.ts
@@ -1,3 +1,4 @@
+import fs from "fs";
 import path from "path";
 import { getManagedDataDir, isElectronRuntime, PROJECT_ROOT } from "@/lib/runtime/runtime-config";
 import { normalizeVirtualPath } from "@/lib/virtual-paths";
@@ -12,6 +13,28 @@ export const FILE_SCHEMA_STATE_PATH = path.join(CABINET_INTERNAL_DIR, "file-sche
 export const BACKUP_ROOT = isElectronRuntime()
   ? path.join(path.dirname(DATA_DIR), "cabinet-backups")
   : path.resolve(PROJECT_ROOT, "..", ".cabinet-backups", path.basename(PROJECT_ROOT));
+
+/**
+ * Single source of truth for an agent's spawn cwd (#178). `workdir` is a
+ * persona/job value: "/data" or "/" (the room root), or "/subfolder" (a folder
+ * inside the room). It is ALWAYS resolved relative to the room (cabinetPath),
+ * never relative to DATA_DIR — six hand-rolled copies of this disagreed (some
+ * over-joined cabinetPath+workdir, some dropped cabinetPath), so scheduled runs
+ * failed for pre-Rooms migrated agents while manual Retry worked.
+ */
+export function resolveAgentCwd(cabinetPath?: string, workdir?: string): string {
+  const baseCwd = cabinetPath ? path.join(DATA_DIR, cabinetPath) : DATA_DIR;
+  const sub = (workdir ?? "").replace(/^\/+/, "");
+  if (!sub || sub === "data") return baseCwd;
+  const scoped = path.join(baseCwd, sub);
+  // ponytail: a stale pre-Rooms workdir (cabinetPath already ends in the
+  // subfolder) makes `scoped` a doubled, non-existent path — spawning there
+  // yields ENOENT that gets mislabeled cli_not_found. Fall back to the room
+  // root rather than into a missing cwd; the migration backfills the data so
+  // this rarely fires. Upgrade path if workdirs ever legitimately point at a
+  // not-yet-created folder: mkdir it here instead of falling back.
+  return fs.existsSync(scoped) ? scoped : baseCwd;
+}
 
 export function resolveContentPath(virtualPath: string): string {
   const dataDir = path.resolve(DATA_DIR);


### PR DESCRIPTION
Fixes #178.

## Root cause
Six hand-rolled cwd resolvers disagreed. Scheduled paths (`heartbeat.ts`, `startJobConversation`) did `path.join(baseCwd, workdir)` — for a pre-Rooms agent where `cabinetPath` already encoded the sub-room (`dragonstone/home`) and `workdir` still held the flat-layout `/home`, this double-joined to `<DATA_DIR>/dragonstone/home/home`, which doesn't exist → `posix_spawn` ENOENT → mislabeled `cli_not_found` ("reinstall the CLI"). The interactive paths did `DATA_DIR + workdir` (dropping the room), which is why manual Retry always worked.

## Fix
- **`resolveAgentCwd(cabinetPath, workdir)`** in `path-utils` — one room-relative resolver with an existence fallback to the room root, so a stale/doubled workdir never spawns into a missing cwd. Self-heals affected installs at runtime (no re-migration needed).
- All six sites routed through it (`heartbeat.ts`, `conversation-runner.ts` ×5; job→persona workdir precedence preserved).
- **`migrate-rooms-v3.mjs`** — `backfillWorkdirs()` resets stale subfolder workdirs → `/data`, running *before* the home-marker short-circuit so already-migrated installs clean up on re-run.

## Verification
- New `path-utils.test.ts`: root values, real subfolder, stale fallback, no-cabinet.
- `tsc --noEmit` 0 errors · eslint clean.
- Migration smoke test: rewrites the stale case, keeps a real `/reports` and an existing `/data`.

## Not included
The error-classifier still maps any ENOENT → `cli_not_found`. The resolver removes the crash here so it no longer misfires, but stat-ing the cwd before that label (issue's suggested fix #2) is a separate latent bug left for a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how agent working directories are resolved, so jobs and conversations now start in the correct place more consistently.
  * Fixed stale or missing work directory paths to safely fall back to an available location instead of failing or pointing to a non-existent folder.
  * Existing installations are now automatically corrected for outdated workspace paths during migration.

* **Tests**
  * Added coverage for working directory resolution across root paths, subfolders, and fallback cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->