### PR TITLE
fix(desktop): make macOS window draggable from every top bar

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1014,14 +1014,28 @@ em-emoji-picker {
 
 .source-viewer-code .hljs-symbol { color: #b5cea8; }
 
-/* Electron macOS: hidden title bar drag region + traffic light clearance */
-.electron-desktop header {
+/* Electron macOS: hidden title bar drag region + traffic light clearance.
+   titleBarStyle "hiddenInset" removes the native title bar, so the window can
+   only be moved by CSS drag regions. Every top bar is a drag handle:
+     • <header>        — dashboard, tasks, agents, task conversation, etc.
+     • .viewer-toolbar — the editor + all file viewers (a <div>, not a header)
+     • .sidebar-header — the one bar present in every view, under the lights
+   Interactive controls opt back out (below) so they stay clickable. */
+.electron-desktop header,
+.electron-desktop .viewer-toolbar,
+.electron-desktop .sidebar-header {
   -webkit-app-region: drag;
 }
-.electron-desktop header button,
-.electron-desktop header a,
-.electron-desktop header input,
-.electron-desktop header [role="button"] {
+/* Any interactive control opts out of dragging so clicks/typing still work.
+   Scoped app-wide (not per-bar): no-drag is a harmless no-op outside a drag
+   region, and this keeps future drag handles working without re-listing. */
+.electron-desktop button,
+.electron-desktop a,
+.electron-desktop input,
+.electron-desktop select,
+.electron-desktop textarea,
+.electron-desktop [role="button"],
+.electron-desktop [contenteditable="true"] {
   -webkit-app-region: no-drag;
 }
 /* The macOS traffic lights sit at the window's *physical* top-left

--- a/src/components/layout/viewer-toolbar.tsx
+++ b/src/components/layout/viewer-toolbar.tsx
@@ -105,7 +105,11 @@ export function ViewerToolbar({
   return (
     <div
       className={cn(
-        "flex shrink-0 items-center justify-between gap-x-3 gap-y-2 px-3 py-1.5 transition-[padding] duration-200 md:h-10 md:py-0",
+        // `viewer-toolbar` is the stable hook the Electron macOS drag-region
+        // CSS targets (globals.css) — this bar is a <div>, not a <header>, so
+        // without the class the hidden-title-bar window can't be dragged from
+        // the editor or any file viewer built on ViewerToolbar.
+        "viewer-toolbar flex shrink-0 items-center justify-between gap-x-3 gap-y-2 px-3 py-1.5 transition-[padding] duration-200 md:h-10 md:py-0",
         className
       )}
       style={{ paddingInlineStart: `calc(1rem + var(--sidebar-toggle-offset, 0px))` }}


### PR DESCRIPTION
Fix to https://github.com/cabinetai/cabinet/issues/75