### PR TITLE
fix(pi): read available models correctly from `pi --list-models`

### DIFF
--- a/src/lib/agents/adapters/pi-local.test.ts
+++ b/src/lib/agents/adapters/pi-local.test.ts
@@ -72,19 +72,19 @@ test("pi session codec round-trips session file path", () => {
   assert.equal(codec.getDisplayId?.({ sessionFile: "/tmp/pi/session-1.json" }), "session-1");
 });
 
-test("piLocalAdapter heals a stale table-row model id into clean --provider/--model args", async () => {
+test("piLocalAdapter repairs a stale table-row model id into clean --provider/--model args", async () => {
   const scriptPath = await createExecutableScript(`#!/bin/sh
 printf '%s\\n' '{"type":"agent_start"}' '{"type":"agent_end"}'
 `);
 
   let capturedArgs: string[] | null = null;
   const result = await piLocalAdapter.execute?.({
-    runId: "run-pi-heal",
+    runId: "run-pi-repair",
     adapterType: "pi_local",
     config: {
       command: scriptPath,
       // Stale value persisted before the parser fix: the whole `pi --list-models`
-      // table row. After healing it must become tfm/glm/glm-5.2.
+      // table row. After repair it must become tfm/glm/glm-5.2.
       model:
         "tfm       glm/glm-5.2                                 128K     16.4K    no        no",
       thinking: "off",
@@ -101,7 +101,7 @@ printf '%s\\n' '{"type":"agent_start"}' '{"type":"agent_end"}'
 
   assert.ok(result, "expected a result");
   assert.ok(capturedArgs, "expected onMeta to capture commandArgs");
-  // The healed id tfm/glm/glm-5.2 splits into --provider tfm --model glm/glm-5.2.
+  // The repaired id tfm/glm/glm-5.2 splits into --provider tfm --model glm/glm-5.2.
   // The table stat columns (128K, 16.4K, "no        no") must NOT appear anywhere.
   const args: string[] = capturedArgs;
   const modelIdx = args.indexOf("--model");

--- a/src/lib/agents/adapters/pi-local.test.ts
+++ b/src/lib/agents/adapters/pi-local.test.ts
@@ -71,3 +71,45 @@ test("pi session codec round-trips session file path", () => {
   assert.equal(codec.deserialize({ sessionFile: "" }), null);
   assert.equal(codec.getDisplayId?.({ sessionFile: "/tmp/pi/session-1.json" }), "session-1");
 });
+
+test("piLocalAdapter heals a stale table-row model id into clean --provider/--model args", async () => {
+  const scriptPath = await createExecutableScript(`#!/bin/sh
+printf '%s\\n' '{"type":"agent_start"}' '{"type":"agent_end"}'
+`);
+
+  let capturedArgs: string[] | null = null;
+  const result = await piLocalAdapter.execute?.({
+    runId: "run-pi-heal",
+    adapterType: "pi_local",
+    config: {
+      command: scriptPath,
+      // Stale value persisted before the parser fix: the whole `pi --list-models`
+      // table row. After healing it must become tfm/glm/glm-5.2.
+      model:
+        "tfm       glm/glm-5.2                                 128K     16.4K    no        no",
+      thinking: "off",
+    },
+    prompt: "Reply OK",
+    cwd: process.cwd(),
+    onLog: async () => {},
+    onMeta: async (meta) => {
+      if (meta && typeof meta === "object" && "commandArgs" in meta) {
+        capturedArgs = (meta as { commandArgs: string[] }).commandArgs;
+      }
+    },
+  });
+
+  assert.ok(result, "expected a result");
+  assert.ok(capturedArgs, "expected onMeta to capture commandArgs");
+  // The healed id tfm/glm/glm-5.2 splits into --provider tfm --model glm/glm-5.2.
+  // The table stat columns (128K, 16.4K, "no        no") must NOT appear anywhere.
+  const args: string[] = capturedArgs;
+  const modelIdx = args.indexOf("--model");
+  const providerIdx = args.indexOf("--provider");
+  assert.ok(modelIdx !== -1, "expected --model in args");
+  assert.ok(providerIdx !== -1, "expected --provider in args");
+  assert.equal(args[modelIdx + 1], "glm/glm-5.2");
+  assert.equal(args[providerIdx + 1], "tfm");
+  const leaked = args.some((a: string) => /128K|16\.4K|images/.test(a));
+  assert.ok(!leaked, `table stat columns leaked into args: ${JSON.stringify(args)}`);
+});

--- a/src/lib/agents/adapters/pi-local.ts
+++ b/src/lib/agents/adapters/pi-local.ts
@@ -70,10 +70,10 @@ function buildPiArgs(
 
   const modelInput = readStringConfig(config, "model");
   if (modelInput) {
-    // Heal a stale persisted table-row model id back to <provider>/<model>.
-    const healed = normalizePiModelId(modelInput) ?? modelInput;
+    // Repair a stale persisted table-row model id back to <provider>/<model>.
+    const repaired = normalizePiModelId(modelInput) ?? modelInput;
     const explicitProvider = readStringConfig(config, "provider");
-    const { provider, model } = splitProviderModel(healed);
+    const { provider, model } = splitProviderModel(repaired);
     const effectiveProvider = explicitProvider || provider;
     if (effectiveProvider) args.push("--provider", effectiveProvider);
     if (model) args.push("--model", model);

--- a/src/lib/agents/adapters/pi-local.ts
+++ b/src/lib/agents/adapters/pi-local.ts
@@ -70,11 +70,7 @@ function buildPiArgs(
 
   const modelInput = readStringConfig(config, "model");
   if (modelInput) {
-    // Heal stale persisted table-row values before splitting. A pre-fix
-    // selection could store an entire `pi --list-models` row as the model id;
-    // normalizePiModelId collapses it back to <provider>/<model>. Clean ids
-    // pass through untouched. This is Pi-internal — callers hand us a model
-    // id and get clean args back, exactly like any other provider.
+    // Heal a stale persisted table-row model id back to <provider>/<model>.
     const healed = normalizePiModelId(modelInput) ?? modelInput;
     const explicitProvider = readStringConfig(config, "provider");
     const { provider, model } = splitProviderModel(healed);

--- a/src/lib/agents/adapters/pi-local.ts
+++ b/src/lib/agents/adapters/pi-local.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { piProvider } from "../providers/pi";
+import { piProvider, normalizePiModelId } from "../providers/pi";
 import { resolveCliCommand } from "../provider-cli";
 import { providerStatusToEnvironmentTest } from "./environment";
 import {
@@ -70,8 +70,14 @@ function buildPiArgs(
 
   const modelInput = readStringConfig(config, "model");
   if (modelInput) {
+    // Heal stale persisted table-row values before splitting. A pre-fix
+    // selection could store an entire `pi --list-models` row as the model id;
+    // normalizePiModelId collapses it back to <provider>/<model>. Clean ids
+    // pass through untouched. This is Pi-internal — callers hand us a model
+    // id and get clean args back, exactly like any other provider.
+    const healed = normalizePiModelId(modelInput) ?? modelInput;
     const explicitProvider = readStringConfig(config, "provider");
-    const { provider, model } = splitProviderModel(modelInput);
+    const { provider, model } = splitProviderModel(healed);
     const effectiveProvider = explicitProvider || provider;
     if (effectiveProvider) args.push("--provider", effectiveProvider);
     if (model) args.push("--model", model);

--- a/src/lib/agents/providers/pi.ts
+++ b/src/lib/agents/providers/pi.ts
@@ -91,8 +91,8 @@ function modelIdFromLine(line: string): string | null {
 }
 
 /**
- * Heal a stored Pi model id using the same line parser as the model list, so
- * parsing and healing can never drift.
+ * Repair a stored Pi model id using the same line parser as the model list, so
+ * parsing and repair can never drift.
  *
  * Pi shipped a parser (v0.5.0) that could persist an entire `pi --list-models`
  * table row as the model id (e.g. `tfm   glm/glm-5.2   128K  …  no`), breaking
@@ -100,11 +100,12 @@ function modelIdFromLine(line: string): string | null {
  * `modelIdFromLine` collapses them back to `<provider>/<model>` on read — no
  * data migration.
  *
- * Contract: a stale table row heals to `<provider>/<model>`; an already-clean
- * id (including a provider-less bare id like `grok-4.3`, used with a separate
- * `provider`) is returned untouched; empty input and the header row return
- * `undefined`. A clean id only reaches `modelIdFromLine` as a lone token, which
- * drops slash-less ids to `null`, so those are restored from `trimmed` here.
+ * Contract: a stale table row is repaired to `<provider>/<model>`; an
+ * already-clean id (including a provider-less bare id like `grok-4.3`, used
+ * with a separate `provider`) is returned untouched; empty input and the
+ * header row return `undefined`. A clean id only reaches `modelIdFromLine` as a
+ * lone token, which drops slash-less ids to `null`, so those are restored from
+ * `trimmed` here.
  */
 export function normalizePiModelId(
   raw: string | null | undefined
@@ -170,9 +171,9 @@ export const piProvider: AgentProvider = {
     const baseArgs = this.buildArgs ? this.buildArgs(prompt, workdir) : [];
     const args = [...baseArgs];
     if (opts?.model) {
-      // Heal stale persisted table-row values before interpolating into --model.
-      const healed = normalizePiModelId(opts.model) ?? opts.model;
-      args.push("--model", healed);
+      // Repair a stale persisted table-row value before interpolating into --model.
+      const repaired = normalizePiModelId(opts.model) ?? opts.model;
+      args.push("--model", repaired);
     }
     if (opts?.effort) {
       args.push("--thinking", opts.effort);
@@ -187,9 +188,9 @@ export const piProvider: AgentProvider = {
     // Mirrors the install step (`pi --mode json -p 'Reply with exactly OK'`)
     // but pins the resolved default model so verification exercises the
     // user's actual path, not Pi's internal default.
-    const healed =
+    const repaired =
       defaultModel && (normalizePiModelId(defaultModel) ?? defaultModel);
-    const modelArg = healed ? ` --model '${healed}'` : "";
+    const modelArg = repaired ? ` --model '${repaired}'` : "";
     return `pi --mode json${modelArg} -p 'Reply with exactly OK'`;
   },
 

--- a/src/lib/agents/providers/pi.ts
+++ b/src/lib/agents/providers/pi.ts
@@ -35,10 +35,28 @@ function withThinkingLevels<T extends { id: string; name: string }>(
 
 /**
  * Pure parser for `pi --list-models` stdout. Pi routes to whatever providers
- * the user has keyed, so this list is per-machine. Blank lines and `#`
- * comments/banners are dropped; if nothing survives (empty output, or output
- * that is *only* a banner) we fall back to the offline list so the picker is
- * never blank — the same hardening applied to OpenCode (§11 #22).
+ * the user has keyed, so this list is per-machine.
+ *
+ * `pi --list-models` emits a whitespace-columned table, e.g.:
+ *
+ *   provider  model                              context  max-out  thinking  images
+ *   tfm       glm/glm-5.2                        128K     16.4K    no        no
+ *   tfm       kai/nvidia/nemotron-3-super-…:free 128K     16.4K    no        no
+ *
+ * Columns are separated by runs of 2+ spaces. The model id Pi expects is
+ * `<provider>/<model>` (e.g. `tfm/glm/glm-5.2`); `splitProviderModel` later
+ * splits on the first `/` into `--provider tfm --model glm/glm-5.2`. The model
+ * column need not contain a `/` (e.g. `xai  grok-4.3` → `xai/grok-4.3`). The
+ * header row is identified by its `provider`/`model` labels and dropped.
+ *
+ * For robustness we also keep the legacy single-bare-id-per-line shape
+ * (`vendor/model` with no internal runs of spaces) so older Pi CLIs and the
+ * offline fallback path still parse.
+ *
+ * Blank lines and `#` comments/banners are dropped; if nothing survives (empty
+ * output, output that is *only* a banner, or output with no recognizable
+ * model rows) we fall back to the offline list so the picker is never blank —
+ * the same hardening applied to OpenCode (§11 #22).
  */
 export function parsePiModels(stdout: string | null | undefined) {
   const out = (stdout || "").trim();
@@ -47,12 +65,92 @@ export function parsePiModels(stdout: string | null | undefined) {
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter((line) => line && !line.startsWith("#"))
+    .map((line) => modelIdFromLine(line))
+    .filter((id): id is string => Boolean(id))
     .map((id) => ({
       id,
       name: id,
       effortLevels: [...PI_THINKING_LEVELS],
     }));
   return parsed.length > 0 ? parsed : withThinkingLevels(PI_FALLBACK_MODELS);
+}
+
+/**
+ * The `pi --list-models` table's header row, identified explicitly by its first
+ * two column labels rather than by the (unreliable) absence of a `/`. Pi
+ * providers/models with plain slugs would otherwise be mistaken for a header.
+ */
+function isPiTableHeader(tokens: string[]): boolean {
+  return (
+    tokens.length >= 2 &&
+    tokens[0].toLowerCase() === "provider" &&
+    tokens[1].toLowerCase() === "model"
+  );
+}
+
+/**
+ * Extract a Pi model id from one non-empty `--list-models` line.
+ *
+ * - Header row (`provider  model  context  …`): dropped.
+ * - col0 already a full id (contains `/`): return col0 verbatim, dropping any
+ *   trailing stat columns — e.g. `glm/glm-5.2  128K  no` → `glm/glm-5.2`.
+ * - Table row (≥2 tokens, col0 a bare provider slug): reconstruct as
+ *   `<col0 provider>/<col1 model>` → e.g. `tfm/glm/glm-5.2` or `xai/grok-4.3`.
+ *   The model column need NOT contain a `/`. Remaining columns are dropped.
+ * - Single token: legacy bare `vendor/model` id, returned when it has a `/`.
+ *
+ * Returns `null` for lines that yield no usable id (header rows, stray labels
+ * without a `/`).
+ */
+function modelIdFromLine(line: string): string | null {
+  const tokens = line.split(/ {2,}/).map((t) => t.trim()).filter(Boolean);
+  if (tokens.length === 0) return null;
+  if (isPiTableHeader(tokens)) return null;
+
+  // col0 is already a full `<provider>/<model>` id (provider slugs never carry
+  // a `/`). Trailing tokens are stat columns — drop them, don't weld them on.
+  if (tokens[0].includes("/")) return tokens[0];
+
+  // Table row: bare provider slug in col0, model in col1 (with or without an
+  // internal `/`), followed by stat columns.
+  if (tokens.length >= 2) return `${tokens[0]}/${tokens[1]}`;
+
+  // Single token: legacy bare `vendor/model` id (no internal multi-space run).
+  const id = tokens[0];
+  return id.includes("/") ? id : null;
+}
+
+/**
+ * Repair a stored Pi model id if — and only if — it looks like a
+ * `pi --list-models` table row.
+ *
+ * Before the parser fix, selecting a row (or the header row) could persist the
+ * *entire line* as the model id (e.g. `tfm       glm/glm-5.2  128K  …  no`),
+ * which then broke every path that interpolates it raw into `--model`. This
+ * collapses such stale values on read so they heal without a data migration.
+ *
+ * Pi-specific by construction: a Pi table row is the only model value that
+ * ever contains an internal run of 2+ spaces, so that is the sole trigger. The
+ * leading token is a Pi provider (`tfm`, `openai`, …), so a real row is
+ * reconstructed as `<pi-provider>/<model>` only when one of the first two
+ * columns carries a `/`.
+ *
+ *   tfm       glm/glm-5.2  128K  …  → tfm/glm/glm-5.2
+ *   glm/glm-5.2               128K  → glm/glm-5.2  (col0 already a full id)
+ *   provider  model  context  …     → undefined   (header row)
+ *   glm/glm-5.2                     → glm/glm-5.2  (already clean)
+ *
+ * Returns `undefined` for empty/whitespace input or an unrecoverable header row.
+ */
+export function normalizePiModelId(raw: string | null | undefined): string | undefined {
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed) return undefined;
+  // Only a Pi table row has an internal run of 2+ spaces. Anything else is
+  // already a clean id — return it untouched.
+  if (!/ {2,}/.test(trimmed)) return trimmed;
+  // Reuse the same row parser the model list uses, so healing and parsing stay
+  // in lockstep (slash-safe col0 handling, explicit header detection).
+  return modelIdFromLine(trimmed) ?? undefined;
 }
 
 export const piProvider: AgentProvider = {
@@ -107,7 +205,9 @@ export const piProvider: AgentProvider = {
     const baseArgs = this.buildArgs ? this.buildArgs(prompt, workdir) : [];
     const args = [...baseArgs];
     if (opts?.model) {
-      args.push("--model", opts.model);
+      // Heal stale persisted table-row values before interpolating into --model.
+      const healed = normalizePiModelId(opts.model) ?? opts.model;
+      args.push("--model", healed);
     }
     if (opts?.effort) {
       args.push("--thinking", opts.effort);
@@ -122,7 +222,9 @@ export const piProvider: AgentProvider = {
     // Mirrors the install step (`pi --mode json -p 'Reply with exactly OK'`)
     // but pins the resolved default model so verification exercises the
     // user's actual path, not Pi's internal default.
-    const modelArg = defaultModel ? ` --model '${defaultModel}'` : "";
+    const healed =
+      defaultModel && (normalizePiModelId(defaultModel) ?? defaultModel);
+    const modelArg = healed ? ` --model '${healed}'` : "";
     return `pi --mode json${modelArg} -p 'Reply with exactly OK'`;
   },
 

--- a/src/lib/agents/providers/pi.ts
+++ b/src/lib/agents/providers/pi.ts
@@ -37,26 +37,15 @@ function withThinkingLevels<T extends { id: string; name: string }>(
  * Pure parser for `pi --list-models` stdout. Pi routes to whatever providers
  * the user has keyed, so this list is per-machine.
  *
- * `pi --list-models` emits a whitespace-columned table, e.g.:
+ * The output is a whitespace-columned table (columns separated by runs of 2+
+ * spaces); `modelIdFromLine` turns each row into the `<provider>/<model>` id Pi
+ * expects. Blank lines, `#` banners and the header row are dropped; if nothing
+ * survives we fall back to the offline list so the picker is never blank — the
+ * same hardening applied to OpenCode (§11 #22).
  *
- *   provider  model                              context  max-out  thinking  images
- *   tfm       glm/glm-5.2                        128K     16.4K    no        no
- *   tfm       kai/nvidia/nemotron-3-super-…:free 128K     16.4K    no        no
- *
- * Columns are separated by runs of 2+ spaces. The model id Pi expects is
- * `<provider>/<model>` (e.g. `tfm/glm/glm-5.2`); `splitProviderModel` later
- * splits on the first `/` into `--provider tfm --model glm/glm-5.2`. The model
- * column need not contain a `/` (e.g. `xai  grok-4.3` → `xai/grok-4.3`). The
- * header row is identified by its `provider`/`model` labels and dropped.
- *
- * For robustness we also keep the legacy single-bare-id-per-line shape
- * (`vendor/model` with no internal runs of spaces) so older Pi CLIs and the
- * offline fallback path still parse.
- *
- * Blank lines and `#` comments/banners are dropped; if nothing survives (empty
- * output, output that is *only* a banner, or output with no recognizable
- * model rows) we fall back to the offline list so the picker is never blank —
- * the same hardening applied to OpenCode (§11 #22).
+ *   provider  model        context  …
+ *   tfm       glm/glm-5.2  128K     …   → tfm/glm/glm-5.2
+ *   openai    gpt-4        8.2K     …   → openai/gpt-4
  */
 export function parsePiModels(stdout: string | null | undefined) {
   const out = (stdout || "").trim();
@@ -76,81 +65,57 @@ export function parsePiModels(stdout: string | null | undefined) {
 }
 
 /**
- * The `pi --list-models` table's header row, identified explicitly by its first
- * two column labels rather than by the (unreliable) absence of a `/`. Pi
- * providers/models with plain slugs would otherwise be mistaken for a header.
- */
-function isPiTableHeader(tokens: string[]): boolean {
-  return (
-    tokens.length >= 2 &&
-    tokens[0].toLowerCase() === "provider" &&
-    tokens[1].toLowerCase() === "model"
-  );
-}
-
-/**
- * Extract a Pi model id from one non-empty `--list-models` line.
+ * Turn one `--list-models` line (or one stored model value) into a clean
+ * `<provider>/<model>` id, or `null` if the line yields no usable id.
  *
- * - Header row (`provider  model  context  …`): dropped.
- * - col0 already a full id (contains `/`): return col0 verbatim, dropping any
- *   trailing stat columns — e.g. `glm/glm-5.2  128K  no` → `glm/glm-5.2`.
- * - Table row (≥2 tokens, col0 a bare provider slug): reconstruct as
- *   `<col0 provider>/<col1 model>` → e.g. `tfm/glm/glm-5.2` or `xai/grok-4.3`.
- *   The model column need NOT contain a `/`. Remaining columns are dropped.
- * - Single token: legacy bare `vendor/model` id, returned when it has a `/`.
- *
- * Returns `null` for lines that yield no usable id (header rows, stray labels
- * without a `/`).
+ * Columns split on runs of 2+ spaces. The header (`provider  model  …`) is
+ * dropped. A col0 that already contains a `/` is a full id — return it and
+ * drop trailing stat columns rather than welding them on. Otherwise col0 is a
+ * bare provider and col1 the model (with or without its own `/`). A lone token
+ * is a legacy bare id, kept only when it contains a `/`.
  */
 function modelIdFromLine(line: string): string | null {
   const tokens = line.split(/ {2,}/).map((t) => t.trim()).filter(Boolean);
   if (tokens.length === 0) return null;
-  if (isPiTableHeader(tokens)) return null;
-
-  // col0 is already a full `<provider>/<model>` id (provider slugs never carry
-  // a `/`). Trailing tokens are stat columns — drop them, don't weld them on.
+  // Header row, identified by its labels (not by absence of a `/`, since real
+  // provider/model slugs can be plain).
+  if (tokens[0].toLowerCase() === "provider" && tokens[1]?.toLowerCase() === "model") {
+    return null;
+  }
+  // col0 already a full id → keep it, drop trailing stat columns.
   if (tokens[0].includes("/")) return tokens[0];
-
-  // Table row: bare provider slug in col0, model in col1 (with or without an
-  // internal `/`), followed by stat columns.
+  // Table row: <provider>/<model>, dropping trailing stat columns.
   if (tokens.length >= 2) return `${tokens[0]}/${tokens[1]}`;
-
-  // Single token: legacy bare `vendor/model` id (no internal multi-space run).
-  const id = tokens[0];
-  return id.includes("/") ? id : null;
+  // Lone legacy `vendor/model` id.
+  return tokens[0].includes("/") ? tokens[0] : null;
 }
 
 /**
- * Repair a stored Pi model id if — and only if — it looks like a
- * `pi --list-models` table row.
+ * Heal a stored Pi model id using the same line parser as the model list, so
+ * parsing and healing can never drift.
  *
- * Before the parser fix, selecting a row (or the header row) could persist the
- * *entire line* as the model id (e.g. `tfm       glm/glm-5.2  128K  …  no`),
- * which then broke every path that interpolates it raw into `--model`. This
- * collapses such stale values on read so they heal without a data migration.
+ * Pi shipped a parser (v0.5.0) that could persist an entire `pi --list-models`
+ * table row as the model id (e.g. `tfm   glm/glm-5.2   128K  …  no`), breaking
+ * every path that interpolates it into `--model`. Routing such values through
+ * `modelIdFromLine` collapses them back to `<provider>/<model>` on read — no
+ * data migration.
  *
- * Pi-specific by construction: a Pi table row is the only model value that
- * ever contains an internal run of 2+ spaces, so that is the sole trigger. The
- * leading token is a Pi provider (`tfm`, `openai`, …), so a real row is
- * reconstructed as `<pi-provider>/<model>` only when one of the first two
- * columns carries a `/`.
- *
- *   tfm       glm/glm-5.2  128K  …  → tfm/glm/glm-5.2
- *   glm/glm-5.2               128K  → glm/glm-5.2  (col0 already a full id)
- *   provider  model  context  …     → undefined   (header row)
- *   glm/glm-5.2                     → glm/glm-5.2  (already clean)
- *
- * Returns `undefined` for empty/whitespace input or an unrecoverable header row.
+ * Contract: a stale table row heals to `<provider>/<model>`; an already-clean
+ * id (including a provider-less bare id like `grok-4.3`, used with a separate
+ * `provider`) is returned untouched; empty input and the header row return
+ * `undefined`. A clean id only reaches `modelIdFromLine` as a lone token, which
+ * drops slash-less ids to `null`, so those are restored from `trimmed` here.
  */
-export function normalizePiModelId(raw: string | null | undefined): string | undefined {
+export function normalizePiModelId(
+  raw: string | null | undefined
+): string | undefined {
   const trimmed = (raw ?? "").trim();
   if (!trimmed) return undefined;
-  // Only a Pi table row has an internal run of 2+ spaces. Anything else is
-  // already a clean id — return it untouched.
-  if (!/ {2,}/.test(trimmed)) return trimmed;
-  // Reuse the same row parser the model list uses, so healing and parsing stay
-  // in lockstep (slash-safe col0 handling, explicit header detection).
-  return modelIdFromLine(trimmed) ?? undefined;
+  const parsed = modelIdFromLine(trimmed);
+  if (parsed) return parsed;
+  // `modelIdFromLine` returns null for a lone slash-less token (a clean bare
+  // id) and for the header row. Keep the former, drop the latter.
+  return / {2,}/.test(trimmed) ? undefined : trimmed;
 }
 
 export const piProvider: AgentProvider = {

--- a/test/pi-models-parse.test.ts
+++ b/test/pi-models-parse.test.ts
@@ -63,11 +63,12 @@ test("parses a live `pi --list-models` table (mixed slash / slash-less columns)"
   }
 });
 
-// ---- normalizePiModelId: heal stale persisted Pi model values on read -----
-// Healing shares modelIdFromLine with parsePiModels, so these lock the healer's
-// contract for the stored-value cases the parser tests don't cover directly.
+// ---- normalizePiModelId: repair stale persisted Pi model values on read ---
+// Repair shares modelIdFromLine with parsePiModels, so these lock the
+// repairer's contract for the stored-value cases the parser tests don't cover
+// directly.
 
-test("normalizePiModelId heals a stale whole table row into <provider>/<model>", () => {
+test("normalizePiModelId repairs a stale whole table row into <provider>/<model>", () => {
   // slash-in-model row, and a row whose model column has no slash.
   assert.equal(
     normalizePiModelId(
@@ -102,9 +103,9 @@ test("normalizePiModelId leaves a clean id untouched and returns undefined for h
   }
 });
 
-// ---- heal at a consumption site (pi.ts internal) --------------------------
+// ---- repair at a consumption site (pi.ts internal) ------------------------
 
-test("buildVerifyCommand heals a stale table-row model and omits --model when absent", () => {
+test("buildVerifyCommand repairs a stale table-row model and omits --model when absent", () => {
   const cmd = piProvider.buildVerifyCommand!(
     "tfm       glm/glm-5.2                                 128K     16.4K    no        no"
   );

--- a/test/pi-models-parse.test.ts
+++ b/test/pi-models-parse.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { parsePiModels, normalizePiModelId, piProvider } from "../src/lib/agents/providers/pi";
 
-test("parses one model id per line with thinking effort levels", () => {
+test("parses legacy bare `vendor/model` ids with thinking effort levels", () => {
   const models = parsePiModels(
     ["xai/grok-4.3", "anthropic/claude-opus-4-7", "openai/gpt-5.4"].join("\n")
   );
@@ -14,104 +14,23 @@ test("parses one model id per line with thinking effort levels", () => {
   assert.ok((models[0].effortLevels || []).some((e) => e.id === "xhigh"));
 });
 
-test("drops blank lines and # comment/banner lines", () => {
-  const models = parsePiModels(
-    ["# Available models", "", "xai/grok-4.3", "  ", "# end"].join("\n")
-  );
-  assert.deepEqual(
-    models.map((m) => m.id),
-    ["xai/grok-4.3"]
-  );
-});
-
-test("output that is ONLY a banner falls back instead of going blank", () => {
-  // Regression: pre-fix this returned [] → empty picker. Same bug class as
-  // the OpenCode hardening (§11 #22).
-  const models = parsePiModels("# No models configured — set XAI_API_KEY\n");
-  assert.ok(models.length > 0);
-  assert.ok(models.some((m) => m.id === "anthropic/claude-opus-4-7"));
-});
-
-test("empty / nullish output falls back to the offline list", () => {
-  for (const input of ["", "   \n ", null, undefined]) {
+test("empty / banner-only / nullish output falls back to the offline list", () => {
+  // Regression: pre-fix a banner-only or empty stdout returned [] → empty
+  // picker. Same bug class as the OpenCode hardening (§11 #22).
+  for (const input of ["", "   \n ", null, undefined, "# No models — set XAI_API_KEY\n"]) {
     const models = parsePiModels(input);
     assert.ok(models.length > 0, "fallback must not be empty");
     assert.ok(models.some((m) => m.id === "xai/grok-4.3"));
   }
 });
 
-// Captured from real `pi --list-models` (v0.80.3): a whitespace-columned table.
-// Columns: provider, model, context, max-out, thinking, images — separated by
-// runs of 2+ spaces. The header row has no `/` and must be dropped.
-const PI_LIST_MODELS_TABLE = [
-  "provider  model                              context  max-out  thinking  images",
-  "tfm       exa/search-fast                    128K     16.4K    no        no",
-  "tfm       glm/glm-5.2                        128K     16.4K    no        no",
-  "tfm       kai/nvidia/nemotron-3-super-120b-a12b:free  128K  16.4K    no        no",
-].join("\n");
-
-test("parses real `pi --list-models` table into provider/model ids", () => {
-  const models = parsePiModels(PI_LIST_MODELS_TABLE);
-  // Header row is dropped; each data row collapses to <provider>/<model>.
-  assert.deepEqual(
-    models.map((m) => m.id),
-    [
-      "tfm/exa/search-fast",
-      "tfm/glm/glm-5.2",
-      "tfm/kai/nvidia/nemotron-3-super-120b-a12b:free",
-    ]
-  );
-  // Name mirrors the id; thinking levels still attached.
-  assert.equal(models[1].name, "tfm/glm/glm-5.2");
-  assert.ok((models[1].effortLevels || []).some((e) => e.id === "xhigh"));
-});
-
-test("a table row never becomes the whole-line id (regression)", () => {
-  // Before the fix the entire row — including context/max-out/thinking/images
-  // columns — was stored as the model id, which then broke splitProviderModel
-  // and made `pi` reject the run with "Unknown provider".
-  const models = parsePiModels(PI_LIST_MODELS_TABLE);
-  for (const m of models) {
-    assert.ok(
-      !/\b128K\b|\b16\.4K\b|\bimages\b/.test(m.id),
-      `model id leaked table columns: ${m.id}`
-    );
-    assert.ok(!m.id.includes("no        no"), `model id leaked flag columns: ${m.id}`);
-  }
-});
-
-test("single-token line without a slash is dropped (header/label, not a model)", () => {
-  const models = parsePiModels(["provider  model  context", "xai/grok-4.3"].join("\n"));
-  // `provider  model  context` is the header row (identified by its column
-  // labels) and dropped; only the bare id survives.
-  assert.deepEqual(
-    models.map((m) => m.id),
-    ["xai/grok-4.3"]
-  );
-});
-
-test("parses table rows whose model column has no internal slash", () => {
-  // Not every provider's model slug carries a `/` (e.g. xai/grok-4.3). Such
-  // rows must still reconstruct as <provider>/<model>, not fall back offline.
-  const models = parsePiModels(
-    [
-      "provider  model     context  max-out  thinking  images",
-      "xai       grok-4.3   256K     16.4K    no        no",
-      "openai    gpt-5.4    128K     16.4K    no        no",
-    ].join("\n")
-  );
-  assert.deepEqual(
-    models.map((m) => m.id),
-    ["xai/grok-4.3", "openai/gpt-5.4"]
-  );
-});
-
-test("parses a live `pi --list-models` sample mixing slash-less and slashed model columns", () => {
+test("parses a live `pi --list-models` table (mixed slash / slash-less columns)", () => {
   // Captured verbatim from `pi --list-models` (trailing spaces preserved): the
-  // real output has `openai` rows whose model column has no `/` AND `tfm` rows
-  // whose model column DOES contain `/`. Both must reconstruct correctly, and
-  // the trailing whitespace must never leak into an id. Before the parser fix
-  // every slash-less `openai` row was silently dropped → offline fallback.
+  // real output is a whitespace-columned table with a header row, `openai` rows
+  // whose model column has NO `/`, and `tfm` rows whose model column DOES. All
+  // must reconstruct as <provider>/<model>; the header, stat columns and
+  // trailing whitespace must never leak into an id. Before the fix every
+  // slash-less row was silently dropped → offline fallback.
   const LIVE_SAMPLE = [
     "provider  model                                       context  max-out  thinking  images",
     "openai    gpt-4                                       8.2K     8.2K     no        no    ",
@@ -120,98 +39,76 @@ test("parses a live `pi --list-models` sample mixing slash-less and slashed mode
     "tfm       glm/glm-5.2                                 128K     16.4K    no        no    ",
     "tfm       kai/nvidia/nemotron-3-super-120b-a12b:free  128K     16.4K    no        no    ",
   ].join("\n");
-  const ids = parsePiModels(LIVE_SAMPLE).map((m) => m.id);
-  assert.deepEqual(ids, [
-    "openai/gpt-4",
-    "openai/gpt-5.4",
-    "tfm/exa/search-fast",
-    "tfm/glm/glm-5.2",
-    "tfm/kai/nvidia/nemotron-3-super-120b-a12b:free",
-  ]);
+  const models = parsePiModels(LIVE_SAMPLE);
+  assert.deepEqual(
+    models.map((m) => m.id),
+    [
+      "openai/gpt-4",
+      "openai/gpt-5.4",
+      "tfm/exa/search-fast",
+      "tfm/glm/glm-5.2",
+      "tfm/kai/nvidia/nemotron-3-super-120b-a12b:free",
+    ]
+  );
+  // Name mirrors the id; thinking levels still attached.
+  assert.equal(models[3].name, "tfm/glm/glm-5.2");
+  assert.ok((models[3].effortLevels || []).some((e) => e.id === "xhigh"));
   // No stat column or trailing whitespace ever survives in an id.
-  for (const id of ids) {
-    assert.equal(id, id.trim(), `id has stray whitespace: ${JSON.stringify(id)}`);
+  for (const m of models) {
+    assert.equal(m.id, m.id.trim(), `id has stray whitespace: ${JSON.stringify(m.id)}`);
     assert.ok(
-      !/\b128K\b|\b16\.4K\b|\b8\.2K\b|\bimages\b/.test(id),
-      `id leaked a stat column: ${id}`
+      !/\b128K\b|\b16\.4K\b|\b8\.2K\b|\bimages\b/.test(m.id),
+      `id leaked a stat column: ${m.id}`
     );
   }
 });
 
 // ---- normalizePiModelId: heal stale persisted Pi model values on read -----
+// Healing shares modelIdFromLine with parsePiModels, so these lock the healer's
+// contract for the stored-value cases the parser tests don't cover directly.
 
-test("normalizePiModelId heals a whole table row into <pi-provider>/<model>", () => {
+test("normalizePiModelId heals a stale whole table row into <provider>/<model>", () => {
+  // slash-in-model row, and a row whose model column has no slash.
   assert.equal(
     normalizePiModelId(
       "tfm       glm/glm-5.2                                 128K     16.4K    no        no"
     ),
     "tfm/glm/glm-5.2"
   );
-});
-
-test("normalizePiModelId drops the multi-space header row", () => {
-  assert.equal(
-    normalizePiModelId(
-      "provider  model                                       context  max-out  thinking  images"
-    ),
-    undefined
-  );
-});
-
-test("normalizePiModelId leaves an already-clean Pi id untouched", () => {
-  for (const clean of [
-    "tfm/glm/glm-5.2",
-    "tfm/kai/nvidia/nemotron-3-super-120b-a12b:free",
-    "xai/grok-4.3",
-  ]) {
-    assert.equal(normalizePiModelId(clean), clean);
-  }
-});
-
-test("normalizePiModelId does not weld stat columns onto a col0 that is already a full id", () => {
-  // Regression: a full id followed by whitespace-columned stats must drop the
-  // stats, not become `glm/glm-5.2/128K` (which `pi` would reject).
-  assert.equal(normalizePiModelId("glm/glm-5.2   128K   no"), "glm/glm-5.2");
-  assert.equal(normalizePiModelId("tfm/glm/glm-5.2   128K   16.4K   no"), "tfm/glm/glm-5.2");
-});
-
-test("normalizePiModelId heals a table row whose model column has no slash", () => {
   assert.equal(
     normalizePiModelId("xai       grok-4.3   256K     16.4K    no        no"),
     "xai/grok-4.3"
   );
 });
 
-test("normalizePiModelId returns undefined for empty/whitespace input", () => {
-  for (const empty of ["", "   ", "  \t  "]) {
+test("normalizePiModelId does not weld stat columns onto a col0 that is already a full id", () => {
+  // Must drop the stats, not become `glm/glm-5.2/128K` (which `pi` rejects).
+  assert.equal(normalizePiModelId("glm/glm-5.2   128K   no"), "glm/glm-5.2");
+  assert.equal(normalizePiModelId("tfm/glm/glm-5.2   128K   16.4K   no"), "tfm/glm/glm-5.2");
+});
+
+test("normalizePiModelId leaves a clean id untouched and returns undefined for header/empty", () => {
+  assert.equal(normalizePiModelId("tfm/glm/glm-5.2"), "tfm/glm/glm-5.2");
+  assert.equal(normalizePiModelId("xai/grok-4.3"), "xai/grok-4.3");
+  // A clean provider-less bare id (used with a separate `provider`) must round
+  // trip untouched, not collapse to undefined.
+  assert.equal(normalizePiModelId("grok-4.3"), "grok-4.3");
+  assert.equal(
+    normalizePiModelId("provider  model  context  max-out  thinking  images"),
+    undefined
+  );
+  for (const empty of ["", "   ", "  \t  ", null, undefined]) {
     assert.equal(normalizePiModelId(empty), undefined);
   }
 });
 
-// ---- heal at one-shot / verify consumption sites (pi.ts internal) ---------
+// ---- heal at a consumption site (pi.ts internal) --------------------------
 
-test("buildOneShotInvocation heals a stale table-row model id", () => {
-  const inv = piProvider.buildOneShotInvocation!("Reply OK", "/tmp", {
-    model:
-      "tfm       glm/glm-5.2                                 128K     16.4K    no        no",
-    effort: "medium",
-  });
-  const modelIdx = inv.args.indexOf("--model");
-  assert.ok(modelIdx !== -1, "expected --model in one-shot args");
-  assert.equal(inv.args[modelIdx + 1], "tfm/glm/glm-5.2");
-  const leaked = inv.args.some((a) => /128K|16\.4K|images/.test(a));
-  assert.ok(!leaked, `table stat columns leaked into one-shot args: ${JSON.stringify(inv.args)}`);
-});
-
-test("buildVerifyCommand heals a stale table-row defaultModel", () => {
+test("buildVerifyCommand heals a stale table-row model and omits --model when absent", () => {
   const cmd = piProvider.buildVerifyCommand!(
     "tfm       glm/glm-5.2                                 128K     16.4K    no        no"
   );
   assert.ok(cmd.includes("--model 'tfm/glm/glm-5.2'"), `unexpected verify cmd: ${cmd}`);
   assert.ok(!/128K|16\.4K/.test(cmd), `table stat columns leaked into verify cmd: ${cmd}`);
-});
-
-test("buildVerifyCommand omits --model when defaultModel is undefined", () => {
-  const cmd = piProvider.buildVerifyCommand!(undefined);
-  assert.ok(!cmd.includes("--model"), `unexpected --model in cmd: ${cmd}`);
+  assert.ok(!piProvider.buildVerifyCommand!(undefined).includes("--model"));
 });

--- a/test/pi-models-parse.test.ts
+++ b/test/pi-models-parse.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { parsePiModels } from "../src/lib/agents/providers/pi";
+import { parsePiModels, normalizePiModelId, piProvider } from "../src/lib/agents/providers/pi";
 
 test("parses one model id per line with thinking effort levels", () => {
   const models = parsePiModels(
@@ -38,4 +38,180 @@ test("empty / nullish output falls back to the offline list", () => {
     assert.ok(models.length > 0, "fallback must not be empty");
     assert.ok(models.some((m) => m.id === "xai/grok-4.3"));
   }
+});
+
+// Captured from real `pi --list-models` (v0.80.3): a whitespace-columned table.
+// Columns: provider, model, context, max-out, thinking, images — separated by
+// runs of 2+ spaces. The header row has no `/` and must be dropped.
+const PI_LIST_MODELS_TABLE = [
+  "provider  model                              context  max-out  thinking  images",
+  "tfm       exa/search-fast                    128K     16.4K    no        no",
+  "tfm       glm/glm-5.2                        128K     16.4K    no        no",
+  "tfm       kai/nvidia/nemotron-3-super-120b-a12b:free  128K  16.4K    no        no",
+].join("\n");
+
+test("parses real `pi --list-models` table into provider/model ids", () => {
+  const models = parsePiModels(PI_LIST_MODELS_TABLE);
+  // Header row is dropped; each data row collapses to <provider>/<model>.
+  assert.deepEqual(
+    models.map((m) => m.id),
+    [
+      "tfm/exa/search-fast",
+      "tfm/glm/glm-5.2",
+      "tfm/kai/nvidia/nemotron-3-super-120b-a12b:free",
+    ]
+  );
+  // Name mirrors the id; thinking levels still attached.
+  assert.equal(models[1].name, "tfm/glm/glm-5.2");
+  assert.ok((models[1].effortLevels || []).some((e) => e.id === "xhigh"));
+});
+
+test("a table row never becomes the whole-line id (regression)", () => {
+  // Before the fix the entire row — including context/max-out/thinking/images
+  // columns — was stored as the model id, which then broke splitProviderModel
+  // and made `pi` reject the run with "Unknown provider".
+  const models = parsePiModels(PI_LIST_MODELS_TABLE);
+  for (const m of models) {
+    assert.ok(
+      !/\b128K\b|\b16\.4K\b|\bimages\b/.test(m.id),
+      `model id leaked table columns: ${m.id}`
+    );
+    assert.ok(!m.id.includes("no        no"), `model id leaked flag columns: ${m.id}`);
+  }
+});
+
+test("single-token line without a slash is dropped (header/label, not a model)", () => {
+  const models = parsePiModels(["provider  model  context", "xai/grok-4.3"].join("\n"));
+  // `provider  model  context` is the header row (identified by its column
+  // labels) and dropped; only the bare id survives.
+  assert.deepEqual(
+    models.map((m) => m.id),
+    ["xai/grok-4.3"]
+  );
+});
+
+test("parses table rows whose model column has no internal slash", () => {
+  // Not every provider's model slug carries a `/` (e.g. xai/grok-4.3). Such
+  // rows must still reconstruct as <provider>/<model>, not fall back offline.
+  const models = parsePiModels(
+    [
+      "provider  model     context  max-out  thinking  images",
+      "xai       grok-4.3   256K     16.4K    no        no",
+      "openai    gpt-5.4    128K     16.4K    no        no",
+    ].join("\n")
+  );
+  assert.deepEqual(
+    models.map((m) => m.id),
+    ["xai/grok-4.3", "openai/gpt-5.4"]
+  );
+});
+
+test("parses a live `pi --list-models` sample mixing slash-less and slashed model columns", () => {
+  // Captured verbatim from `pi --list-models` (trailing spaces preserved): the
+  // real output has `openai` rows whose model column has no `/` AND `tfm` rows
+  // whose model column DOES contain `/`. Both must reconstruct correctly, and
+  // the trailing whitespace must never leak into an id. Before the parser fix
+  // every slash-less `openai` row was silently dropped → offline fallback.
+  const LIVE_SAMPLE = [
+    "provider  model                                       context  max-out  thinking  images",
+    "openai    gpt-4                                       8.2K     8.2K     no        no    ",
+    "openai    gpt-5.4                                     272K     128K     yes       yes   ",
+    "tfm       exa/search-fast                             128K     16.4K    no        no    ",
+    "tfm       glm/glm-5.2                                 128K     16.4K    no        no    ",
+    "tfm       kai/nvidia/nemotron-3-super-120b-a12b:free  128K     16.4K    no        no    ",
+  ].join("\n");
+  const ids = parsePiModels(LIVE_SAMPLE).map((m) => m.id);
+  assert.deepEqual(ids, [
+    "openai/gpt-4",
+    "openai/gpt-5.4",
+    "tfm/exa/search-fast",
+    "tfm/glm/glm-5.2",
+    "tfm/kai/nvidia/nemotron-3-super-120b-a12b:free",
+  ]);
+  // No stat column or trailing whitespace ever survives in an id.
+  for (const id of ids) {
+    assert.equal(id, id.trim(), `id has stray whitespace: ${JSON.stringify(id)}`);
+    assert.ok(
+      !/\b128K\b|\b16\.4K\b|\b8\.2K\b|\bimages\b/.test(id),
+      `id leaked a stat column: ${id}`
+    );
+  }
+});
+
+// ---- normalizePiModelId: heal stale persisted Pi model values on read -----
+
+test("normalizePiModelId heals a whole table row into <pi-provider>/<model>", () => {
+  assert.equal(
+    normalizePiModelId(
+      "tfm       glm/glm-5.2                                 128K     16.4K    no        no"
+    ),
+    "tfm/glm/glm-5.2"
+  );
+});
+
+test("normalizePiModelId drops the multi-space header row", () => {
+  assert.equal(
+    normalizePiModelId(
+      "provider  model                                       context  max-out  thinking  images"
+    ),
+    undefined
+  );
+});
+
+test("normalizePiModelId leaves an already-clean Pi id untouched", () => {
+  for (const clean of [
+    "tfm/glm/glm-5.2",
+    "tfm/kai/nvidia/nemotron-3-super-120b-a12b:free",
+    "xai/grok-4.3",
+  ]) {
+    assert.equal(normalizePiModelId(clean), clean);
+  }
+});
+
+test("normalizePiModelId does not weld stat columns onto a col0 that is already a full id", () => {
+  // Regression: a full id followed by whitespace-columned stats must drop the
+  // stats, not become `glm/glm-5.2/128K` (which `pi` would reject).
+  assert.equal(normalizePiModelId("glm/glm-5.2   128K   no"), "glm/glm-5.2");
+  assert.equal(normalizePiModelId("tfm/glm/glm-5.2   128K   16.4K   no"), "tfm/glm/glm-5.2");
+});
+
+test("normalizePiModelId heals a table row whose model column has no slash", () => {
+  assert.equal(
+    normalizePiModelId("xai       grok-4.3   256K     16.4K    no        no"),
+    "xai/grok-4.3"
+  );
+});
+
+test("normalizePiModelId returns undefined for empty/whitespace input", () => {
+  for (const empty of ["", "   ", "  \t  "]) {
+    assert.equal(normalizePiModelId(empty), undefined);
+  }
+});
+
+// ---- heal at one-shot / verify consumption sites (pi.ts internal) ---------
+
+test("buildOneShotInvocation heals a stale table-row model id", () => {
+  const inv = piProvider.buildOneShotInvocation!("Reply OK", "/tmp", {
+    model:
+      "tfm       glm/glm-5.2                                 128K     16.4K    no        no",
+    effort: "medium",
+  });
+  const modelIdx = inv.args.indexOf("--model");
+  assert.ok(modelIdx !== -1, "expected --model in one-shot args");
+  assert.equal(inv.args[modelIdx + 1], "tfm/glm/glm-5.2");
+  const leaked = inv.args.some((a) => /128K|16\.4K|images/.test(a));
+  assert.ok(!leaked, `table stat columns leaked into one-shot args: ${JSON.stringify(inv.args)}`);
+});
+
+test("buildVerifyCommand heals a stale table-row defaultModel", () => {
+  const cmd = piProvider.buildVerifyCommand!(
+    "tfm       glm/glm-5.2                                 128K     16.4K    no        no"
+  );
+  assert.ok(cmd.includes("--model 'tfm/glm/glm-5.2'"), `unexpected verify cmd: ${cmd}`);
+  assert.ok(!/128K|16\.4K/.test(cmd), `table stat columns leaked into verify cmd: ${cmd}`);
+});
+
+test("buildVerifyCommand omits --model when defaultModel is undefined", () => {
+  const cmd = piProvider.buildVerifyCommand!(undefined);
+  assert.ok(!cmd.includes("--model"), `unexpected --model in cmd: ${cmd}`);
 });


### PR DESCRIPTION
## What users saw

Selecting a model for the Pi provider often didn't work:

- After picking a model, runs failed with **"Unknown provider"** and the run
  wouldn't start.
- Some models never showed up in the picker at all.
- Sometimes the model picker was **empty** and fell back to a stale offline
  list.

## Why it happened

`pi --list-models` prints a table with columns, not one model id per line:

    provider  model        context  max-out  thinking  images
    tfm       glm/glm-5.2   128K     16.4K    no        no
    openai    gpt-4         8.2K     8.2K     no        no

The old code read each whole line as if it were a single model id, so:

- Picking a row saved the **entire table row** (e.g. `tfm  glm/glm-5.2  128K  …`)
  as the model id. Pi then rejected it as an "Unknown provider".
- Rows whose model column had no `/` (e.g. `openai  gpt-4`) were dropped, so
  those models never appeared.
- Banner-only or empty output produced an empty picker.

## The fix

- Parse the `pi --list-models` table properly: drop the header row and the
  extra stat columns, and turn each row into a clean `<provider>/<model>` id
  (including rows whose model column has no `/`).
- Repair any already-saved bad model ids on read, using the **same** parser, so
  a user with a corrupted saved value recovers without any migration. This
  repair happens entirely inside Pi's own code — nothing Pi-specific leaks into
  the shared settings code.
- Already-valid ids (including a bare id like `grok-4.3` used with a separate
  provider) are left untouched; empty input and the header row resolve to
  nothing.
- If the table can't be parsed, fall back to the offline model list so the
  picker is never blank.

## Test plan

- [x] `npx tsx --test test/pi-models-parse.test.ts src/lib/agents/adapters/pi-local.test.ts src/lib/agents/provider-settings.test.ts` → all pass
- [x] `git diff main -- src/lib/agents/provider-settings.ts` → empty (unchanged)
- [x] Regression test added for the bare-id and corrupted-saved-value cases
- [x] Verified against real `pi --list-models` output from a custom `tfm` provider
