### PR TITLE
feat(cloud): integrations wave 1 — honest gating for desktop-only surfaces + cloud OAuth paste flow

### DIFF
--- a/src/app/api/agents/config/mcp-catalog/route.ts
+++ b/src/app/api/agents/config/mcp-catalog/route.ts
@@ -9,6 +9,7 @@ import { getSelectedEnvironments } from "@/lib/agents/integration-environments";
 import { getRegistryPresence, verifyTier } from "@/lib/agents/mcp-registry-verify";
 import { getDeploymentMode, resolveAuthBackend } from "@/lib/agents/deployment-mode";
 import { getConfiguredDefaultProviderId } from "@/lib/agents/provider-settings";
+import { isCloud } from "@/lib/cloud/tier";
 
 /**
  * `/api/agents/config/mcp-catalog` — Integrations Hub data source.
@@ -32,7 +33,13 @@ export async function GET(): Promise<NextResponse> {
     configPath: p.mcpConfig?.displayPath,
   }));
 
-  const approved = MCP_CATALOG.map((entry) => {
+  // On Cabinet Cloud, drop integrations whose sign-in needs a local terminal / desktop app the
+  // hosted container can't reach (LinkedIn, Salesforce, Figma). Inert off-cloud.
+  const catalog = isCloud()
+    ? MCP_CATALOG.filter((entry) => !entry.cloudUnsupported)
+    : MCP_CATALOG;
+
+  const approved = catalog.map((entry) => {
     const supportedProviderIds = MCP_PROVIDERS.filter(
       (p) => p.mcpConfig?.transports.includes(entry.transport),
     ).map((p) => p.id);

--- a/src/components/integrations/hub/connect-panel.tsx
+++ b/src/components/integrations/hub/connect-panel.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { showError, showSuccess } from "@/lib/ui/toast";
 import { openExternalUrl } from "@/lib/runtime/open-url";
+import { useIsCloud } from "@/lib/cloud/client-tier";
 import type { IntegrationItem } from "@/lib/integrations/preview-catalog";
 
 /**
@@ -95,6 +96,7 @@ export function ConnectPanel({
    *  greyed out and unclickable rather than just un-selected. */
   msPersonalDisabled?: boolean;
 }) {
+  const cloud = useIsCloud();
   const [data, setData] = useState<Payload | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [targets, setTargets] = useState<Set<string>>(new Set());
@@ -792,7 +794,7 @@ export function ConnectPanel({
           ) : oauthLogin.state === "pending" ? (
             <div className="rounded-lg border border-border bg-background p-3">
               <p className="text-[12px] font-medium text-foreground">
-                Approve access in your browser
+                {cloud ? "Step 1: approve access" : "Approve access in your browser"}
               </p>
               <button
                 type="button"
@@ -809,35 +811,74 @@ export function ConnectPanel({
               >
                 Open {item.name} sign-in <ExternalLink className="h-3.5 w-3.5" />
               </button>
-              <p className="mt-3 flex items-center gap-1.5 text-[12px] text-muted-foreground">
-                <Loader2 className="h-3.5 w-3.5 animate-spin" /> Waiting for you to
-                finish…
-              </p>
-              <details className="mt-3">
-                <summary className="cursor-pointer text-[11px] text-muted-foreground hover:text-foreground">
-                  Stuck on a &ldquo;can&apos;t be reached&rdquo; page?
-                </summary>
-                <p className="mt-2 text-[11px] text-muted-foreground">
-                  That page is harmless. Copy its full address-bar URL (it starts
-                  with <code>http://localhost</code>) and paste it here:
-                </p>
-                <div className="mt-2 flex gap-2">
-                  <input
-                    value={callbackPaste}
-                    onChange={(e) => setCallbackPaste(e.target.value)}
-                    placeholder="http://localhost:…/callback?code=…"
-                    className="h-8 flex-1 rounded-md border border-border bg-background px-2.5 text-[12px] text-foreground placeholder:text-muted-foreground/50 outline-none focus:border-foreground/20"
-                  />
-                  <button
-                    type="button"
-                    onClick={submitOauthCallback}
-                    disabled={!callbackPaste.trim()}
-                    className="shrink-0 rounded-md border border-border px-3 py-2 text-[12px] font-medium text-foreground hover:bg-accent disabled:opacity-50"
-                  >
-                    Submit
-                  </button>
-                </div>
-              </details>
+              {cloud ? (
+                // In cloud the OAuth callback redirects to a localhost port inside
+                // the user's own machine, which their browser can't reach — so the
+                // paste step is the normal path here, not a hidden fallback.
+                <>
+                  <p className="mt-3 text-[12px] font-medium text-foreground">
+                    Step 2: paste the URL you land on
+                  </p>
+                  <p className="mt-1 text-[11px] text-muted-foreground">
+                    After you approve, your browser will land on a localhost page it
+                    can&apos;t open. That&apos;s expected. Copy that page&apos;s full
+                    address-bar URL (it starts with <code>http://localhost</code>)
+                    and paste it here to finish.
+                  </p>
+                  <div className="mt-2 flex gap-2">
+                    <input
+                      value={callbackPaste}
+                      onChange={(e) => setCallbackPaste(e.target.value)}
+                      placeholder="http://localhost:…/callback?code=…"
+                      className="h-8 flex-1 rounded-md border border-border bg-background px-2.5 text-[12px] text-foreground placeholder:text-muted-foreground/50 outline-none focus:border-foreground/20"
+                    />
+                    <button
+                      type="button"
+                      onClick={submitOauthCallback}
+                      disabled={!callbackPaste.trim()}
+                      className="shrink-0 rounded-md border border-border px-3 py-2 text-[12px] font-medium text-foreground hover:bg-accent disabled:opacity-50"
+                    >
+                      Submit
+                    </button>
+                  </div>
+                  <p className="mt-3 flex items-center gap-1.5 text-[12px] text-muted-foreground">
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" /> Waiting for you
+                    to finish…
+                  </p>
+                </>
+              ) : (
+                <>
+                  <p className="mt-3 flex items-center gap-1.5 text-[12px] text-muted-foreground">
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" /> Waiting for you to
+                    finish…
+                  </p>
+                  <details className="mt-3">
+                    <summary className="cursor-pointer text-[11px] text-muted-foreground hover:text-foreground">
+                      Stuck on a &ldquo;can&apos;t be reached&rdquo; page?
+                    </summary>
+                    <p className="mt-2 text-[11px] text-muted-foreground">
+                      That page is harmless. Copy its full address-bar URL (it starts
+                      with <code>http://localhost</code>) and paste it here:
+                    </p>
+                    <div className="mt-2 flex gap-2">
+                      <input
+                        value={callbackPaste}
+                        onChange={(e) => setCallbackPaste(e.target.value)}
+                        placeholder="http://localhost:…/callback?code=…"
+                        className="h-8 flex-1 rounded-md border border-border bg-background px-2.5 text-[12px] text-foreground placeholder:text-muted-foreground/50 outline-none focus:border-foreground/20"
+                      />
+                      <button
+                        type="button"
+                        onClick={submitOauthCallback}
+                        disabled={!callbackPaste.trim()}
+                        className="shrink-0 rounded-md border border-border px-3 py-2 text-[12px] font-medium text-foreground hover:bg-accent disabled:opacity-50"
+                      >
+                        Submit
+                      </button>
+                    </div>
+                  </details>
+                </>
+              )}
               <button
                 type="button"
                 onClick={cancelOauthLogin}

--- a/src/components/integrations/hub/integration-detail-page.tsx
+++ b/src/components/integrations/hub/integration-detail-page.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { showSuccess } from "@/lib/ui/toast";
 import { ConnectPanel } from "@/components/integrations/hub/connect-panel";
+import { useIsCloud } from "@/lib/cloud/client-tier";
 import { AppleNotesSection } from "@/components/settings/apple-notes-section";
 import { GoogleDriveSection } from "@/components/settings/google-drive-section";
 import { GmailSection } from "@/components/settings/gmail-section";
@@ -57,6 +58,7 @@ export function IntegrationDetailPage({
   via?: string | null;
   onBack: () => void;
 }) {
+  const cloud = useIsCloud();
   const category = CATEGORY_META[item.category].label;
   const entry = getCatalogEntry(item.id);
   // Microsoft 365 has a personal/work toggle in the ConnectPanel; we lift it
@@ -239,7 +241,18 @@ export function IntegrationDetailPage({
         <aside>
           {item.id === "apple-notes" ? (
             <div className="rounded-2xl border border-border bg-card/40 p-5">
-              <AppleNotesSection />
+              {cloud ? (
+                // Apple Notes import runs a local macOS scripting bridge on the
+                // user's own Mac — no cloud path. Honest note instead of the
+                // desktop import button.
+                <p className="text-[13px] leading-relaxed text-muted-foreground">
+                  Apple Notes import uses the desktop app on your Mac. On Cabinet
+                  Cloud, upload files directly or use the Notion, GitHub and Drive
+                  connectors.
+                </p>
+              ) : (
+                <AppleNotesSection />
+              )}
             </div>
           ) : item.id === "google-drive" ? (
             // Drive connects via Google Drive for Desktop (folder mounts), not

--- a/src/components/settings/google-drive-section.tsx
+++ b/src/components/settings/google-drive-section.tsx
@@ -27,6 +27,7 @@ import { GDRIVE_MOUNTS_CHANGED_EVENT } from "@/components/sidebar/google-drive-t
 import { useAppStore } from "@/stores/app-store";
 import { useRoomsStore } from "@/stores/rooms-store";
 import { ROOT_CABINET_PATH } from "@/lib/cabinets/paths";
+import { useIsCloud } from "@/lib/cloud/client-tier";
 
 interface Mount {
   id: string;
@@ -198,6 +199,7 @@ function FolderPickerDialog({
 }
 
 export function GoogleDriveSection() {
+  const cloud = useIsCloud();
   const [status, setStatus] = useState<DriveStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -231,6 +233,21 @@ export function GoogleDriveSection() {
   useEffect(() => {
     void loadStatus();
   }, [loadStatus]);
+
+  // Cabinet Cloud has no desktop-sync mount to browse. Replace the whole
+  // Drive-for-Desktop surface with one honest explainer — no dead buttons.
+  // Gate strictly on cloud === true so self-hosted (cloud undefined/false)
+  // renders the desktop surface exactly as before, with no extra delay.
+  if (cloud === true) {
+    return (
+      <div className="rounded-md border border-border bg-muted/20 px-3.5 py-3">
+        <h3 className="text-[14px] font-semibold mb-1">Desktop sync folders</h3>
+        <p className="text-[12px] text-muted-foreground">
+          Google Drive, iCloud and OneDrive folder sync uses the desktop app on your computer. On Cabinet Cloud, upload files directly or use the Notion, GitHub and Drive connectors below. Cloud-native Drive sync is coming.
+        </p>
+      </div>
+    );
+  }
 
   const addMount = async (absPath: string, folderName: string) => {
     const res = await fetch("/api/google-drive/mounts", {

--- a/src/components/sidebar/connect-knowledge-dialog.tsx
+++ b/src/components/sidebar/connect-knowledge-dialog.tsx
@@ -17,6 +17,7 @@ import {
   type ConnectKnowledgeTile,
 } from "@/lib/knowledge-sources/providers";
 import type { KnowledgeProviderId } from "@/lib/knowledge-sources/store";
+import { useIsCloud } from "@/lib/cloud/client-tier";
 
 interface DetectedAccount {
   provider: KnowledgeProviderId;
@@ -51,20 +52,29 @@ export function ConnectKnowledgeDialog({
   onAppleNotes: () => void;
 }) {
   const setSection = useAppStore((s) => s.setSection);
+  const cloud = useIsCloud();
 
   // Apple Notes only exists on macOS — hide the tile elsewhere.
   const isMac =
     typeof navigator !== "undefined" &&
     /mac/i.test(navigator.platform || navigator.userAgent);
-  const tiles = isMac
-    ? CONNECT_KNOWLEDGE_TILES
-    : CONNECT_KNOWLEDGE_TILES.filter((t) => t.key !== "apple-notes");
+  const tiles = (
+    isMac
+      ? CONNECT_KNOWLEDGE_TILES
+      : CONNECT_KNOWLEDGE_TILES.filter((t) => t.key !== "apple-notes")
+  ).filter((t) =>
+    // On Cabinet Cloud there is no desktop-sync mount and no native folder
+    // picker, so drop the "local" (link folder) and "cloud" (Drive/iCloud/
+    // OneDrive desktop-sync) tiles and the Mac-only Apple Notes import. The
+    // remaining MCP "hub" connectors (Notion, Confluence) work in cloud.
+    cloud ? t.kind === "hub" && t.key !== "apple-notes" : true,
+  );
 
   // Auto-scan: surface the desktop-sync accounts actually installed on this
   // machine, so the user can jump straight to the one they have.
   const [accounts, setAccounts] = useState<DetectedAccount[]>([]);
   useEffect(() => {
-    if (!open) return;
+    if (!open || cloud) return; // no desktop-sync accounts to scan on Cabinet Cloud
     let cancelled = false;
     fetch("/api/knowledge-sources/scan", { cache: "no-store" })
       .then((r) => r.json())
@@ -75,7 +85,7 @@ export function ConnectKnowledgeDialog({
     return () => {
       cancelled = true;
     };
-  }, [open]);
+  }, [open, cloud]);
 
   const handlePick = (tile: ConnectKnowledgeTile) => {
     if (tile.kind === "soon") return;

--- a/src/components/sidebar/notion-connect-dialog.tsx
+++ b/src/components/sidebar/notion-connect-dialog.tsx
@@ -20,6 +20,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { useAppStore } from "@/stores/app-store";
 import { useTreeStore } from "@/stores/tree-store";
+import { useIsCloud } from "@/lib/cloud/client-tier";
 import { SetupGuide } from "@/components/integrations/hub/setup-guide";
 import {
   MockWindow,
@@ -52,6 +53,7 @@ export function NotionConnectDialog({
   /** Tree path the import lands under (the right-clicked folder). */
   targetPath: string;
 }) {
+  const cloud = useIsCloud();
   const [step, setStep] = useState<"choose" | "export">("choose");
   const [phase, setPhase] = useState<Phase>("intro");
   const [error, setError] = useState("");
@@ -231,12 +233,16 @@ export function NotionConnectDialog({
         </DialogHeader>
 
         <div className="grid gap-3 py-1">
-          <ChooserCard
-            icon={<FileArchive className="h-5 w-5" aria-hidden="true" />}
-            title="Import from an export"
-            body="One-time import. Your pages become editable Markdown files in this room — offline, searchable, no account needed."
-            onClick={() => setStep("export")}
-          />
+          {/* The export import reads a .zip through the native file picker, which
+              Cabinet Cloud has no access to — offer only the live MCP sync there. */}
+          {!cloud && (
+            <ChooserCard
+              icon={<FileArchive className="h-5 w-5" aria-hidden="true" />}
+              title="Import from an export"
+              body="One-time import. Your pages become editable Markdown files in this room — offline, searchable, no account needed."
+              onClick={() => setStep("export")}
+            />
+          )}
           <ChooserCard
             icon={<RefreshCw className="h-5 w-5" aria-hidden="true" />}
             title="Connect & sync"

--- a/src/components/sidebar/tree-node.tsx
+++ b/src/components/sidebar/tree-node.tsx
@@ -103,6 +103,7 @@ import { NewFileDialog } from "./new-file-dialog";
 import { EditSymlinkDialog } from "./edit-symlink-dialog";
 import { FileSettingsDialog } from "./file-settings-dialog";
 import { useFileImport } from "./use-file-import";
+import { useIsCloud } from "@/lib/cloud/client-tier";
 import { getDataDir } from "@/lib/data-dir-cache";
 import { isMacPlatform, isEditableTarget, formatShortcut } from "@/lib/keys";
 import { useLocale } from "@/i18n/use-locale";
@@ -530,6 +531,7 @@ function TreeNodeImpl({
     ? node.path
     : node.path.split("/").slice(0, -1).join("/");
 
+  const cloud = useIsCloud();
   const {
     importFiles,
     importFilesList,
@@ -932,17 +934,21 @@ function TreeNodeImpl({
               )}
               {t("treeNode:importFile")}
             </ContextMenuItem>
-            <ContextMenuItem
-              disabled={importingFolder || isReadOnly}
-              onClick={() => importFolder(importTargetPath)}
-            >
-              {importingFolder ? (
-                <Loader2 className="h-4 w-4 me-2 animate-spin" />
-              ) : (
-                <FolderInput className="h-4 w-4 me-2" />
-              )}
-              {t("treeNode:importFolder")}
-            </ContextMenuItem>
+            {/* Import folder uses the native directory picker — desktop only.
+                Cloud users upload files with Import file (browser upload) above. */}
+            {!cloud && (
+              <ContextMenuItem
+                disabled={importingFolder || isReadOnly}
+                onClick={() => importFolder(importTargetPath)}
+              >
+                {importingFolder ? (
+                  <Loader2 className="h-4 w-4 me-2 animate-spin" />
+                ) : (
+                  <FolderInput className="h-4 w-4 me-2" />
+                )}
+                {t("treeNode:importFolder")}
+              </ContextMenuItem>
+            )}
             <ContextMenuItem disabled={isReadOnly} onClick={() => setConnectKnowledgeOpen(true)}>
               <GitBranch className="h-4 w-4 me-2" />
               {t("treeNode:connectKnowledge")}

--- a/src/lib/agents/mcp-catalog.ts
+++ b/src/lib/agents/mcp-catalog.ts
@@ -73,6 +73,12 @@ export interface CatalogEntry {
   registryId?: string;
   /** Declared tier; the UI shows the *verified* tier, falling back to this offline. */
   trustTier: TrustTier;
+  /**
+   * Cannot be connected on Cabinet Cloud — sign-in needs a local terminal / desktop app on the
+   * user's own machine (e.g. a CLI `login`, the Figma desktop app's local MCP server, `sf org
+   * login`). The catalog route filters these out when `isCloud()`. Inert (undefined) off-cloud.
+   */
+  cloudUnsupported?: true;
   authBackend: AuthBackend;
   /** Used when authBackend can't run locally (confidential client, no PKCE). */
   fallbackAuthBackend?: AuthBackend;
@@ -787,6 +793,8 @@ const LINKEDIN: CatalogEntry = {
   // `uv` must be installed (flagged in the setup steps, like Salesforce's CLI).
   sourceUrl: "https://github.com/stickerdaniel/linkedin-mcp-server",
   trustTier: "community",
+  // Auth is a `uvx …--login` browser profile created in a local terminal — no cloud path.
+  cloudUnsupported: true,
   authBackend: "token",
   transport: "stdio",
   mcpServerName: "cabinet-linkedin",
@@ -927,6 +935,8 @@ const EXTENDED: CatalogEntry[] = [
     id: "figma", label: "Figma", blurb: "Pull design context and generate code from frames.",
     iconSlug: "figma", bgImage: "/integrations/figma-bg.webp", logo: "/logos/figma.svg",
     sourceUrl: "https://developers.figma.com/docs/figma-mcp-server/", registryId: "figma", trustTier: "official",
+    // Needs the Figma desktop app's local Dev Mode MCP server (127.0.0.1:3845) — no cloud path.
+    cloudUnsupported: true,
     authBackend: "token", transport: "http", mcpServerName: "cabinet-figma",
     url: "http://127.0.0.1:3845/mcp", credentials: [],
     actions: ["Read selected frames & layers", "Extract design context", "Generate code from designs", "Fetch comments"],
@@ -936,6 +946,8 @@ const EXTENDED: CatalogEntry[] = [
     id: "salesforce", label: "Salesforce", blurb: "Query and update CRM data with the official DX MCP.",
     iconSlug: "salesforce", bgImage: "/integrations/salesforce-bg.webp", logo: "/logos/salesforce.webp",
     sourceUrl: "https://github.com/salesforcecli/mcp", registryId: "salesforce", trustTier: "official",
+    // Auth is a local `sf org login web` via the Salesforce CLI on the user's machine — no cloud path.
+    cloudUnsupported: true,
     authBackend: "token", transport: "stdio", mcpServerName: "cabinet-salesforce",
     command: "npx", args: ["-y", "@salesforce/mcp", "--orgs", "DEFAULT_TARGET_ORG", "--toolsets", "all"], credentials: [],
     actions: ["Query records (SOQL)", "Create & update records", "Run Apex & tests", "Inspect org metadata"],

--- a/src/lib/cloud/client-tier.ts
+++ b/src/lib/cloud/client-tier.ts
@@ -3,19 +3,45 @@
 // /api/cloud/status so it costs at most one request a minute. Inert off-cloud (tier is never "free"
 // unless CABINET_CLOUD is set), so self-hosted builds never gate.
 
-let cache: { free: boolean; panelUrl: string | null; at: number } | null = null;
+import { useEffect, useState } from "react";
 
-async function cloudStatus(): Promise<{ free: boolean; panelUrl: string | null }> {
+let cache: { cloud: boolean; free: boolean; panelUrl: string | null; at: number } | null = null;
+
+async function cloudStatus(): Promise<{ cloud: boolean; free: boolean; panelUrl: string | null }> {
   const now = Date.now();
   if (cache && now - cache.at < 60_000) return cache;
   try {
     const r = await fetch("/api/cloud/status", { cache: "no-store" });
     const d = (await r.json()) as { cloud?: boolean; tier?: string; panelUrl?: string | null };
-    cache = { free: d?.cloud === true && d?.tier === "free", panelUrl: d?.panelUrl ?? null, at: now };
+    cache = {
+      cloud: d?.cloud === true,
+      free: d?.cloud === true && d?.tier === "free",
+      panelUrl: d?.panelUrl ?? null,
+      at: now,
+    };
   } catch {
-    cache = { free: false, panelUrl: null, at: now };
+    cache = { cloud: false, free: false, panelUrl: null, at: now };
   }
   return cache;
+}
+
+/**
+ * Client twin of `isCloud()` (server tier.ts) for gating desktop-only UI surfaces in the hosted
+ * edition. Returns `undefined` until the first /api/cloud/status resolves so callers can avoid a
+ * flash of the wrong surface, then `true` only when CABINET_CLOUD is set. Inert off-cloud.
+ */
+export function useIsCloud(): boolean | undefined {
+  const [cloud, setCloud] = useState<boolean | undefined>(undefined);
+  useEffect(() => {
+    let alive = true;
+    void cloudStatus().then((s) => {
+      if (alive) setCloud(s.cloud);
+    });
+    return () => {
+      alive = false;
+    };
+  }, []);
+  return cloud;
 }
 
 export const UPGRADE_GATE_EVENT = "cabinet:upgrade-gate";


### PR DESCRIPTION
## What

Integrations wave 1 for Cabinet Cloud: gate desktop-only integration surfaces behind the cloud tier so hosted tenants see honest explainers instead of dead buttons, and make the OAuth paste-callback path a first-class step in cloud. Everything is inert when `CABINET_CLOUD` is unset — self-hosted / OSS behavior is byte-identical.

## Gating conditions

- Server: existing `isCloud()` (`src/lib/cloud/tier.ts`), used in the MCP catalog route.
- Client: new `useIsCloud()` in `src/lib/cloud/client-tier.ts` — a client twin cached off `/api/cloud/status`. Returns `undefined` until resolved, then `true` only when `CABINET_CLOUD=1`. All client gates check `cloud === true` (or fall through to the non-cloud branch while `undefined`), so self-host renders exactly as before.

## Changes

**1. Hide desktop-only surfaces with honest explainers (cloud only)**
- `google-drive-section.tsx`: replaces the whole Drive-for-Desktop / iCloud / OneDrive / Dropbox surface with one compact "Desktop sync folders" card. No dead buttons.
- `connect-knowledge-dialog.tsx`: drops the Local folder tile, the desktop-sync Drive tiles, the Apple Notes tile, and the "Detected on this Mac" scan; keeps the MCP hub connectors (Notion, Confluence). This hides the Connect Drive entry point and the native folder-picker (link-repo) path in one place.
- `notion-connect-dialog.tsx`: hides the native-file-picker "Import from an export" (local zip) path; keeps live MCP "Connect & sync".
- `tree-node.tsx`: hides the native "Import folder" context-menu item (pick-directory / import-folder); keeps the browser-upload "Import file".
- `integration-detail-page.tsx`: hides the Apple Notes import section behind an honest note.

**2. MCP catalog cloud flags**
- `mcp-catalog.ts`: adds optional `cloudUnsupported?: true`; set on LinkedIn, Salesforce, Figma (their auth needs a local terminal / desktop app).
- `mcp-catalog/route.ts`: filters those entries out when `isCloud()`.

**3. Paste-callback prominence in cloud**
- `connect-panel.tsx`: in cloud the OAuth loopback is unreachable, so the "copy the localhost URL from your address bar and paste it here" instruction is shown up front as step 2 of the flow (visible input), not a hidden `<details>` fallback. Non-cloud keeps the exact existing behavior (waiting spinner + collapsed fallback).

## Off-cloud inertness

Every gate resolves to the pre-existing behavior when `CABINET_CLOUD` is unset: server `isCloud()` is `false`, client `useIsCloud()` is `undefined`/`false`, so no surface, tile, menu item, or copy changes on self-host.

## Verification

- `npx tsc --noEmit`: clean.
- `npm test`: 350 pass, 0 fail.
- `eslint` on changed files: 0 errors (3 warnings, all pre-existing on `main`).