### PR TITLE
feat(cli): Windows (win32-x64) prebuilt app bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,8 @@ jobs:
             bundleKey: darwin-x64
           - runner: macos-14
             bundleKey: darwin-arm64
+          - runner: windows-latest
+            bundleKey: win32-x64
     permissions:
       contents: write
     steps:
@@ -81,6 +83,11 @@ jobs:
 
       - name: Package app bundle
         id: package
+        # Force bash on all runners — windows-latest defaults to pwsh, and this
+        # script is bash (parameter expansion, tar). GitHub's Windows runners
+        # ship Git Bash, and `tar` there creates a valid .tgz of the relative
+        # standalone dir.
+        shell: bash
         run: |
           TAG_VERSION="${GITHUB_REF_NAME#v}"
           BUNDLE_NAME="cabinet-app-${{ matrix.bundleKey }}-v${TAG_VERSION}.tgz"

--- a/cabinetai/src/commands/run.ts
+++ b/cabinetai/src/commands/run.ts
@@ -335,7 +335,8 @@ async function runCabinet(opts: {
       NODE_PATH: [path.join(appDir, ".native"), process.env.NODE_PATH].filter(Boolean).join(path.delimiter),
     };
 
-    const bundledNode = path.join(appDir, "bin", "node");
+    const bundledNodeName = process.platform === "win32" ? "node.exe" : "node";
+    const bundledNode = path.join(appDir, "bin", bundledNodeName);
     const nodeExec = fs.existsSync(bundledNode) ? bundledNode : process.execPath;
 
     log("Starting production app server...");

--- a/cabinetai/src/lib/release-manifest.ts
+++ b/cabinetai/src/lib/release-manifest.ts
@@ -1,4 +1,4 @@
-export type AppBundleKey = "darwin-arm64" | "darwin-x64" | "linux-arm64" | "linux-x64";
+export type AppBundleKey = "darwin-arm64" | "darwin-x64" | "linux-arm64" | "linux-x64" | "win32-x64";
 
 export interface ReleaseAppBundle {
   assetName: string;
@@ -46,6 +46,7 @@ export function getAppBundleKey(platform = process.platform, arch = process.arch
   if (platform === "darwin" && arch === "x64") return "darwin-x64";
   if (platform === "linux" && arch === "arm64") return "linux-arm64";
   if (platform === "linux" && arch === "x64") return "linux-x64";
+  if (platform === "win32" && arch === "x64") return "win32-x64";
   return null;
 }
 

--- a/scripts/generate-release-manifest.mjs
+++ b/scripts/generate-release-manifest.mjs
@@ -29,9 +29,8 @@ const repositoryUrl = (
 ).replace(/\.git$/, "");
 
 // Prebuilt app-bundle keys for the zero-install `npx cabinetai run` path.
-// darwin/linux only — Windows still uses the source + npm-install fallback
-// until a win32 bundle is validated (tracked in a follow-up PR).
-const appBundleKeys = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64"];
+// A platform with no bundle in a given release falls back to source + npm install.
+const appBundleKeys = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64", "win32-x64"];
 
 function appBundleAssetName(key, tag) {
   return `cabinet-app-${key}-${tag}.tgz`;

--- a/src/lib/system/release-manifest.ts
+++ b/src/lib/system/release-manifest.ts
@@ -11,7 +11,7 @@ interface PackageManifest {
   };
 }
 
-const APP_BUNDLE_KEYS: AppBundleKey[] = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64"];
+const APP_BUNDLE_KEYS: AppBundleKey[] = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64", "win32-x64"];
 
 function buildReleaseUrls(repositoryUrl: string, gitTag: string): Pick<
   ReleaseManifest,

--- a/src/types/update.ts
+++ b/src/types/update.ts
@@ -15,7 +15,7 @@ export type UpdateState =
   | "restart-required"
   | "failed";
 
-export type AppBundleKey = "darwin-arm64" | "darwin-x64" | "linux-arm64" | "linux-x64";
+export type AppBundleKey = "darwin-arm64" | "darwin-x64" | "linux-arm64" | "linux-x64" | "win32-x64";
 
 export interface ReleaseAppBundle {
   assetName: string;


### PR DESCRIPTION
## Windows prebuilt app bundle (`win32-x64`)

Follow-up to #65, which shipped the zero-install `npx cabinetai run` prebuilt-bundle path for **macOS/Linux** and left Windows on the source + `npm install` fallback. This adds the Windows (x64) bundle.

### Changes
- `win32-x64` added to `AppBundleKey` (cabinetai + app-side) and to the key lists in `generate-release-manifest.mjs` / `src/lib/system/release-manifest.ts`.
- `getAppBundleKey()` maps `win32` + `x64` → `win32-x64`.
- `release.yml` `publish-app-bundles` builds on `windows-latest` (with `shell: bash` so the bash packaging script runs under Git Bash).
- `run.ts` resolves the bundled node as `node.exe` on Windows.

The node-pty staging for `win32` prebuilds already landed with #65 (`prepare-electron-package.mjs`, keyed off `targetPlatform`).

### ⚠️ Not yet validated on Windows — needs a real Windows box
I built and verified the macOS/Linux path end-to-end (bundle boots, app + daemon healthy, Chrome DevTools render), but I can't produce or run a Windows bundle here. Before merging, please validate on Windows x64:

1. **CI packaging** — trigger the `publish-app-bundles` matrix (or a test release tag) and confirm the `windows-latest` job builds and uploads `cabinet-app-win32-x64-vX.tgz` + `.sha256`. Watch for: `tar` behavior under Git Bash, and `npm run electron:prep` staging `node-pty/prebuilds/win32-x64`.
2. **Runtime** — on a clean Windows machine: `npx cabinetai run`, confirm it downloads the win32 bundle (not the source fallback), boots `server.js` via `bin\node.exe`, and the app + daemon serve. node-pty terminals in particular exercise the native binding.
3. Confirm the source-install fallback still works if the bundle is absent.

Leaving as **draft** until someone confirms the above on Windows.
