### PR TITLE
fix(chat): color inline code + links with theme accent (#76)

### DIFF
--- a/src/components/tasks/conversation/markdown.tsx
+++ b/src/components/tasks/conversation/markdown.tsx
@@ -46,12 +46,13 @@ export function Markdown({
         "prose prose-sm max-w-none dark:prose-invert",
         "prose-p:my-2 prose-p:leading-[1.65]",
         "prose-pre:my-3 prose-pre:rounded-lg prose-pre:bg-muted/60 prose-pre:text-[12.5px] prose-pre:text-foreground",
-        "prose-code:text-[0.9em] prose-code:bg-muted/60 prose-code:rounded prose-code:px-1 prose-code:py-px prose-code:font-mono prose-code:text-foreground prose-code:before:content-none prose-code:after:content-none",
-        "prose-pre:prose-code:bg-transparent prose-pre:prose-code:p-0",
+        "prose-code:text-[0.9em] prose-code:bg-muted/60 prose-code:rounded prose-code:px-1 prose-code:py-px prose-code:font-mono prose-code:text-primary prose-code:before:content-none prose-code:after:content-none",
+        // ponytail: color inline code + code-block-code via existing --primary token (theme-aware); full syntax highlighting would need shiki/rehype-highlight — add if plain accent isn't enough
+        "prose-pre:prose-code:bg-transparent prose-pre:prose-code:p-0 prose-pre:prose-code:text-foreground",
         "prose-ul:my-2 prose-ol:my-2 prose-li:my-0.5",
-        "prose-headings:font-semibold prose-headings:tracking-tight",
+        "prose-headings:font-semibold prose-headings:tracking-tight prose-headings:text-foreground",
         "prose-h1:text-[17px] prose-h2:text-[15.5px] prose-h3:text-[14px]",
-        "prose-a:text-foreground prose-a:underline prose-a:underline-offset-2",
+        "prose-a:text-primary prose-a:underline prose-a:underline-offset-2",
         "prose-strong:text-foreground prose-strong:font-semibold",
         "prose-blockquote:border-l-2 prose-blockquote:border-border prose-blockquote:pl-3 prose-blockquote:italic prose-blockquote:text-muted-foreground",
         className


### PR DESCRIPTION
Fixes #76 — the chat box read monochrome because the markdown renderer pinned every element to `--foreground`.

## Change
One file (`src/components/tasks/conversation/markdown.tsx`): point **inline code** and **links** at the theme's `--primary` token instead of `--foreground`. Fenced code blocks stay neutral; headings kept explicit foreground.

## Theme coverage
Because it reuses `--primary`, it's theme-aware for free: **15 of 17 themes** get real color (Cabinet=brown, Claude=amber, Matrix=green, Sky/Apple=blue, …). **White** and **Black** keep grey — those themes set `--primary` to chroma 0 on purpose, so respecting that is correct. Inline code still stands out there via its pill + mono font.

Skipped (out of scope for #76): syntax highlighting in code blocks (needs shiki/rehype-highlight) and reviving ANSI colors stripped from CLI/tool logs.