### PR TITLE
fix(deps): declare highlight.js and sync package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "emoji-mart": "^5.6.0",
         "flexsearch": "^0.8.212",
         "gray-matter": "^4.0.3",
+        "highlight.js": "^11.11.1",
         "html-to-image": "^1.11.13",
         "i18next": "^26.1.0",
         "i18next-browser-languagedetector": "^8.2.1",
@@ -11082,6 +11083,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
     "node_modules/encoding-japanese": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-2.2.0.tgz",
@@ -11089,6 +11101,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/end-of-stream": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "emoji-mart": "^5.6.0",
     "flexsearch": "^0.8.212",
     "gray-matter": "^4.0.3",
+    "highlight.js": "^11.11.1",
     "html-to-image": "^1.11.13",
     "i18next": "^26.1.0",
     "i18next-browser-languagedetector": "^8.2.1",


### PR DESCRIPTION
## Problem

Two related dependency-correctness issues on `main`.

### 1. `highlight.js` is a phantom dependency

`src/components/editor/extensions.ts` imports 13 language grammars from `highlight.js`, but the package is not declared in `package.json`. It resolves today only because npm flat-hoists it out of `lowlight`.

That makes it a phantom dependency: under any strict `node_modules` layout (pnpm, yarn PnP) it disappears and every route 500s with:

```
Module not found: Can't resolve 'highlight.js/lib/languages/yaml'
```

### 2. `package.json` and `package-lock.json` are out of sync

`@electron-forge/cli` floats at `^7.8.1` and now resolves to `7.11.2`, which pulls in `encoding` + `iconv-lite` as optional transitives of `node-fetch@2` (`cli` → `core-utils` → `@electron/rebuild` → `@electron/node-gyp` → `make-fetch-happen` → `minipass-fetch` → `encoding`). The committed lockfile predates that resolution.

**This does not break CI today**, and I want to be precise about why: npm 10 — what Node 22 ships, and therefore what the runners install with — is lenient about those missing optional transitives. npm 11 (Node 24) validates them and refuses:

```
npm error `npm ci` can only install packages when your package.json
and package-lock.json are in sync.
npm error Missing: encoding@0.1.13 from lock file
npm error Missing: iconv-lite@0.6.3 from lock file
```

So the impact is:
- **`npm ci` fails outright for any contributor on Node 24.** This is how I found it — a clean clone would not install.
- **CI breaks the moment the runner moves to Node 24.**

## Changes

1. **`fix(deps)`** — declare `highlight.js: ^11.11.1`. That is the version `lowlight` already resolves, so the dependency tree is unchanged; this only makes the existing import honest.
2. **`fix(deps)`** — sync `package-lock.json`. No dependency ranges were changed.

## Verification

Against a clean worktree at `77a11d2c`, `npm ci` tested under both npm majors:

| | npm 10.9.2 (Node 22 — what CI uses) | npm 11.8.0 (Node 24) |
|---|---|---|
| `main` today | ✅ passes | ❌ `Missing: encoding` |
| this PR | ✅ passes | ✅ passes |

So this is strictly additive: CI stays green, and Node 24 installs start working.

`npm run build` also passes on the branch (exit 0, including the `copy-standalone-assets` postbuild).

## Notes

- I initially opened this claiming the release pipeline was broken. That was wrong — I had reproduced the failure on npm 11 locally and had not checked it against the npm version CI actually uses. Corrected above; the lockfile drift is real, but it is a Node 24 / contributor-onboarding break, not a live CI break.
- An earlier revision of this PR also added a `ci.yml`. #194 landed a better one in the meantime, so that commit is dropped.
- Unrelated, spotted while verifying: `npm test` fails one case on a clean checkout — `cabinet overview keeps own scope separate from descendant scope` (`test/cabinet-v2.test.ts:111`, `ownOverview.parent?.path` is `undefined`, expected `"."`). Your `ci.yml` comment suggests you already know (untracked ambient `data/` fixture). Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
