### PR TITLE
polish(providers): logo tiles for theme contrast + JetBrains Mono terminal

### DIFF
--- a/src/components/settings/provider-setup-dialog.tsx
+++ b/src/components/settings/provider-setup-dialog.tsx
@@ -335,8 +335,13 @@ function ProviderSetupPanel({ providerId }: { providerId: string }) {
 function ProviderLogo({ src, name }: { src?: string; name: string }) {
   const [broken, setBroken] = useState(false);
   if (src && !broken) {
-    // eslint-disable-next-line @next/next/no-img-element
-    return <img src={src} alt="" className="h-9 w-9 shrink-0 rounded-lg object-contain" onError={() => setBroken(true)} />;
+    // Light tile so monochrome brand marks stay visible on any theme.
+    return (
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-white ring-1 ring-black/[0.06]">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={src} alt="" className="h-6 w-6 object-contain" onError={() => setBroken(true)} />
+      </div>
+    );
   }
   return (
     <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-muted text-sm font-semibold text-muted-foreground">

--- a/src/components/settings/settings-page.tsx
+++ b/src/components/settings/settings-page.tsx
@@ -1422,9 +1422,12 @@ export function SettingsPage() {
                               >
                                 <div className="flex items-center justify-between">
                                   <div className="flex items-center gap-3">
-                                    {/* Provider logo + a status dot (ready/installed/none). */}
-                                    <div className="relative shrink-0 text-foreground/80">
-                                      <ProviderGlyph icon={provider.icon} asset={provider.iconAsset} className="h-7 w-7" />
+                                    {/* Provider logo on a light tile (so monochrome
+                                        marks stay visible on any theme) + status dot. */}
+                                    <div className="relative shrink-0">
+                                      <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-white ring-1 ring-black/[0.06]">
+                                        <ProviderGlyph icon={provider.icon} asset={provider.iconAsset} className="h-6 w-6" />
+                                      </div>
                                       <span className={cn(
                                         "absolute -bottom-0.5 -end-0.5 h-2.5 w-2.5 rounded-full ring-2 ring-card",
                                         isReady ? "bg-green-500" : isInstalled ? "bg-amber-500" : "bg-muted-foreground/40",

--- a/src/components/terminal/web-terminal.tsx
+++ b/src/components/terminal/web-terminal.tsx
@@ -311,13 +311,21 @@ export const WebTerminal = forwardRef<WebTerminalHandle, WebTerminalProps>(funct
 
       if (disposed) return;
 
+      // The app bundles JetBrains Mono under a hashed next/font family exposed
+      // via --font-mono, so the literal "JetBrains Mono" name never matched and
+      // the terminal fell back to a system mono. Read the resolved var and put
+      // it first, with a literal stack as fallback.
+      const monoFamily = readRootVar("--font-mono", "")
+        .replace(/var\([^)]*\)/g, "")
+        .replace(/^[\s,]+/, "")
+        .trim();
       terminal = new Terminal({
         cursorBlink: true,
         cursorStyle: "bar",
         fontSize: 13,
         fontFamily:
-          "'JetBrains Mono', 'Fira Code', 'Cascadia Code', Menlo, Monaco, 'Courier New', monospace",
-        lineHeight: 1.2,
+          `${monoFamily ? monoFamily + ", " : ""}'JetBrains Mono', 'Fira Code', 'Cascadia Code', Menlo, Monaco, 'Courier New', monospace`,
+        lineHeight: 1.3,
         letterSpacing: 0,
         theme: getTerminalTheme(themeSurface),
         scrollback: 10000,


### PR DESCRIPTION
Follow-ups to the provider onboarding work.

1. **Logo tiles** — provider logos in the Settings list and the setup dialog now sit on a light rounded tile, so the monochrome brand marks (Grok/Copilot/Cursor/OpenCode/Pi) stay legible on dark themes too.
2. **Terminal font** — the embedded setup console now actually renders in the app-bundled JetBrains Mono. It listed the name before but the app loads it under a hashed next/font family via `--font-mono`, so the literal name never matched and it fell back to a system mono. Reads the resolved var and puts it first, with a slightly roomier line-height.

tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)