### PR TITLE
polish(providers): logo tile only on dark themes, borderless

### DIFF
--- a/src/components/settings/provider-setup-dialog.tsx
+++ b/src/components/settings/provider-setup-dialog.tsx
@@ -335,11 +335,12 @@ function ProviderSetupPanel({ providerId }: { providerId: string }) {
 function ProviderLogo({ src, name }: { src?: string; name: string }) {
   const [broken, setBroken] = useState(false);
   if (src && !broken) {
-    // Light tile so monochrome brand marks stay visible on any theme.
+    // Plain logo on light themes; a borderless light tile on dark themes so
+    // monochrome brand marks stay legible.
     return (
-      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-white ring-1 ring-black/[0.06]">
+      <div className="flex shrink-0 items-center justify-center rounded-lg dark:bg-white dark:p-1.5">
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img src={src} alt="" className="h-6 w-6 object-contain" onError={() => setBroken(true)} />
+        <img src={src} alt="" className="h-9 w-9 object-contain" onError={() => setBroken(true)} />
       </div>
     );
   }

--- a/src/components/settings/settings-page.tsx
+++ b/src/components/settings/settings-page.tsx
@@ -1422,11 +1422,12 @@ export function SettingsPage() {
                               >
                                 <div className="flex items-center justify-between">
                                   <div className="flex items-center gap-3">
-                                    {/* Provider logo on a light tile (so monochrome
-                                        marks stay visible on any theme) + status dot. */}
+                                    {/* Plain logo on light themes; on dark themes a
+                                        borderless light tile so monochrome marks stay
+                                        legible. + status dot. */}
                                     <div className="relative shrink-0">
-                                      <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-white ring-1 ring-black/[0.06]">
-                                        <ProviderGlyph icon={provider.icon} asset={provider.iconAsset} className="h-6 w-6" />
+                                      <div className="flex items-center justify-center rounded-lg dark:bg-white dark:p-1.5">
+                                        <ProviderGlyph icon={provider.icon} asset={provider.iconAsset} className="h-7 w-7" />
                                       </div>
                                       <span className={cn(
                                         "absolute -bottom-0.5 -end-0.5 h-2.5 w-2.5 rounded-full ring-2 ring-card",


### PR DESCRIPTION
The white logo tile looked too heavy on the light (paper) theme. Now:
- **Light themes**: plain logo, no tile (back to how it was).
- **Dark themes**: a borderless light tile behind the logo, so monochrome brand marks stay legible.

Keys off the app's .dark class (Cabinet dark themes), tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)