### PR TITLE
Full-screen focus mode for file viewers + UI polish

### DIFF
--- a/src/components/composer/task-runtime-picker.tsx
+++ b/src/components/composer/task-runtime-picker.tsx
@@ -56,7 +56,7 @@ const EFFORT_TONES: Record<
 > = {
   [AUTO_EFFORT_ID]: {
     header: "text-slate-600 dark:text-slate-200",
-    bg: "bg-slate-100 border border-slate-200 dark:bg-slate-800/50 dark:border-slate-700",
+    bg: "bg-slate-100 dark:bg-slate-800/50",
     line: "bg-slate-400 dark:bg-slate-500",
     dot: "bg-slate-500 dark:bg-slate-400",
     selected:
@@ -68,7 +68,7 @@ const EFFORT_TONES: Record<
   },
   none: {
     header: "text-slate-600 dark:text-slate-200",
-    bg: "bg-slate-100 border border-slate-200 dark:bg-slate-800/50 dark:border-slate-700",
+    bg: "bg-slate-100 dark:bg-slate-800/50",
     line: "bg-slate-400 dark:bg-slate-500",
     dot: "bg-slate-500 dark:bg-slate-400",
     selected:
@@ -80,7 +80,7 @@ const EFFORT_TONES: Record<
   },
   minimal: {
     header: "text-yellow-700 dark:text-yellow-300",
-    bg: "bg-yellow-50 border border-yellow-200 dark:bg-yellow-900/30 dark:border-yellow-800/60",
+    bg: "bg-yellow-50 dark:bg-yellow-900/30",
     line: "bg-yellow-400 dark:bg-yellow-500",
     dot: "bg-yellow-500 dark:bg-yellow-400",
     selected:
@@ -92,7 +92,7 @@ const EFFORT_TONES: Record<
   },
   low: {
     header: "text-amber-700 dark:text-amber-300",
-    bg: "bg-amber-50 border border-amber-200 dark:bg-amber-900/30 dark:border-amber-800/60",
+    bg: "bg-amber-50 dark:bg-amber-900/30",
     line: "bg-amber-400 dark:bg-amber-500",
     dot: "bg-amber-500 dark:bg-amber-400",
     selected:
@@ -104,7 +104,7 @@ const EFFORT_TONES: Record<
   },
   medium: {
     header: "text-orange-700 dark:text-orange-300",
-    bg: "bg-orange-50 border border-orange-200 dark:bg-orange-900/30 dark:border-orange-800/60",
+    bg: "bg-orange-50 dark:bg-orange-900/30",
     line: "bg-orange-400 dark:bg-orange-500",
     dot: "bg-orange-500 dark:bg-orange-400",
     selected:
@@ -116,7 +116,7 @@ const EFFORT_TONES: Record<
   },
   high: {
     header: "text-emerald-700 dark:text-emerald-300",
-    bg: "bg-emerald-50 border border-emerald-200 dark:bg-emerald-900/30 dark:border-emerald-800/60",
+    bg: "bg-emerald-50 dark:bg-emerald-900/30",
     line: "bg-emerald-400 dark:bg-emerald-500",
     dot: "bg-emerald-500 dark:bg-emerald-400",
     selected:
@@ -128,7 +128,7 @@ const EFFORT_TONES: Record<
   },
   xhigh: {
     header: "text-rose-700 dark:text-rose-300",
-    bg: "bg-rose-50 border border-rose-200 dark:bg-rose-900/30 dark:border-rose-800/60",
+    bg: "bg-rose-50 dark:bg-rose-900/30",
     line: "bg-rose-400 dark:bg-rose-500",
     dot: "bg-rose-500 dark:bg-rose-400",
     selected:
@@ -140,7 +140,7 @@ const EFFORT_TONES: Record<
   },
   max: {
     header: "text-red-700 dark:text-red-300",
-    bg: "bg-red-50 border border-red-200 dark:bg-red-900/30 dark:border-red-800/60",
+    bg: "bg-red-50 dark:bg-red-900/30",
     line: "bg-red-400 dark:bg-red-500",
     dot: "bg-red-500 dark:bg-red-400",
     selected:

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -132,6 +132,7 @@ function resolveInternalLink(
 
 export function KBEditor() {
   const { t } = useLocale();
+  const focusMode = useAppStore((s) => s.focusMode);
   const { currentPath, assetBase, content, saveStatus, frontmatter, isLoading, loadStatus, createMissingPage } = useEditorStore();
   const nodes = useTreeStore((s) => s.nodes);
   // A page under a read-only Connect Knowledge mount is view-only — edits would
@@ -702,7 +703,9 @@ export function KBEditor() {
     <div className="flex-1 flex flex-col overflow-hidden min-h-0">
       {/* Chrome row on the desk: folder tabs on the left; on the Page tab the
           formatting toolbar scrolls to the right of them (transparent, faded).
-          Only the tabs connect down into the sheet below. */}
+          Only the tabs connect down into the sheet below. Hidden entirely in
+          focus mode — content only. */}
+      {!focusMode && (
       <div className="flex shrink-0 items-end gap-3 ps-4 pe-2 min-h-[34px]">
         {showFolderTabs && (
           <FolderTabs
@@ -728,6 +731,7 @@ export function KBEditor() {
           </div>
         )}
       </div>
+      )}
       {/* Files tab: elevated sheet holding the folder index. */}
       {onFilesTab && (
         <ContentSheet>

--- a/src/components/editor/source-viewer.tsx
+++ b/src/components/editor/source-viewer.tsx
@@ -158,6 +158,7 @@ export function SourceViewer({ path }: SourceViewerProps) {
           <ToolbarButton
             icon={WrapText}
             label="Wrap"
+            iconOnly
             active={wrap}
             onClick={() => setWrap((v) => !v)}
             title={wrap ? "Disable line wrap" : "Enable line wrap"}
@@ -167,6 +168,7 @@ export function SourceViewer({ path }: SourceViewerProps) {
           <ToolbarButton
             icon={copied ? Check : Copy}
             label={copied ? "Copied" : "Copy"}
+            iconOnly
             onClick={copyToClipboard}
             title={t("sourceViewer:copyContents")}
           />
@@ -174,6 +176,7 @@ export function SourceViewer({ path }: SourceViewerProps) {
         <ToolbarButton
           icon={Download}
           label="Download"
+          iconOnly
           title={t("sourceViewer:downloadFile")}
           onClick={() => {
             const a = document.createElement("a");
@@ -185,6 +188,7 @@ export function SourceViewer({ path }: SourceViewerProps) {
         <ToolbarButton
           icon={ExternalLink}
           label="Raw"
+          iconOnly
           onClick={() => window.open(assetUrl, "_blank")}
         />
         </ViewerToolbar>

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useLayoutEffect, useRef, useState, useCallback, useMemo } from "react";
-import { Loader2 } from "lucide-react";
+import { Loader2, Minimize2 } from "lucide-react";
 import { Sidebar } from "@/components/sidebar/sidebar";
 import { Header } from "@/components/layout/header";
 import { KBEditor } from "@/components/editor/editor";
@@ -135,6 +135,7 @@ import { useRoute } from "@/hooks/use-hash-route";
 import { useTaskFileSync } from "@/hooks/use-task-file-sync";
 import { useTreeStore } from "@/stores/tree-store";
 import { useAppStore } from "@/stores/app-store";
+import { useLocale } from "@/i18n/use-locale";
 import { useEditorStore } from "@/stores/editor-store";
 import { useRoomsStore } from "@/stores/rooms-store";
 
@@ -163,6 +164,7 @@ const useIsoLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : use
 export function AppShell() {
   useGlobalHotkeys();
   const isMobile = useIsMobile();
+  const { t } = useLocale();
   const loadTree = useTreeStore((s) => s.loadTree);
   const nodes = useTreeStore((s) => s.nodes);
   const selectedPath = useTreeStore((s) => s.selectedPath);
@@ -176,6 +178,17 @@ export function AppShell() {
   const taskRailOpen = useAppStore((s) => s.taskRailOpen);
   const setTerminalCwd = useAppStore((s) => s.setTerminalCwd);
   const sidebarCollapsed = useAppStore((s) => s.sidebarCollapsed);
+  const focusMode = useAppStore((s) => s.focusMode);
+  const setFocusMode = useAppStore((s) => s.setFocusMode);
+  // Escape exits focus mode — registered only while active.
+  useEffect(() => {
+    if (!focusMode) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setFocusMode(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [focusMode, setFocusMode]);
   const setSidebarCollapsed = useAppStore((s) => s.setSidebarCollapsed);
   const setAiPanelCollapsed = useAppStore((s) => s.setAiPanelCollapsed);
   const setTaskPanelConversation = useAppStore((s) => s.setTaskPanelConversation);
@@ -1088,7 +1101,7 @@ export function AppShell() {
     <div
       className="flex h-screen bg-[var(--gutter)] text-foreground transition-[padding] duration-200 ease-out"
       style={
-        isMobile
+        isMobile || focusMode
           ? undefined
           : { paddingTop: 10, paddingInlineEnd: taskRailOpen ? 52 : 10, paddingBottom: 0, paddingInlineStart: 0 }
       }
@@ -1105,7 +1118,15 @@ export function AppShell() {
         aria-atomic="true"
         className="sr-only"
       />
-      <Sidebar />
+      <div
+        className={
+          focusMode
+            ? "hidden"
+            : "flex h-full min-h-0 shrink-0 animate-in fade-in slide-in-from-left-4 duration-300 ease-out"
+        }
+      >
+        <Sidebar />
+      </div>
       {/* The main column is transparent (shows the desk gutter). The content
           "sheet" floats inside it (rounded + shadow); the status bar sits
           BELOW the sheet, on the desk — outside the floating page. */}
@@ -1117,7 +1138,23 @@ export function AppShell() {
         <CloudConnectClaudeBanner />
         <CloudTierBanner />
         <CloudUpgradeModal />
-        {!isMobile && <NarrowViewportHint />}
+        {!isMobile && !focusMode && <NarrowViewportHint />}
+        {focusMode && (
+          <div className="viewer-toolbar flex h-10 shrink-0 items-center justify-between px-4 animate-in fade-in slide-in-from-top-2 duration-300 ease-out">
+            <span className="font-logo text-[20px] italic tracking-[-0.01em] text-foreground select-none">
+              <span className="brand-en">cabinet</span>
+            </span>
+            <button
+              type="button"
+              onClick={() => setFocusMode(false)}
+              title={`${t("editor:header.exitFocusMode")} (Esc)`}
+              aria-label={t("editor:header.exitFocusMode")}
+              className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground/70 transition-colors hover:bg-accent hover:text-foreground"
+            >
+              <Minimize2 className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        )}
         {/* The main column IS the desk (transparent). Content floats on an
             elevated ContentSheet; the editor manages its own layout — its
             toolbars sit on the desk — so it opts out of the default sheet. */}
@@ -1129,11 +1166,19 @@ export function AppShell() {
           )}
         </main>
         {terminalOpen && terminalPosition === "bottom" && <TerminalTabs />}
-        {!isMobile && <StatusBar />}
+        {!isMobile && (
+          <div className={focusMode ? "hidden" : "animate-in fade-in duration-300 ease-out"}>
+            <StatusBar />
+          </div>
+        )}
       </div>
-      <MobileBottomNav />
+      {!focusMode && <MobileBottomNav />}
       {terminalOpen && terminalPosition === "right" && <TerminalTabs />}
-      {!isMobile && <TaskRail />}
+      {!isMobile && (
+        <div className={focusMode ? "hidden" : "contents"}>
+          <TaskRail />
+        </div>
+      )}
       <TaskDetailPanel />
       <SearchPalette />
       <FileHistoryPanel />

--- a/src/components/layout/viewer-toolbar.tsx
+++ b/src/components/layout/viewer-toolbar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, type ReactNode } from "react";
-import { Archive, Globe } from "lucide-react";
+import { Archive, Globe, Maximize2 } from "lucide-react";
 import { HeaderActions } from "@/components/layout/header-actions";
 import { ToolbarButton } from "@/components/layout/toolbar-button";
 import { ReturnToChip } from "@/components/layout/return-to-chip";
@@ -48,6 +48,8 @@ export function ViewerToolbar({
   const { t } = useLocale();
   const appMode = useAppStore((s) => s.appMode);
   const setAppMode = useAppStore((s) => s.setAppMode);
+  const focusMode = useAppStore((s) => s.focusMode);
+  const setFocusMode = useAppStore((s) => s.setFocusMode);
   const nodes = useTreeStore((s) => s.nodes);
   const selectedPath = useTreeStore((s) => s.selectedPath);
   const sourcePath = path || selectedPath;
@@ -84,6 +86,10 @@ export function ViewerToolbar({
   // URL isn't browsable (e.g. .md downloads as octet-stream), so no button.
   const isBrowsable = sourceNode?.type === "website" || sourceNode?.type === "app";
 
+  // Focus mode: the whole toolbar disappears — app-shell renders the slim
+  // logo/exit bar instead.
+  if (focusMode) return null;
+
   const modeButtons = !showModeButtons ? null : appMode === "browse" ? (
     // Always offer the exit affordance while browsing, regardless of which node
     // is selected (you may have entered browse from a link in a markdown page).
@@ -109,7 +115,7 @@ export function ViewerToolbar({
         // CSS targets (globals.css) — this bar is a <div>, not a <header>, so
         // without the class the hidden-title-bar window can't be dragged from
         // the editor or any file viewer built on ViewerToolbar.
-        "viewer-toolbar flex shrink-0 items-center justify-between gap-x-3 gap-y-2 px-3 py-1.5 transition-[padding] duration-200 md:h-10 md:py-0",
+        "viewer-toolbar flex shrink-0 items-center justify-between gap-x-3 gap-y-2 px-3 py-1.5 transition-[padding] duration-200 md:h-10 md:py-0 animate-in fade-in slide-in-from-top-1 duration-300 ease-out",
         className
       )}
       style={{ paddingInlineStart: `calc(1rem + var(--sidebar-toggle-offset, 0px))` }}
@@ -133,6 +139,12 @@ export function ViewerToolbar({
         {children}
         {/* File history moved to the sidebar right-click menu — the toolbar
             stays minimal so the content leads. */}
+        <ToolbarButton
+          icon={Maximize2}
+          label={t("editor:header.focusMode")}
+          iconOnly
+          onClick={() => setFocusMode(true)}
+        />
         {modeButtons}
         <HeaderActions />
         <NewTaskButton />

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1070,6 +1070,8 @@
   },
   "editor": {
     "header": {
+      "focusMode": "Full screen",
+      "exitFocusMode": "Exit full screen",
       "exportPage": "Export page",
       "copyMarkdown": "Copy Markdown",
       "copyForLlms": "Copy for LLMs",
@@ -1634,7 +1636,7 @@
     },
     "tabs": {
       "profile": "Profile",
-      "providers": "Providers",
+      "providers": "AI Providers",
       "skills": "Skills",
       "storage": "Storage",
       "integrations": "Integrations",

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -408,7 +408,7 @@ export const THEMES: ThemeDefinition[] = [
     label: "Meadow",
     type: "light",
     font: "'Rubik', var(--font-sans)",
-    headingFont: "'Bitter', Georgia, serif",
+    headingFont: "'Rubik', var(--font-sans)",
     accent: "#16a34a",
     vars: {
       "--background": "oklch(0.97 0.01 140)",

--- a/src/stores/app-store.ts
+++ b/src/stores/app-store.ts
@@ -135,6 +135,9 @@ interface AppState {
   sidebarCollapsed: boolean;
   sidebarDrawer: SidebarDrawer;
   aiPanelCollapsed: boolean;
+  /** Full-screen focus mode: hides sidebars, rails and viewer toolbars —
+   *  only a slim logo/exit bar remains. Session-only, not persisted. */
+  focusMode: boolean;
   cabinetVisibilityModes: Record<string, CabinetVisibilityMode>;
   taskPanelConversation: ConversationMeta | null;
   taskPanelOpen: boolean;
@@ -187,6 +190,7 @@ interface AppState {
   setSidebarCollapsed: (collapsed: boolean) => void;
   setSidebarDrawer: (drawer: SidebarDrawer) => void;
   setAiPanelCollapsed: (collapsed: boolean) => void;
+  setFocusMode: (on: boolean) => void;
   setCabinetVisibilityMode: (
     cabinetPath: string,
     mode: CabinetVisibilityMode
@@ -261,6 +265,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   sidebarCollapsed: loadSidebarCollapsed(),
   sidebarDrawer: loadSidebarDrawer(),
   aiPanelCollapsed: false,
+  focusMode: false,
   cabinetVisibilityModes: loadCabinetVisibilityModes(),
   taskPanelConversation: null,
   taskPanelOpen: false,
@@ -532,6 +537,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     set({ sidebarDrawer: drawer });
   },
   setAiPanelCollapsed: (collapsed) => set({ aiPanelCollapsed: collapsed }),
+  setFocusMode: (on) => set({ focusMode: on }),
   setCabinetVisibilityMode: (cabinetPath, mode) => {
     const normalizedCabinetPath = normalizeVisibilityCabinetPath(cabinetPath);
     const nextModes = {


### PR DESCRIPTION
## What

- **Full-screen focus mode**: a Maximize button on every file-viewer toolbar (code, markdown, PDF, CSV, images, office). It hides the sidebar, task rail, status bar, and all viewer/editing toolbars — only a slim bar with the cabinet wordmark and a minimize button remains. Esc or the minimize button exits.
- Sidebars stay mounted (CSS-hidden) in focus mode, so exiting is instant; returning chrome animates in with the app's existing fade/slide language.
- Source viewer's Wrap / Copy / Download / Raw buttons are now icon-only with tooltips.
- Effort chip in the runtime picker drops its border (Arc Manila: separate by fill, not strokes).
- Meadow theme headings switch from Bitter to Rubik.
- Settings sidebar tab renamed "Providers" → "AI Providers".

## Notes

- `focusMode` is session-only state (not persisted).
- The slim focus bar keeps the `viewer-toolbar` class so the Electron frameless window stays draggable.