### PR TITLE
One-click backend restart for supervised installs

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -246,18 +246,57 @@ async function checkHealth(url, timeoutMs = 1200) {
   }
 }
 
-function spawnBackend(command, args, env) {
+// Backends are restart-by-exit: the in-app Restart button (and any crash)
+// just ends the child process, and this respawn logic brings it back on the
+// same ports/env. `meta` carries the respawn identity; a child that lived
+// under a minute counts toward a crash-loop, and after 5 consecutive quick
+// deaths we stop trying so a broken backend can't spin forever.
+let backendsQuitting = false;
+
+function spawnBackend(command, args, env, meta) {
   const child = spawn(command, args, {
     env,
     stdio: "inherit",
   });
   backendChildren.push(child);
+  const spawnedAt = Date.now();
+  child.on("exit", () => {
+    backendChildren = backendChildren.filter((c) => c !== child);
+    if (backendsQuitting || !meta) {
+      return;
+    }
+    meta.quickDeaths = Date.now() - spawnedAt > 60_000 ? 0 : (meta.quickDeaths || 0) + 1;
+    if (meta.quickDeaths >= 5) {
+      console.error(`electron: ${meta.name} backend is crash-looping — not respawning`);
+      return;
+    }
+    console.warn(`electron: ${meta.name} backend exited — respawning`);
+    setTimeout(() => {
+      if (backendsQuitting) {
+        return;
+      }
+      spawnBackend(command, args, env, meta);
+      if (meta.healthUrl) {
+        // The app server serves every window; once it's back on the same
+        // port, reload windows so they recover from the connection error.
+        waitForHealth(meta.healthUrl)
+          .then(() => {
+            for (const win of BrowserWindow.getAllWindows()) {
+              if (!win.isDestroyed()) {
+                win.webContents.reload();
+              }
+            }
+          })
+          .catch(() => {});
+      }
+    }, 1000);
+  });
   return child;
 }
 
-function spawnNodeBackend(args, env) {
+function spawnNodeBackend(args, env, meta) {
   if (isDev) {
-    return spawnBackend(process.execPath, args, env);
+    return spawnBackend(process.execPath, args, env, meta);
   }
 
   const bundledNodePath = path.join(
@@ -270,15 +309,20 @@ function spawnNodeBackend(args, env) {
   );
 
   if (fs.existsSync(bundledNodePath)) {
-    return spawnBackend(bundledNodePath, args, env);
+    return spawnBackend(bundledNodePath, args, env, meta);
   }
 
-  return spawnBackend(process.execPath, args, {
-    ...env,
-    // Fallback for older packages that do not yet bundle a standalone Node
-    // runtime alongside the embedded Next.js server.
-    ELECTRON_RUN_AS_NODE: "1",
-  });
+  return spawnBackend(
+    process.execPath,
+    args,
+    {
+      ...env,
+      // Fallback for older packages that do not yet bundle a standalone Node
+      // runtime alongside the embedded Next.js server.
+      ELECTRON_RUN_AS_NODE: "1",
+    },
+    meta
+  );
 }
 
 function packagedStandalonePath(...parts) {
@@ -463,8 +507,12 @@ async function startEmbeddedCabinet() {
     NODE_PATH: [externalModulesDir, env.NODE_PATH].filter(Boolean).join(path.delimiter),
   };
 
-  spawnNodeBackend([serverEntry], env);
-  spawnNodeBackend([daemonEntry], daemonEnv);
+  backendsQuitting = false;
+  spawnNodeBackend([serverEntry], env, {
+    name: "app",
+    healthUrl: `${appOrigin}/api/health`,
+  });
+  spawnNodeBackend([daemonEntry], daemonEnv, { name: "daemon" });
 
   await waitForHealth(`${appOrigin}/api/health`);
   return { appUrl: appOrigin };
@@ -562,6 +610,7 @@ function configureAutoUpdates() {
 }
 
 function cleanupBackends() {
+  backendsQuitting = true;
   for (const child of backendChildren) {
     child.kill("SIGTERM");
   }

--- a/server/cabinet-daemon.ts
+++ b/server/cabinet-daemon.ts
@@ -1920,6 +1920,17 @@ const server = http.createServer(async (req, res) => {
     return;
   }
 
+  // Restart-by-exit: the daemon never respawns itself — whoever supervises it
+  // does (Electron main respawns the child; the cloud entrypoint exits and the
+  // container restart policy relaunches everything). Token-gated above.
+  if (url.pathname === "/restart" && req.method === "POST") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true, restarting: true }));
+    console.log("[daemon] restart requested — exiting for supervisor respawn");
+    setTimeout(() => process.exit(0), 250);
+    return;
+  }
+
   // Health check
   if (url.pathname === "/health") {
     res.writeHead(200, { "Content-Type": "application/json" });

--- a/src/app/api/system/restart/route.ts
+++ b/src/app/api/system/restart/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import { restartDaemon } from "@/lib/agents/daemon-client";
+import { isCloud } from "@/lib/cloud/tier";
+import { isElectronRuntime } from "@/lib/runtime/runtime-config";
+
+// Restart-by-exit: this route never respawns anything itself — it asks the
+// target process to exit and relies on the supervisor to bring it back
+// (Electron main respawns its children; the cloud container's entrypoint
+// exits when either process dies and docker's restart policy relaunches
+// both). Source installs have no supervisor, so restarting there stays a
+// terminal affair and this route refuses.
+
+function supervised(): boolean {
+  return isCloud() || isElectronRuntime();
+}
+
+function exitSoon(): void {
+  // Give the response time to flush before the process goes away.
+  setTimeout(() => process.exit(0), 300);
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => ({}));
+  const target = body?.target === "app" || body?.target === "all" ? body.target : "daemon";
+
+  if (target === "daemon") {
+    if (await restartDaemon()) {
+      return NextResponse.json({ ok: true, restarting: "daemon" });
+    }
+    // Daemon too wedged to accept HTTP. In the cloud the whole container
+    // restarts when this process exits, which recovers the daemon too.
+    if (isCloud()) {
+      exitSoon();
+      return NextResponse.json({ ok: true, restarting: "all" });
+    }
+    return NextResponse.json(
+      { error: "The daemon is not responding to a restart request." },
+      { status: 502 }
+    );
+  }
+
+  if (!supervised()) {
+    return NextResponse.json(
+      { error: "No supervisor to restart the app server on this install." },
+      { status: 400 }
+    );
+  }
+
+  exitSoon();
+  return NextResponse.json({ ok: true, restarting: isCloud() ? "all" : "app" });
+}

--- a/src/components/layout/status-bar.tsx
+++ b/src/components/layout/status-bar.tsx
@@ -13,6 +13,7 @@ import {
   useHealthStore,
 } from "@/stores/health-store";
 import { useGithubStatsStore } from "@/stores/github-stats-store";
+import { useIsCloud } from "@/lib/cloud/client-tier";
 import { StarExplosion, formatGithubStars } from "@/components/layout/star-explosion";
 import { dedupFetch } from "@/lib/api/dedup-fetch";
 import { useLocale } from "@/i18n/use-locale";
@@ -248,6 +249,37 @@ export function StatusBar() {
   const daemonAlive = daemonLevel !== "down";
 
   const [showServerPopup, setShowServerPopup] = useState(false);
+
+  // Restart affordance for non-technical installs: only where a supervisor
+  // exists to bring the process back (Electron main respawns children; the
+  // cloud container's restart policy relaunches everything). Source installs
+  // keep the textual command tips below.
+  const isCloudEdition = useIsCloud() === true;
+  const isElectronInstall =
+    installKind === "electron-macos" || installKind === "electron-windows";
+  const canRestartBackend = isCloudEdition || isElectronInstall;
+  const [restarting, setRestarting] = useState(false);
+  useEffect(() => {
+    // The 5s health poll is the source of truth — clear the spinner when the
+    // daemon reports healthy again, or after 90s if it never comes back.
+    if (restarting && daemonAlive) setRestarting(false);
+  }, [restarting, daemonAlive]);
+  useEffect(() => {
+    if (!restarting) return;
+    const id = window.setTimeout(() => setRestarting(false), 90_000);
+    return () => window.clearTimeout(id);
+  }, [restarting]);
+  const requestBackendRestart = useCallback(() => {
+    setRestarting(true);
+    // In the cloud the whole container can bounce mid-request, so a network
+    // error here still means the restart is underway — swallow it and let
+    // the health poll flip the row back to green.
+    void fetch("/api/system/restart", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ target: "daemon" }),
+    }).catch(() => {});
+  }, []);
 
   // Tick a "now" value while the popover is open so the relative-time
   // strings ("13s ago") stay fresh even when no poll has fired in the
@@ -504,6 +536,19 @@ export function StatusBar() {
                       <span className={`inline-block h-1.5 w-1.5 rounded-full shrink-0 ${daemonAlive ? "bg-green-500" : "bg-red-500"}`} />
                       <span className="font-medium text-foreground/80">{t("status:server.daemon")}</span>
                       <span className={`ml-auto ${daemonAlive ? "text-green-500" : "text-red-500"}`}>{daemonAlive ? t("status:server.running") : t("status:server.down")}</span>
+                      {/* One-click recovery where a supervisor can respawn the
+                          daemon; restart-by-exit, the health poll confirms. */}
+                      {!daemonAlive && appAlive && canRestartBackend && (
+                        <button
+                          type="button"
+                          onClick={requestBackendRestart}
+                          disabled={restarting}
+                          className="flex items-center gap-1 rounded bg-foreground px-1.5 py-0.5 text-[9px] font-medium text-background hover:bg-foreground/85 disabled:opacity-60"
+                        >
+                          {restarting && <Loader2 className="h-2.5 w-2.5 animate-spin" aria-hidden="true" />}
+                          {restarting ? t("status:server.restarting") : t("status:server.restart")}
+                        </button>
+                      )}
                     </div>
                     <p className="text-[10px] text-muted-foreground/70 pl-3.5">
                       {daemonAlive
@@ -573,13 +618,17 @@ export function StatusBar() {
                     <div className="pt-1.5 border-t border-border space-y-1">
                       <p className="text-[10px] font-medium text-foreground/70">{t("status:server.howToFix")}</p>
                       {(!appAlive || !daemonAlive) && (
-                        installKind === "electron-macos" ? (
+                        isCloudEdition ? (
                           <p className="text-[10px] text-muted-foreground">
-                            {!appAlive && !daemonAlive
-                              ? "Both servers are down. Try quitting and reopening the Cabinet app."
-                              : !appAlive
-                              ? "The app server is not responding. Try quitting and reopening the Cabinet app."
-                              : "The background daemon is not running. Try quitting and reopening the Cabinet app. If the issue persists, check Activity Monitor for stuck Cabinet processes."}
+                            {!appAlive
+                              ? "Your cabinet is restarting itself. This page should recover within a minute — if it doesn't, refresh your browser."
+                              : "The background service stopped. Click Restart above — your cabinet will be back in about a minute."}
+                          </p>
+                        ) : isElectronInstall ? (
+                          <p className="text-[10px] text-muted-foreground">
+                            {!appAlive
+                              ? "The app server is not responding. It restarts itself automatically — if this message persists, quit and reopen the Cabinet app."
+                              : "The background daemon is not running. Click Restart above; if the issue persists, quit and reopen the Cabinet app."}
                           </p>
                         ) : installKind === "source-managed" ? (
                           <p className="text-[10px] text-muted-foreground">

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1909,6 +1909,8 @@
       "degraded": "Degraded",
       "allSystemsRunning": "All Systems Running",
       "serviceDisruption": "Service Disruption",
+      "restart": "Restart",
+      "restarting": "Restarting…",
       "appServer": "App Server",
       "daemon": "Daemon",
       "agentProviders": "Agent Providers",

--- a/src/lib/agents/daemon-client.ts
+++ b/src/lib/agents/daemon-client.ts
@@ -212,6 +212,22 @@ export async function isDaemonSessionAlive(id: string): Promise<boolean> {
   }
 }
 
+/**
+ * Ask the daemon to exit so its supervisor respawns it. Returns false when
+ * the daemon can't be reached (already dead or wedged past accepting HTTP).
+ */
+export async function restartDaemon(): Promise<boolean> {
+  try {
+    const response = await daemonFetch("/restart", {
+      method: "POST",
+      signal: AbortSignal.timeout(3000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
 export async function reloadDaemonSchedules(): Promise<void> {
   const response = await daemonFetch("/reload-schedules", {
     method: "POST",

--- a/src/stores/health-store.ts
+++ b/src/stores/health-store.ts
@@ -1,8 +1,10 @@
 import { create } from "zustand";
 import { dedupFetch } from "@/lib/api/dedup-fetch";
 
+import type { InstallKind } from "@/types/update";
+
 export type ServiceLevel = "unknown" | "ok" | "degraded" | "down";
-export type InstallKind = "source-managed" | "source-custom" | "electron-macos";
+export type { InstallKind };
 
 interface HealthState {
   appMissCount: number; // -1 = no poll completed yet


### PR DESCRIPTION
## What

- Daemon: new token-gated `POST /restart` — replies OK and exits; the supervisor respawns it.
- App server: new `POST /api/system/restart` — `target: "daemon"` asks the daemon to exit; on cloud, a wedged daemon falls back to exiting the app server so the container restart policy bounces everything. `target: "app"/"all"` allowed only where a supervisor exists (cloud/Electron).
- Electron: backends respawn automatically on unexpected exit (crash-loop guard: 5 quick deaths → stop), windows reload once the app server is healthy again.
- Status popover: a **Restart** button on the Daemon row when the install is Electron or cloud, with "Restarting…" until the health poll flips the row green. Cloud users get plain-language tips instead of npm commands; `electron-windows` now gets the Electron tips (previously fell through to source-install tips).

## Why

Cloud launch targets non-technical users — a red "Down" row must have a button, not a terminal command.

## Verified

- Live against dev servers: daemon `/restart` 401s without a token; authenticated app-route restart exits the daemon; 502 path exercised when the daemon is already down; daemon recovered via supervisor respawn.
- `tsc --noEmit` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)