### PR TITLE
Warn at boot when KB_PASSWORD is set but empty

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -35,6 +35,14 @@ export async function register(): Promise<void> {
   } catch (err) {
     console.error("instrumentation: ensureAuthSalt failed", err);
   }
+  // A present-but-empty KB_PASSWORD (e.g. a dangling `KB_PASSWORD=` line in
+  // .env.local) silently disables password protection — warn so an operator
+  // who thinks they enabled auth finds out at boot, not from an open KB.
+  if (process.env.KB_PASSWORD === "") {
+    console.warn(
+      "[auth] KB_PASSWORD is set but EMPTY — password protection is OFF. Set a value or remove the line."
+    );
+  }
   try {
     const { ensureGlobalAgents } = await import("./lib/agents/library-manager");
     await ensureGlobalAgents();


### PR DESCRIPTION
A dangling `KB_PASSWORD=` line (empty value) silently disables password protection — that's the documented meaning of an empty value, but it's easy to write it believing auth is now on. This logs a clear one-line warning at server boot.

Found while chasing a dev server reporting `authEnabled: false` "despite" KB_PASSWORD being set — the value was empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)