### PR TITLE
fix: fall back to a neutral trigger badge for unknown triggers (#85)

### DIFF
--- a/src/components/tasks/board/list-view.tsx
+++ b/src/components/tasks/board/list-view.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { Bot, Clock3, HeartPulse } from "lucide-react";
+import { Bot, CircleHelp, Clock3, HeartPulse, type LucideIcon } from "lucide-react";
 import { TelegramMark } from "@/components/integrations/telegram-mark";
 import { cn } from "@/lib/utils";
 import type { TaskMeta } from "@/types/tasks";
 import type { CabinetAgentSummary } from "@/types/cabinets";
 import type { LaneKey } from "./lane-rules";
+import { resolveTriggerBadge, type TriggerIconKind } from "./trigger-badge";
 import { AgentPill } from "./agent-pill";
 import { RowActions } from "./row-actions";
 import { SelectCheckbox } from "./select-checkbox";
@@ -26,46 +27,20 @@ function relTime(fromIso: string | undefined, now: number): string {
   return `${Math.floor(hours / 24)}d ago`;
 }
 
-// Audit #134: badges used to ride saturated 500-tier sky/emerald/pink/
-// violet, which fought the warm paper theme. Now they share a single
-// muted/theme-aware look — the icon shape (Bot / Clock3 / HeartPulse /
-// Sparkles) carries the trigger meaning, and the badge just sits politely
-// on whatever surface the active theme paints.
-const TRIGGER_STYLES: Record<
-  NonNullable<TaskMeta["trigger"]>,
-  { label: string; className: string }
+const TRIGGER_ICONS: Record<
+  Exclude<TriggerIconKind, "telegram">,
+  LucideIcon
 > = {
-  manual: {
-    label: "Manual",
-    className: "bg-muted text-muted-foreground ring-1 ring-border/60",
-  },
-  job: {
-    label: "Job",
-    className: "bg-muted text-muted-foreground ring-1 ring-border/60",
-  },
-  heartbeat: {
-    label: "Heartbeat",
-    className: "bg-muted text-muted-foreground ring-1 ring-border/60",
-  },
-  agent: {
-    label: "Agent",
-    className: "bg-muted text-muted-foreground ring-1 ring-border/60",
-  },
-  telegram: {
-    label: "Telegram",
-    className: "bg-muted text-muted-foreground ring-1 ring-border/60",
-  },
-  channel: {
-    label: "Channel",
-    className: "bg-muted text-muted-foreground ring-1 ring-border/60",
-  },
+  bot: Bot,
+  clock: Clock3,
+  heartbeat: HeartPulse,
+  unknown: CircleHelp,
 };
 
 function TriggerBadge({ trigger }: { trigger: TaskMeta["trigger"] }) {
-  if (!trigger) return null;
-  const style = TRIGGER_STYLES[trigger];
-  const Icon =
-    trigger === "manual" ? Bot : trigger === "job" ? Clock3 : HeartPulse;
+  const style = resolveTriggerBadge(trigger);
+  if (!style) return null;
+  const Icon = style.icon === "telegram" ? null : TRIGGER_ICONS[style.icon];
   return (
     <span
       title={style.label}
@@ -75,10 +50,10 @@ function TriggerBadge({ trigger }: { trigger: TaskMeta["trigger"] }) {
         style.className
       )}
     >
-      {trigger === "telegram" ? (
-        <TelegramMark className="size-3" />
-      ) : (
+      {Icon ? (
         <Icon className="size-2.75" />
+      ) : (
+        <TelegramMark className="size-3" />
       )}
     </span>
   );

--- a/src/components/tasks/board/trigger-badge.test.ts
+++ b/src/components/tasks/board/trigger-badge.test.ts
@@ -1,0 +1,51 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { resolveTriggerBadge } from "./trigger-badge";
+
+test("known triggers keep their label and icon", () => {
+  assert.deepEqual(resolveTriggerBadge("manual")?.label, "Manual");
+  assert.equal(resolveTriggerBadge("manual")?.icon, "bot");
+  assert.equal(resolveTriggerBadge("job")?.icon, "clock");
+  assert.equal(resolveTriggerBadge("heartbeat")?.icon, "heartbeat");
+  assert.equal(resolveTriggerBadge("telegram")?.icon, "telegram");
+  assert.equal(resolveTriggerBadge("agent")?.label, "Agent");
+  assert.equal(resolveTriggerBadge("channel")?.label, "Channel");
+});
+
+test("every known trigger resolves to a non-empty className", () => {
+  for (const trigger of ["manual", "job", "heartbeat", "agent", "telegram", "channel"]) {
+    const style = resolveTriggerBadge(trigger);
+    assert.ok(style, `${trigger} should resolve`);
+    assert.ok(style.className.length > 0, `${trigger} should have a className`);
+  }
+});
+
+test("missing trigger renders no badge", () => {
+  assert.equal(resolveTriggerBadge(undefined), null);
+  assert.equal(resolveTriggerBadge(""), null);
+});
+
+// Regression: issue #85. Task data is written to disk by agents and older
+// Cabinet versions, so `trigger` can hold a value outside the TaskTrigger
+// union. The lookup used to return undefined and crash the whole board on
+// `style.label`.
+test("unknown trigger falls back to a usable badge instead of crashing", () => {
+  const style = resolveTriggerBadge("webhook");
+  assert.ok(style, "unknown trigger should still resolve to a badge");
+  assert.equal(style.label, "webhook");
+  assert.equal(style.icon, "unknown");
+  assert.ok(style.className.length > 0);
+});
+
+// Inherited Object.prototype keys must not be mistaken for known triggers:
+// `TRIGGER_STYLES["constructor"]` is truthy but has no label/className/icon.
+test("prototype-chain keys are treated as unknown triggers", () => {
+  for (const trigger of ["constructor", "toString", "__proto__", "hasOwnProperty"]) {
+    const style = resolveTriggerBadge(trigger);
+    assert.ok(style, `${trigger} should resolve to a badge`);
+    assert.equal(style.icon, "unknown", `${trigger} should be treated as unknown`);
+    assert.equal(typeof style.label, "string");
+    assert.equal(typeof style.className, "string");
+  }
+});

--- a/src/components/tasks/board/trigger-badge.ts
+++ b/src/components/tasks/board/trigger-badge.ts
@@ -1,0 +1,53 @@
+import type { TaskMeta } from "@/types/tasks";
+
+export type TriggerIconKind =
+  | "bot"
+  | "clock"
+  | "heartbeat"
+  | "telegram"
+  | "unknown";
+
+export interface TriggerBadgeStyle {
+  label: string;
+  className: string;
+  icon: TriggerIconKind;
+}
+
+// Audit #134: badges used to ride saturated 500-tier sky/emerald/pink/
+// violet, which fought the warm paper theme. Now they share a single
+// muted/theme-aware look — the icon shape carries the trigger meaning, and
+// the badge just sits politely on whatever surface the active theme paints.
+const BADGE_CLASS = "bg-muted text-muted-foreground ring-1 ring-border/60";
+
+const TRIGGER_STYLES: Record<
+  NonNullable<TaskMeta["trigger"]>,
+  TriggerBadgeStyle
+> = {
+  manual: { label: "Manual", className: BADGE_CLASS, icon: "bot" },
+  job: { label: "Job", className: BADGE_CLASS, icon: "clock" },
+  heartbeat: { label: "Heartbeat", className: BADGE_CLASS, icon: "heartbeat" },
+  agent: { label: "Agent", className: BADGE_CLASS, icon: "heartbeat" },
+  telegram: { label: "Telegram", className: BADGE_CLASS, icon: "telegram" },
+  channel: { label: "Channel", className: BADGE_CLASS, icon: "heartbeat" },
+};
+
+/**
+ * Resolve the badge style for a task trigger, or null when there is nothing
+ * to render.
+ *
+ * `trigger` is typed as a closed union, but task metadata is persisted to
+ * disk by agents and by older Cabinet versions, so at runtime it can hold any
+ * string. An unrecognised value gets a neutral badge labelled with the raw
+ * trigger rather than crashing the board (issue #85). `Object.hasOwn` keeps
+ * inherited keys like `constructor` out of the known set — they are truthy on
+ * a plain object literal but carry no label, className, or icon.
+ */
+export function resolveTriggerBadge(
+  trigger: string | null | undefined
+): TriggerBadgeStyle | null {
+  if (!trigger) return null;
+  if (Object.hasOwn(TRIGGER_STYLES, trigger)) {
+    return TRIGGER_STYLES[trigger as NonNullable<TaskMeta["trigger"]>];
+  }
+  return { label: trigger, className: BADGE_CLASS, icon: "unknown" };
+}


### PR DESCRIPTION
Fixes #85.

## Problem

`TaskTrigger` is a closed union at the type level (`manual | job | heartbeat | agent | telegram | channel`), but task metadata is persisted to disk by agents and by older Cabinet versions, so at runtime `trigger` can hold any string. In `list-view.tsx`, `TRIGGER_STYLES[trigger]` then returned `undefined` and `style.label` threw during render — taking down the **entire** Tasks/Board page, not just the offending row.

The unknown values enter at `src/lib/agents/conversation-to-task-view.ts:38`, which copies `trigger` straight out of persisted metadata with no schema validating it.

## Fix

Extract the lookup into a pure `resolveTriggerBadge()` module alongside `lane-rules.ts`. Unknown non-empty triggers now resolve to a neutral badge labelled with the raw trigger value. Known triggers keep their existing label, icon, and styling; empty/undefined still renders nothing.

Two things found while fixing that the issue didn't mention:

- A trigger named `constructor` or `toString` would hit the `Object.prototype` chain of the plain object literal and return a **truthy** non-style value — so the obvious `if (!style) return null` guard would still have crashed on the undefined icon. The lookup is guarded with `Object.hasOwn`.
- `kanban-view.tsx` / `task-card.tsx` are **not** affected: `task-card.tsx:144` only does an equality check (`task.trigger === "telegram"`), which is undefined-safe. No change needed there.

## Why a separate module

The repo's test runner is `tsx --test` over `*.test.ts` only — there is no React renderer or `.tsx` test in the tree — so component-level assertions aren't directly testable. This follows the existing `lane-rules.ts` precedent: pure decision logic in a plain `.ts` sibling, unit-tested, with the `.tsx` left as a thin render layer.

## Verification

- `npx tsx --test src/components/tasks/board/trigger-badge.test.ts` — red before the fix (module absent), **5 pass / 0 fail** after.
- `npm test` on this branch — **358 pass / 1 fail**. The +5 over the 353 baseline are the new tests; the single failure is a pre-existing red at `test/cabinet-v2.test.ts:111` that is already failing on `main` and is unrelated to this change.
- `npx tsc --noEmit` — exit 0. `eslint` on changed files — exit 0.

## Risk

Low. The fallback badge renders the raw trigger string into `title`/`aria-label`; React escapes it, so it is not an injection vector, though a pathologically long trigger value would produce a long tooltip. Behavior for all six known triggers is unchanged.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)