### PR TITLE
test: guard the /login prerender Suspense boundary (#141)

### DIFF
--- a/test/search-params-suspense.test.ts
+++ b/test/search-params-suspense.test.ts
@@ -1,0 +1,144 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+// Next.js refuses to prerender a page whose tree calls useSearchParams() outside a
+// <Suspense> boundary, and `next build` exits on it — the /login failure in #141.
+// A full production build takes minutes, so the invariant is guarded at the source
+// level instead: any module that reads search params owns a Suspense boundary, and
+// a page's default export never reads them itself (the boundary must sit above the
+// reader, so wrapping the caller's own JSX in <Suspense> does not help).
+
+const SRC_DIR = join(__dirname, "..", "src");
+
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+}
+
+// Body of `export default function ...`, brace-matched, or null when the file has no
+// function-declaration default export.
+function defaultExportBody(source: string): string | null {
+  const marker = /export\s+default\s+function\s+\w*\s*\([^)]*\)\s*{/.exec(source);
+  if (!marker) return null;
+  const start = marker.index + marker[0].length - 1;
+  let depth = 0;
+  for (let i = start; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}" && --depth === 0) return source.slice(start, i + 1);
+  }
+  return source.slice(start);
+}
+
+function findSearchParamsViolations(source: string): string[] {
+  const code = stripComments(source);
+  if (!/\buseSearchParams\s*\(/.test(code)) return [];
+
+  const violations: string[] = [];
+  if (!/<Suspense[\s/>]/.test(code)) {
+    violations.push("reads useSearchParams() but declares no <Suspense> boundary");
+  }
+  const body = defaultExportBody(code);
+  if (body && /\buseSearchParams\s*\(/.test(body)) {
+    violations.push(
+      "calls useSearchParams() inside the default-exported component; move the call " +
+        "into a child rendered under <Suspense>"
+    );
+  }
+  return violations;
+}
+
+function collectSources(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...collectSources(full));
+    else if (/\.tsx?$/.test(entry.name)) files.push(full);
+  }
+  return files;
+}
+
+test("the detector flags the unwrapped page shape reported in #141", () => {
+  const brokenPage = `"use client";
+import { useState } from "react";
+import { useSearchParams } from "next/navigation";
+
+export default function LoginPage() {
+  const searchParams = useSearchParams();
+  const [error] = useState(searchParams.get("error") ?? "");
+  return <p>{error}</p>;
+}`;
+
+  assert.deepEqual(findSearchParamsViolations(brokenPage), [
+    "reads useSearchParams() but declares no <Suspense> boundary",
+    "calls useSearchParams() inside the default-exported component; move the call " +
+      "into a child rendered under <Suspense>",
+  ]);
+});
+
+test("the detector flags a page that wraps its own JSX instead of a child", () => {
+  const stillBroken = `"use client";
+import { Suspense } from "react";
+import { useSearchParams } from "next/navigation";
+
+export default function LoginPage() {
+  const searchParams = useSearchParams();
+  return <Suspense fallback={null}><p>{searchParams.get("error")}</p></Suspense>;
+}`;
+
+  assert.deepEqual(findSearchParamsViolations(stillBroken), [
+    "calls useSearchParams() inside the default-exported component; move the call " +
+      "into a child rendered under <Suspense>",
+  ]);
+});
+
+test("the detector accepts a reader wrapped in a Suspense boundary", () => {
+  const fixed = `"use client";
+import { Suspense } from "react";
+import { useSearchParams } from "next/navigation";
+
+function LoginForm() {
+  const searchParams = useSearchParams();
+  return <p>{searchParams.get("error")}</p>;
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense fallback={null}>
+      <LoginForm />
+    </Suspense>
+  );
+}`;
+
+  assert.deepEqual(findSearchParamsViolations(fixed), []);
+});
+
+test("the detector ignores useSearchParams mentioned only in a comment", () => {
+  const prose = `// useSearchParams() needs a boundary, which is why this file avoids it.
+export default function Page() {
+  return <p>hi</p>;
+}`;
+
+  assert.deepEqual(findSearchParamsViolations(prose), []);
+});
+
+test("no source file reads search params outside a Suspense boundary", () => {
+  const sources = collectSources(SRC_DIR);
+  assert.ok(sources.length > 0, "expected to scan at least one source file");
+
+  const offenders: string[] = [];
+  for (const file of sources) {
+    for (const violation of findSearchParamsViolations(readFileSync(file, "utf8"))) {
+      offenders.push(`${relative(SRC_DIR, file)}: ${violation}`);
+    }
+  }
+
+  assert.deepEqual(offenders, [], `next build would fail to prerender:\n${offenders.join("\n")}`);
+});
+
+test("the login page keeps its search-param reader behind a Suspense boundary", () => {
+  const source = readFileSync(join(SRC_DIR, "app", "login", "page.tsx"), "utf8");
+
+  assert.match(source, /\buseSearchParams\s*\(/, "login page still reads the ?error param");
+  assert.deepEqual(findSearchParamsViolations(source), []);
+});


### PR DESCRIPTION
Re: #141. **No production fix — the reported failure no longer reproduces.** This PR adds a regression guard and records one remaining blocker.

## The reported bug is already gone

`src/app/login/page.tsx` already reads the `?error` param inside a child (`LoginForm`) wrapped in `<Suspense>`. Issue #141 was filed 2026-06-15; the login page was rewritten on 2026-07-10 by 56e84cdc (#188) and was created already carrying the boundary — so the fix landed incidentally, after the report.

Verified empirically rather than by inspection: a clean `npm run build` (with `.next` removed) exits **0**, "Compiled successfully", 90/90 static pages, and `/login` is listed as prerendered static.

## What this PR adds instead

A source-level regression guard. Next refuses to prerender a page whose tree calls `useSearchParams()` outside a `<Suspense>` boundary, and `next build` exits on it — but a full production build takes ~12 minutes and cannot be a test. So the invariant is enforced statically over `src/`:

1. Any module reading `useSearchParams()` must declare a `<Suspense>` boundary.
2. A page's default export must never read search params itself — the boundary has to sit **above** the reader, so the naive "wrap your own JSX in `<Suspense>`" fix still fails prerender and is caught here.

**Proved red-able:** temporarily reverting `login/page.tsx` to the exact shape described in the issue turned the two repo-guard tests RED ("next build would fail to prerender"); the page was then restored with zero diffs.

## Remaining blocker (not fixed here)

The packaging chain past the build is clear locally — `postbuild` → OK, `npm run electron:prep` → exit 0, `electron-forge package` for linux x64 → exit 0, and for win32 → exit 0, producing `Cabinet.exe` + `resources/app.asar`.

**`electron-forge make` could not be exercised.** Every maker in `forge.config.cjs` is scoped to darwin/win32 (`MakerZIP[darwin]`, `MakerZIP[win32]`, `MakerDMG`, `MakerSquirrel[win32]`), so a Linux host has no make target. **Squirrel installer generation stays unverified and needs a Windows runner.** Recorded rather than worked around.

## Verification

- `npx tsx --test test/search-params-suspense.test.ts` — **6 pass / 0 fail**.
- `npm test` on this branch — **359 pass / 1 fail**; the single failure is a pre-existing red at `test/cabinet-v2.test.ts:111`, already failing on `main` and unrelated.
- `npx tsc --noEmit` — exit 0. `eslint` on the new test — exit 0.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)