### PR TITLE
Native drag-and-drop uploads: folders, progress, 1GB streaming

### DIFF
--- a/src/app/api/upload/[...path]/route.ts
+++ b/src/app/api/upload/[...path]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import path from "path";
+import { createWriteStream } from "fs";
 import { resolveContentPath } from "@/lib/storage/path-utils";
 import { ensureDirectory, fileExists } from "@/lib/storage/fs-operations";
 import { invalidateTreeCache } from "@/lib/storage/tree-builder";
@@ -7,10 +8,14 @@ import { autoCommit } from "@/lib/git/git-service";
 import { assertWritablePath, ReadOnlySourceError } from "@/lib/knowledge-sources/store";
 import fs from "fs/promises";
 import { storageOverCap } from "@/lib/cloud/tier";
+import { requireApiAuth } from "@/lib/auth/request-gate";
 
 type RouteParams = { params: Promise<{ path: string[] }> };
 
+// POST buffers the whole multipart body in memory, so it stays small-only
+// (editor paste). Large files go through PUT, which streams to disk.
 const MAX_UPLOAD_BYTES = 25 * 1024 * 1024; // 25MB
+const MAX_STREAM_BYTES = 1024 * 1024 * 1024; // 1GB
 const EXECUTABLE_EXTENSIONS = new Set([
   ".exe",
   ".msi",
@@ -34,8 +39,60 @@ function hasExecutableExtension(filename: string): boolean {
   return EXECUTABLE_EXTENSIONS.has(ext);
 }
 
+async function uniqueFilename(dir: string, rawName: string) {
+  let filename = rawName.replace(/[^a-zA-Z0-9._-]/g, "-");
+  const ext = path.extname(filename);
+  const base = path.basename(filename, ext);
+  let filePath = path.join(dir, filename);
+  let counter = 1;
+  while (await fileExists(filePath)) {
+    filename = `${base}-${counter}${ext}`;
+    filePath = path.join(dir, filename);
+    counter++;
+  }
+  return { filename, filePath };
+}
+
+function uploadResponse(
+  virtualPath: string,
+  originalName: string,
+  filename: string,
+  mimeType: string
+) {
+  let markdown: string;
+  if (mimeType.startsWith("image/")) {
+    markdown = `![${originalName}](./${filename})`;
+  } else if (mimeType.startsWith("video/")) {
+    markdown = `<video src="./${filename}" controls></video>`;
+  } else {
+    markdown = `[${originalName}](./${filename})`;
+  }
+  return NextResponse.json({
+    ok: true,
+    filename,
+    markdown,
+    url: `/api/assets/${virtualPath}/${filename}`,
+  });
+}
+
+function finishUpload(virtualPath: string, filename: string, skipCommit: boolean) {
+  if (!skipCommit) {
+    autoCommit(`${virtualPath}/${filename}`, "Add");
+  }
+  // Refresh the tree for visible imports (sidebar Import File). Skip hidden
+  // targets (e.g. conversation attachments) so editor pastes don't thrash
+  // the 5s buildTree cache.
+  if (!virtualPath.split("/").some((seg) => seg.startsWith("."))) {
+    invalidateTreeCache();
+  }
+}
+
 export async function POST(req: NextRequest, { params }: RouteParams) {
   try {
+    // This route sits outside the proxy matcher (large bodies must not be
+    // cloned/truncated by it), so the auth gate runs here instead.
+    const denied = await requireApiAuth(req);
+    if (denied) return denied;
     if (await storageOverCap()) {
       return NextResponse.json(
         { error: "Storage full — the free plan is capped. Upgrade for more room.", errorKind: "storage" },
@@ -74,47 +131,94 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
       );
     }
 
-    let filename = file.name.replace(/[^a-zA-Z0-9._-]/g, "-");
-    const ext = path.extname(filename);
-    const base = path.basename(filename, ext);
-    let filePath = path.join(resolved, filename);
-    let counter = 1;
-
-    while (await fileExists(filePath)) {
-      filename = `${base}-${counter}${ext}`;
-      filePath = path.join(resolved, filename);
-      counter++;
-    }
+    const { filename, filePath } = await uniqueFilename(resolved, file.name);
 
     const buffer = Buffer.from(await file.arrayBuffer());
     await fs.writeFile(filePath, buffer);
-    if (!skipCommit) {
-      autoCommit(`${virtualPath}/${filename}`, "Add");
+    finishUpload(virtualPath, filename, skipCommit);
+    return uploadResponse(virtualPath, file.name, filename, file.type || "");
+  } catch (error) {
+    if (error instanceof ReadOnlySourceError) {
+      return NextResponse.json({ error: error.message }, { status: 403 });
+    }
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+// Streaming upload for large files: raw body piped to disk in chunks, so
+// memory stays flat regardless of file size. ?name=<filename> is required;
+// ?type=<mime> and ?commit=0 are optional.
+export async function PUT(req: NextRequest, { params }: RouteParams) {
+  try {
+    const denied = await requireApiAuth(req);
+    if (denied) return denied;
+    if (await storageOverCap()) {
+      return NextResponse.json(
+        { error: "Storage full — the free plan is capped. Upgrade for more room.", errorKind: "storage" },
+        { status: 402 },
+      );
+    }
+    const { path: segments } = await params;
+    const virtualPath = segments.join("/");
+    await assertWritablePath(`${virtualPath}/upload`);
+    const resolved = resolveContentPath(virtualPath);
+    const { searchParams } = new URL(req.url);
+    const skipCommit = searchParams.get("commit") === "0";
+    const rawName = searchParams.get("name") || "";
+    const mimeType = searchParams.get("type") || "";
+
+    if (!rawName) {
+      return NextResponse.json({ error: "Missing name parameter" }, { status: 400 });
+    }
+    if (hasExecutableExtension(rawName)) {
+      return NextResponse.json(
+        { error: "Executable files are not allowed" },
+        { status: 415 }
+      );
+    }
+    const sizeError = NextResponse.json(
+      { error: `File exceeds ${MAX_STREAM_BYTES / 1024 / 1024 / 1024}GB size limit` },
+      { status: 413 }
+    );
+    const declared = Number(req.headers.get("content-length") || 0);
+    if (declared > MAX_STREAM_BYTES) return sizeError;
+    if (!req.body) {
+      return NextResponse.json({ error: "No file provided" }, { status: 400 });
     }
 
-    // Refresh the tree for visible imports (sidebar Import File). Skip hidden
-    // targets (e.g. conversation attachments) so editor pastes don't thrash
-    // the 5s buildTree cache.
-    if (!virtualPath.split("/").some((seg) => seg.startsWith("."))) {
-      invalidateTreeCache();
+    await ensureDirectory(resolved);
+    const { filename, filePath } = await uniqueFilename(resolved, rawName);
+
+    const ws = createWriteStream(filePath);
+    const reader = req.body.getReader();
+    let bytes = 0;
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        bytes += value.byteLength;
+        if (bytes > MAX_STREAM_BYTES) {
+          ws.destroy();
+          await fs.unlink(filePath).catch(() => {});
+          return sizeError;
+        }
+        await new Promise<void>((resolve, reject) =>
+          ws.write(value, (err) => (err ? reject(err) : resolve()))
+        );
+      }
+      await new Promise<void>((resolve, reject) => {
+        ws.on("error", reject);
+        ws.end(resolve);
+      });
+    } catch (err) {
+      ws.destroy();
+      await fs.unlink(filePath).catch(() => {});
+      throw err;
     }
 
-    const mimeType = file.type || "";
-    let markdown: string;
-    if (mimeType.startsWith("image/")) {
-      markdown = `![${file.name}](./${filename})`;
-    } else if (mimeType.startsWith("video/")) {
-      markdown = `<video src="./${filename}" controls></video>`;
-    } else {
-      markdown = `[${file.name}](./${filename})`;
-    }
-
-    return NextResponse.json({
-      ok: true,
-      filename,
-      markdown,
-      url: `/api/assets/${virtualPath}/${filename}`,
-    });
+    finishUpload(virtualPath, filename, skipCommit);
+    return uploadResponse(virtualPath, rawName, filename, mimeType);
   } catch (error) {
     if (error instanceof ReadOnlySourceError) {
       return NextResponse.json({ error: error.message }, { status: 403 });
@@ -126,6 +230,8 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
 
 export async function DELETE(req: NextRequest, { params }: RouteParams) {
   try {
+    const denied = await requireApiAuth(req);
+    if (denied) return denied;
     const { path: segments } = await params;
     const virtualPath = segments.join("/");
 

--- a/src/components/composer/composer-input.tsx
+++ b/src/components/composer/composer-input.tsx
@@ -9,6 +9,7 @@ import { MentionChips } from "./mention-chips";
 import { AttachmentChips } from "./attachment-chips";
 import { AttachmentPickerButton } from "./attachment-picker-button";
 import type { UseComposerAttachmentsReturn } from "./use-composer-attachments";
+import { filesFromDataTransfer } from "@/lib/storage/datatransfer-files";
 import type { UseComposerReturn, MentionableItem } from "@/hooks/use-composer";
 
 export interface ComposerInputProps {
@@ -162,12 +163,16 @@ export function ComposerInput({
 
   const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
     if (!attachmentsEnabled) return;
-    if (!e.dataTransfer.files || e.dataTransfer.files.length === 0) {
+    if (!e.dataTransfer.types.includes("Files")) {
       setIsDragging(false);
       return;
     }
     e.preventDefault();
-    attachments?.addFiles(e.dataTransfer.files);
+    // Expand dropped folders into their files (flat — attachments have no
+    // hierarchy). Entries must be captured synchronously, inside the event.
+    void filesFromDataTransfer(e.dataTransfer).then((dropped) => {
+      if (dropped.length > 0) attachments?.addFiles(dropped.map((d) => d.file));
+    });
     setIsDragging(false);
   };
 

--- a/src/components/composer/use-composer-attachments.ts
+++ b/src/components/composer/use-composer-attachments.ts
@@ -84,18 +84,21 @@ export function useComposerAttachments(
       });
 
       try {
-        const formData = new FormData();
-        formData.append("file", file);
         const encodedDir = dir
           .split("/")
           .filter(Boolean)
           .map(encodeURIComponent)
           .join("/");
-        const response = await fetch(`/api/upload/${encodedDir}?commit=0`, {
-          method: "POST",
-          body: formData,
-          signal: controller.signal,
-        });
+        // PUT streams the raw file body (no server-side multipart buffering),
+        // lifting the small-file cap of the POST path.
+        const response = await fetch(
+          `/api/upload/${encodedDir}?commit=0&name=${encodeURIComponent(file.name)}&type=${encodeURIComponent(file.type)}`,
+          {
+            method: "PUT",
+            body: file,
+            signal: controller.signal,
+          }
+        );
         if (!response.ok) {
           let message = `Upload failed (${response.status})`;
           try {

--- a/src/components/layout/system-toasts.tsx
+++ b/src/components/layout/system-toasts.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback, useRef } from "react";
-import { CheckCircle2, Info, X, XCircle } from "lucide-react";
+import { CheckCircle2, Info, Loader2, X, XCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 type ToastKind = "info" | "success" | "error";
@@ -26,6 +26,27 @@ const ACTION_DISMISS_MS = 10000;
 export function SystemToasts() {
   const [toasts, setToasts] = useState<SystemToast[]>([]);
   const timers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  // Multi-file drag-drop import progress (single-file imports finish fast
+  // enough that the summary toast alone suffices).
+  const [importProgress, setImportProgress] = useState<{
+    done: number;
+    total: number;
+  } | null>(null);
+
+  useEffect(() => {
+    function handler(event: Event) {
+      const detail = (event as CustomEvent).detail as
+        | { done?: number; total?: number }
+        | undefined;
+      const total = detail?.total ?? 0;
+      setImportProgress(
+        total > 1 ? { done: detail?.done ?? 0, total } : null
+      );
+    }
+    window.addEventListener("cabinet:import-progress", handler);
+    return () =>
+      window.removeEventListener("cabinet:import-progress", handler);
+  }, []);
 
   const dismiss = useCallback((key: string) => {
     const t = timers.current.get(key);
@@ -67,10 +88,28 @@ export function SystemToasts() {
     return () => window.removeEventListener("cabinet:toast", handler);
   }, [dismiss]);
 
-  if (toasts.length === 0) return null;
+  if (toasts.length === 0 && !importProgress) return null;
 
   return (
     <div className="fixed inset-x-0 bottom-4 z-[100] mx-auto flex w-fit flex-col gap-2">
+      {importProgress && (
+        <div className="flex w-56 flex-col gap-1.5 rounded-lg border border-border bg-popover px-3 py-2 text-[12px] shadow-lg backdrop-blur-sm animate-in slide-in-from-bottom-2 fade-in duration-200">
+          <div className="flex items-center gap-2">
+            <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
+            <span className="flex-1 leading-snug">
+              Importing {importProgress.done} / {importProgress.total}…
+            </span>
+          </div>
+          <div className="h-1 overflow-hidden rounded-full bg-muted">
+            <div
+              className="h-full rounded-full bg-primary transition-[width] duration-200"
+              style={{
+                width: `${Math.round((importProgress.done / importProgress.total) * 100)}%`,
+              }}
+            />
+          </div>
+        </div>
+      )}
       {toasts.map((toast) => {
         const Icon =
           toast.kind === "error"

--- a/src/components/sidebar/tree-node.tsx
+++ b/src/components/sidebar/tree-node.tsx
@@ -534,7 +534,7 @@ function TreeNodeImpl({
   const cloud = useIsCloud();
   const {
     importFiles,
-    importFilesList,
+    importDataTransfer,
     importing,
     importFolder,
     importingFolder,
@@ -634,8 +634,8 @@ function TreeNodeImpl({
       const zone = computeZone(e);
       setDragOver(null);
 
-      if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
-        void importFilesList(importTargetPath, e.dataTransfer.files);
+      if (e.dataTransfer.types.includes("Files")) {
+        void importDataTransfer(importTargetPath, e.dataTransfer);
         return;
       }
 
@@ -685,7 +685,7 @@ function TreeNodeImpl({
       setDragOver,
       computeZone,
       siblings,
-      importFilesList,
+      importDataTransfer,
       importTargetPath,
     ]
   );

--- a/src/components/sidebar/tree-view.tsx
+++ b/src/components/sidebar/tree-view.tsx
@@ -33,6 +33,7 @@ import { AppleNotesConnectDialog } from "./apple-notes-connect-dialog";
 import type { KnowledgeProviderId } from "@/lib/knowledge-sources/store";
 import { NewFileDialog } from "./new-file-dialog";
 import { MoveToDialog } from "./move-to-dialog";
+import { useFileImport } from "./use-file-import";
 import { RecentTasks } from "./recent-tasks";
 import type { TreeNode as TreeNodeType } from "@/types";
 import {
@@ -174,6 +175,23 @@ export function TreeView() {
   const [moveToOpen, setMoveToOpen] = useState(false);
   const [moveToSource, setMoveToSource] = useState<TreeNodeType | null>(null);
   const [editingAgent, setEditingAgent] = useState<{ slug: string; cabinetPath?: string } | null>(null);
+  // OS-file drop on the drawer's blank space imports into the current room
+  // root (rows handle their own drops and stopPropagation, so this only
+  // fires between/below them).
+  const { importDataTransfer } = useFileImport();
+  const [fileDragOver, setFileDragOver] = useState(false);
+  // Rows stopPropagation on their drops, so a drop on a row would leave the
+  // container highlight stuck — clear it on any drop/drag-end in the window.
+  useEffect(() => {
+    if (!fileDragOver) return;
+    const clear = () => setFileDragOver(false);
+    window.addEventListener("drop", clear, true);
+    window.addEventListener("dragend", clear, true);
+    return () => {
+      window.removeEventListener("drop", clear, true);
+      window.removeEventListener("dragend", clear, true);
+    };
+  }, [fileDragOver]);
 
   const requestMoveTo = useCallback((node: TreeNodeType) => {
     setMoveToSource(node);
@@ -830,7 +848,28 @@ export function TreeView() {
                 <ContextMenuTrigger className="flex flex-1 flex-col">
                   <div
                     key="drawer-data"
-                    className="flex flex-1 flex-col pt-1 animate-in fade-in slide-in-from-top-1 duration-200 ease-out"
+                    className={cn(
+                      "flex flex-1 flex-col pt-1 animate-in fade-in slide-in-from-top-1 duration-200 ease-out",
+                      fileDragOver &&
+                        "rounded-lg ring-2 ring-inset ring-primary/50 bg-primary/5"
+                    )}
+                    onDragOver={(e) => {
+                      if (!e.dataTransfer.types.includes("Files")) return;
+                      e.preventDefault();
+                      e.dataTransfer.dropEffect = "copy";
+                      if (!fileDragOver) setFileDragOver(true);
+                    }}
+                    onDragLeave={(e) => {
+                      if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
+                      setFileDragOver(false);
+                    }}
+                    onDrop={(e) => {
+                      setFileDragOver(false);
+                      if (!e.dataTransfer.types.includes("Files")) return;
+                      e.preventDefault();
+                      e.stopPropagation();
+                      void importDataTransfer(dataRootPath, e.dataTransfer);
+                    }}
                   >
               <SidebarSearch>
                 {visibleTreeNodes.length === 0 ? (

--- a/src/components/sidebar/use-file-import.ts
+++ b/src/components/sidebar/use-file-import.ts
@@ -2,19 +2,23 @@
 
 import { useCallback, useState } from "react";
 import { useTreeStore } from "@/stores/tree-store";
+import {
+  filesFromDataTransfer,
+  type DroppedFile,
+} from "@/lib/storage/datatransfer-files";
 
 async function uploadOne(targetVirtualPath: string, file: File): Promise<void> {
-  const form = new FormData();
-  form.append("file", file);
   const encoded = targetVirtualPath
     .split("/")
     .filter(Boolean)
     .map(encodeURIComponent)
     .join("/");
-  const res = await fetch(`/api/upload/${encoded}`, {
-    method: "POST",
-    body: form,
-  });
+  // PUT streams the raw file body to disk server-side (no multipart
+  // buffering), so imports aren't limited to small files.
+  const res = await fetch(
+    `/api/upload/${encoded}?name=${encodeURIComponent(file.name)}&type=${encodeURIComponent(file.type)}`,
+    { method: "PUT", body: file }
+  );
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
     throw new Error(body?.error || `Upload failed (${res.status})`);
@@ -35,31 +39,89 @@ export function useFileImport() {
   const [importing, setImporting] = useState(false);
   const [importingFolder, setImportingFolder] = useState(false);
 
-  const importFilesList = useCallback(
-    async (targetVirtualPath: string, files: FileList | File[]) => {
-      const list = Array.from(files);
-      if (list.length === 0) return;
+  const importDroppedList = useCallback(
+    async (targetVirtualPath: string, dropped: DroppedFile[]) => {
+      if (dropped.length === 0) return;
       setImporting(true);
-      let error: unknown = null;
-      try {
-        for (const file of list) {
-          await uploadOne(targetVirtualPath, file);
+      const total = dropped.length;
+      let done = 0;
+      const skipped: string[] = [];
+      const progress = () =>
+        window.dispatchEvent(
+          new CustomEvent("cabinet:import-progress", {
+            detail: { done, total },
+          })
+        );
+      progress();
+      // Skip-and-continue per file (a single oversized file must not abort
+      // the rest of a folder import).
+      // ponytail: fixed 4-way concurrency; make adaptive if cloud latency demands.
+      const queue = [...dropped];
+      const worker = async () => {
+        for (let item = queue.shift(); item; item = queue.shift()) {
+          const dir = item.relativeDir
+            ? [targetVirtualPath, item.relativeDir].filter(Boolean).join("/")
+            : targetVirtualPath;
+          try {
+            await uploadOne(dir, item.file);
+          } catch (err) {
+            skipped.push(
+              `${item.file.name} — ${err instanceof Error ? err.message : String(err)}`
+            );
+          }
+          done++;
+          progress();
         }
-      } catch (err) {
-        error = err;
-      }
+      };
+      await Promise.all(Array.from({ length: Math.min(4, total) }, worker));
+      window.dispatchEvent(
+        new CustomEvent("cabinet:import-progress", {
+          detail: { done: 0, total: 0 },
+        })
+      );
       try {
         if (targetVirtualPath) expandPath(targetVirtualPath);
         await loadTree();
       } finally {
         setImporting(false);
       }
-      if (error) {
-        const msg = error instanceof Error ? error.message : String(error);
-        alert(`Import failed: ${msg}`);
+      if (skipped.length === 0) {
+        emitToast(
+          "success",
+          total === 1 ? "Imported 1 file" : `Imported ${total} files`
+        );
+      } else {
+        const shown = skipped.slice(0, 3).join("; ");
+        const more =
+          skipped.length > 3 ? ` (+${skipped.length - 3} more)` : "";
+        emitToast(
+          "error",
+          `Imported ${total - skipped.length} of ${total} files. Skipped: ${shown}${more}`
+        );
       }
     },
     [loadTree, expandPath]
+  );
+
+  const importFilesList = useCallback(
+    (targetVirtualPath: string, files: FileList | File[]) =>
+      importDroppedList(
+        targetVirtualPath,
+        Array.from(files).map((file) => ({ file, relativeDir: "" }))
+      ),
+    [importDroppedList]
+  );
+
+  // Handles an OS drop, expanding dropped folders into their files (with
+  // structure preserved). Must be called synchronously from the drop handler.
+  const importDataTransfer = useCallback(
+    (targetVirtualPath: string, dt: DataTransfer) => {
+      const pending = filesFromDataTransfer(dt);
+      return pending.then((dropped) =>
+        importDroppedList(targetVirtualPath, dropped)
+      );
+    },
+    [importDroppedList]
   );
 
   const importFiles = useCallback(
@@ -131,6 +193,7 @@ export function useFileImport() {
   return {
     importFiles,
     importFilesList,
+    importDataTransfer,
     importing,
     importFolder,
     importingFolder,

--- a/src/lib/auth/request-gate.test.ts
+++ b/src/lib/auth/request-gate.test.ts
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { NextRequest } from "next/server";
+import { deriveAuthToken } from "./kb-auth";
+import { requireApiAuth } from "./request-gate";
+
+function req(cookie?: string): NextRequest {
+  return new NextRequest("http://localhost/api/upload/some/dir", {
+    headers: cookie ? { cookie } : {},
+  });
+}
+
+const ENV_KEYS = [
+  "KB_PASSWORD",
+  "CABINET_LOGIN_PBKDF2_ITERS",
+  "CABINET_AUTH_SALT",
+  "CABINET_CLOUD",
+  "CABINET_JWT_JWKS_URL",
+] as const;
+
+test("requireApiAuth mirrors the proxy gate for excluded routes", async () => {
+  const prev = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  try {
+    process.env.CABINET_LOGIN_PBKDF2_ITERS = "2";
+    process.env.CABINET_AUTH_SALT = "gate-salt";
+    delete process.env.CABINET_CLOUD;
+    delete process.env.CABINET_JWT_JWKS_URL;
+
+    // Auth disabled (no password) -> pass.
+    delete process.env.KB_PASSWORD;
+    assert.equal(await requireApiAuth(req()), null);
+
+    // Auth enabled: no cookie and wrong cookie -> 401.
+    process.env.KB_PASSWORD = "gate-pw";
+    assert.equal((await requireApiAuth(req()))?.status, 401);
+    assert.equal(
+      (await requireApiAuth(req("kb-auth=deadbeef")))?.status,
+      401
+    );
+
+    // Correct cookie -> pass.
+    const token = await deriveAuthToken("gate-pw", "gate-salt", 2);
+    assert.equal(await requireApiAuth(req(`kb-auth=${token}`)), null);
+
+    // Cloud gate active: no cabinet_jwt cookie -> 401 even though local
+    // KB auth would pass (the cloud gate takes precedence, fail closed).
+    process.env.CABINET_CLOUD = "1";
+    process.env.CABINET_JWT_JWKS_URL = "http://localhost:1/jwks.json";
+    assert.equal(
+      (await requireApiAuth(req(`kb-auth=${token}`)))?.status,
+      401
+    );
+  } finally {
+    for (const k of ENV_KEYS) {
+      if (prev[k] === undefined) delete process.env[k];
+      else process.env[k] = prev[k]!;
+    }
+  }
+});

--- a/src/lib/auth/request-gate.ts
+++ b/src/lib/auth/request-gate.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createRemoteJWKSet, jwtVerify } from "jose";
+import {
+  KB_AUTH_COOKIE,
+  expectedToken,
+  isAuthEnabled,
+  timingSafeEqualHex,
+} from "./kb-auth";
+
+// Shared auth decision used by BOTH the proxy (src/proxy.ts) and API routes
+// that are excluded from the proxy matcher. Large-body routes (/api/upload)
+// must be excluded there because Next's proxy plumbing buffers a full clone
+// of every matched request body in memory (and truncates it at
+// proxyClientMaxBodySize) — so those routes enforce the same gate themselves
+// via requireApiAuth().
+
+/** Cookie the panel sets on `.runcabinet.com` (Supabase ES256 access token). */
+export const CABINET_JWT_COOKIE = "cabinet_jwt";
+
+// A remote JWK set caches keys and rate-limits refetches internally, so build
+// it ONCE per JWKS URL and reuse it across requests (rebuilding per request
+// would defeat jose's caching and hammer the auth server). Memoized on the URL
+// so an env change (e.g. in tests) still rebuilds.
+let jwksMemo: {
+  url: string;
+  jwks: ReturnType<typeof createRemoteJWKSet>;
+} | null = null;
+
+function getJwks(url: string): ReturnType<typeof createRemoteJWKSet> {
+  if (jwksMemo && jwksMemo.url === url) return jwksMemo.jwks;
+  const jwks = createRemoteJWKSet(new URL(url));
+  jwksMemo = { url, jwks };
+  return jwks;
+}
+
+/** Whether the hosted-edition Supabase-JWT gate is active for this process. */
+export function cloudGateActive(): boolean {
+  return (
+    process.env.CABINET_CLOUD === "1" && !!process.env.CABINET_JWT_JWKS_URL
+  );
+}
+
+/**
+ * Verify the `cabinet_jwt` cookie and return the token subject (the Supabase
+ * user id), or null when the token is missing/invalid/expired or the gate is
+ * misconfigured (no JWKS URL). Pinning `algorithms: ["ES256"]` blocks
+ * algorithm-confusion attacks (`alg: none`, HS256-with-public-key). jose also
+ * enforces `exp`/`nbf`, so expired sessions fail closed here.
+ */
+export async function cloudUserSub(req: NextRequest): Promise<string | null> {
+  const jwksUrl = process.env.CABINET_JWT_JWKS_URL;
+  if (!jwksUrl) return null; // Not configured -> deny (fail closed).
+
+  const token = req.cookies.get(CABINET_JWT_COOKIE)?.value;
+  if (!token) return null;
+
+  try {
+    const { payload } = await jwtVerify(token, getJwks(jwksUrl), {
+      algorithms: ["ES256"],
+    });
+    return typeof payload.sub === "string" && payload.sub ? payload.sub : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Constant-time check of the local KB_PASSWORD auth cookie. */
+export async function hasValidKbAuthCookie(
+  req: NextRequest
+): Promise<boolean> {
+  const token = req.cookies.get(KB_AUTH_COOKIE)?.value ?? "";
+  return timingSafeEqualHex(token, await expectedToken());
+}
+
+/**
+ * Same gate the proxy applies, for API routes outside its matcher. Returns a
+ * 401 response to send back, or null when the request is authorized.
+ */
+export async function requireApiAuth(
+  req: NextRequest
+): Promise<NextResponse | null> {
+  const unauthorized = () =>
+    NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  if (cloudGateActive()) {
+    return (await cloudUserSub(req)) ? null : unauthorized();
+  }
+  if (!isAuthEnabled()) return null;
+  return (await hasValidKbAuthCookie(req)) ? null : unauthorized();
+}

--- a/src/lib/storage/datatransfer-files.test.ts
+++ b/src/lib/storage/datatransfer-files.test.ts
@@ -1,0 +1,68 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import { filesFromDataTransfer } from "./datatransfer-files";
+
+function fileEntry(name: string): FileSystemFileEntry {
+  return {
+    isFile: true,
+    isDirectory: false,
+    name,
+    file: (resolve: (f: File) => void) => resolve(new File(["x"], name)),
+  } as unknown as FileSystemFileEntry;
+}
+
+// Reader hands entries back in batches (like Chrome's ~100-entry pages) so
+// the drain loop is exercised.
+function dirEntry(name: string, children: FileSystemEntry[]): FileSystemDirectoryEntry {
+  return {
+    isFile: false,
+    isDirectory: true,
+    name,
+    createReader: () => {
+      const batches = [children.slice(0, 2), children.slice(2), []];
+      return {
+        readEntries: (resolve: (e: FileSystemEntry[]) => void) =>
+          resolve(batches.shift() ?? []),
+      };
+    },
+  } as unknown as FileSystemDirectoryEntry;
+}
+
+function dt(items: Array<FileSystemEntry | File | null>): DataTransfer {
+  return {
+    items: items.map((it) => ({
+      kind: "file",
+      webkitGetAsEntry: () => (it instanceof File || it === null ? null : it),
+      getAsFile: () => (it instanceof File ? it : null),
+    })),
+    files: items.filter((it): it is File => it instanceof File),
+  } as unknown as DataTransfer;
+}
+
+test("recurses folders, preserves relative dirs, skips junk, drains batched readers", async () => {
+  const folder = dirEntry("docs", [
+    fileEntry("a.md"),
+    dirEntry(".git", [fileEntry("HEAD")]),
+    fileEntry("b.md"),
+    dirEntry("sub", [fileEntry("c.md")]),
+  ]);
+  const out = await filesFromDataTransfer(dt([folder, fileEntry("loose.txt")]));
+  assert.deepStrictEqual(
+    out.map((d) => ({ name: d.file.name, dir: d.relativeDir })),
+    [
+      { name: "a.md", dir: "docs" },
+      { name: "b.md", dir: "docs" },
+      { name: "c.md", dir: "docs/sub" },
+      { name: "loose.txt", dir: "" },
+    ]
+  );
+});
+
+test("falls back to flat file list without entry support", async () => {
+  const f = new File(["x"], "plain.txt");
+  const out = await filesFromDataTransfer(dt([f]));
+  assert.deepStrictEqual(
+    out.map((d) => ({ name: d.file.name, dir: d.relativeDir })),
+    [{ name: "plain.txt", dir: "" }]
+  );
+});

--- a/src/lib/storage/datatransfer-files.ts
+++ b/src/lib/storage/datatransfer-files.ts
@@ -1,0 +1,76 @@
+// Expand a drop's DataTransfer into files, recursing into dropped folders
+// via webkitGetAsEntry so folder drag-drop works on web/cloud (where the
+// native Import Folder picker isn't available).
+
+export interface DroppedFile {
+  file: File;
+  /** Path of the containing folder relative to the drop target ("" for loose files). */
+  relativeDir: string;
+}
+
+// ponytail: name-based junk filter only; the upload API already blocks executables.
+const SKIP = new Set([".git", ".svn", "node_modules", ".DS_Store", "Thumbs.db"]);
+
+function readAllEntries(dir: FileSystemDirectoryEntry): Promise<FileSystemEntry[]> {
+  // readEntries returns at most ~100 entries per call; drain until empty.
+  const reader = dir.createReader();
+  return new Promise((resolve, reject) => {
+    const all: FileSystemEntry[] = [];
+    const next = () =>
+      reader.readEntries((batch) => {
+        if (batch.length === 0) return resolve(all);
+        all.push(...batch);
+        next();
+      }, reject);
+    next();
+  });
+}
+
+async function walk(
+  entry: FileSystemEntry,
+  dir: string,
+  out: DroppedFile[]
+): Promise<void> {
+  if (SKIP.has(entry.name)) return;
+  if (entry.isFile) {
+    const file = await new Promise<File>((resolve, reject) =>
+      (entry as FileSystemFileEntry).file(resolve, reject)
+    );
+    out.push({ file, relativeDir: dir });
+    return;
+  }
+  if (entry.isDirectory) {
+    const children = await readAllEntries(entry as FileSystemDirectoryEntry);
+    const childDir = dir ? `${dir}/${entry.name}` : entry.name;
+    for (const child of children) await walk(child, childDir, out);
+  }
+}
+
+/**
+ * Must be called synchronously from the drop event handler — DataTransfer
+ * items are only readable during the event dispatch, so entries are captured
+ * before the first await.
+ */
+export function filesFromDataTransfer(dt: DataTransfer): Promise<DroppedFile[]> {
+  const items = Array.from(dt.items || []).filter((i) => i.kind === "file");
+  const entries = items.map((i) => i.webkitGetAsEntry?.() ?? null);
+  // Fallback (no entry support): flat file list, folders silently skipped.
+  if (!entries.some(Boolean)) {
+    return Promise.resolve(
+      Array.from(dt.files).map((file) => ({ file, relativeDir: "" }))
+    );
+  }
+  return (async () => {
+    const out: DroppedFile[] = [];
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i];
+      if (entry) {
+        await walk(entry, "", out);
+      } else {
+        const file = items[i].getAsFile();
+        if (file) out.push({ file, relativeDir: "" });
+      }
+    }
+    return out;
+  })();
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,11 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createRemoteJWKSet, jwtVerify } from "jose";
+import { isAuthEnabled } from "@/lib/auth/kb-auth";
 import {
-  KB_AUTH_COOKIE,
-  expectedToken,
-  isAuthEnabled,
-  timingSafeEqualHex,
-} from "@/lib/auth/kb-auth";
+  cloudGateActive,
+  cloudUserSub,
+  hasValidKbAuthCookie,
+} from "@/lib/auth/request-gate";
 
 // ---------------------------------------------------------------------------
 // Cabinet Cloud gate (CABINET_CLOUD=1)
@@ -21,48 +20,8 @@ import {
 // and only runs when CABINET_CLOUD === "1"; every other deployment keeps the
 // existing behavior untouched.
 
-/** Cookie the panel sets on `.runcabinet.com` (Supabase ES256 access token). */
-const CABINET_JWT_COOKIE = "cabinet_jwt";
-
-// A remote JWK set caches keys and rate-limits refetches internally, so build
-// it ONCE per JWKS URL and reuse it across requests (rebuilding per request
-// would defeat jose's caching and hammer the auth server). Memoized on the URL
-// so an env change (e.g. in tests) still rebuilds.
-let jwksMemo: {
-  url: string;
-  jwks: ReturnType<typeof createRemoteJWKSet>;
-} | null = null;
-
-function getJwks(url: string): ReturnType<typeof createRemoteJWKSet> {
-  if (jwksMemo && jwksMemo.url === url) return jwksMemo.jwks;
-  const jwks = createRemoteJWKSet(new URL(url));
-  jwksMemo = { url, jwks };
-  return jwks;
-}
-
-/**
- * Verify the `cabinet_jwt` cookie and return the token subject (the Supabase
- * user id), or null when the token is missing/invalid/expired or the gate is
- * misconfigured (no JWKS URL). Pinning `algorithms: ["ES256"]` blocks
- * algorithm-confusion attacks (`alg: none`, HS256-with-public-key). jose also
- * enforces `exp`/`nbf`, so expired sessions fail closed here.
- */
-async function cloudUserSub(req: NextRequest): Promise<string | null> {
-  const jwksUrl = process.env.CABINET_JWT_JWKS_URL;
-  if (!jwksUrl) return null; // Not configured -> deny (fail closed).
-
-  const token = req.cookies.get(CABINET_JWT_COOKIE)?.value;
-  if (!token) return null;
-
-  try {
-    const { payload } = await jwtVerify(token, getJwks(jwksUrl), {
-      algorithms: ["ES256"],
-    });
-    return typeof payload.sub === "string" && payload.sub ? payload.sub : null;
-  } catch {
-    return null;
-  }
-}
+// The JWT verification itself lives in @/lib/auth/request-gate so routes
+// excluded from the matcher below (/api/upload) can apply the identical gate.
 
 async function cloudProxy(req: NextRequest): Promise<NextResponse> {
   const { pathname } = req.nextUrl;
@@ -105,7 +64,7 @@ export async function proxy(req: NextRequest) {
   // the in-app gate a deliberate, verifiable choice (the host agent already gates
   // at the edge) — a cloud tenant with CABINET_CLOUD=1 but no JWKS URL configured
   // must NOT fail closed and lock itself out.
-  if (process.env.CABINET_CLOUD === "1" && process.env.CABINET_JWT_JWKS_URL) {
+  if (cloudGateActive()) {
     return cloudProxy(req);
   }
 
@@ -128,10 +87,7 @@ export async function proxy(req: NextRequest) {
 
   // Check auth cookie (constant-time; expected token is memoized so this is
   // O(1) per request — PBKDF2 runs once per process, not per request).
-  const token = req.cookies.get(KB_AUTH_COOKIE)?.value ?? "";
-  const expected = await expectedToken();
-
-  if (!timingSafeEqualHex(token, expected)) {
+  if (!(await hasValidKbAuthCookie(req))) {
     // API routes return 401
     if (pathname.startsWith("/api/")) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -145,7 +101,12 @@ export async function proxy(req: NextRequest) {
 
 export const config = {
   matcher: [
-    // Protect all routes except static files and Next.js internals
-    "/((?!_next/static|_next/image|favicon.ico).*)",
+    // Protect all routes except static files and Next.js internals.
+    // /api/upload is excluded on purpose: matched requests get their body
+    // cloned into memory by Next (and silently truncated at 10MB —
+    // proxyClientMaxBodySize), which breaks and bloats large streaming
+    // uploads. That route enforces the identical gate itself via
+    // requireApiAuth() from @/lib/auth/request-gate.
+    "/((?!_next/static|_next/image|favicon.ico|api/upload).*)",
   ],
 };

--- a/test/cabinet-v2.test.ts
+++ b/test/cabinet-v2.test.ts
@@ -49,6 +49,31 @@ async function writeAgentPersona(rel: string, slug: string, name: string): Promi
 }
 
 before(async () => {
+  // The overview's parent lookup walks up to DATA_DIR and only finds the
+  // root cabinet if a root `.cabinet` manifest exists. On a fresh checkout
+  // (CI) data/ starts empty and the manifest only appears if some other
+  // test file happens to bootstrap first — an ordering hazard (test files
+  // run concurrently). Provision it here so this file is self-contained;
+  // intentionally not removed in after() since other test files may rely
+  // on it the same way.
+  const rootManifest = path.join(DATA_DIR, ".cabinet");
+  try {
+    await fs.access(rootManifest);
+  } catch {
+    await fs.mkdir(DATA_DIR, { recursive: true });
+    await fs.writeFile(
+      rootManifest,
+      [
+        "schemaVersion: 1",
+        "id: home",
+        "name: Test Home",
+        "kind: home",
+        "entry: index.md",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+  }
   await writeCabinetManifest(FIX, "Test Co");
   for (const slug of ["ceo", "cfo", "coo", "cto"]) {
     await writeAgentPersona(FIX, slug, slug.toUpperCase());


### PR DESCRIPTION
## What

Makes drag-and-drop of files **and folders** feel native across the app — the top ask for the cloud launch — and fixes a pre-existing silent corruption bug for uploads over 10MB.

### Drag & drop (commit 1)
- **Folder drops work everywhere** (sidebar rows, sidebar blank space, chat box): new `datatransfer-files` helper recurses dropped directories via `webkitGetAsEntry` (drains batched `readEntries`, skips `.git`/`node_modules`/`.DS_Store`), preserving structure on import. This is also the only folder-import path available on cloud, where the native Import Folder picker can't work.
- **Sidebar blank space is a drop zone** — imports into the current room root with a ring highlight; previously drops only registered on exact rows.
- **Progress + resilience for big imports**: 4-way concurrent uploads, skip-on-error instead of aborting the batch, a bottom progress pill ("Importing 37 / 214…" with a bar), and a summary toast listing skip reasons.

### Large files (commit 2)
- **Bug fix**: with a proxy file present, Next clones every matched request body and silently truncates it at 10MB — so the old 25MB cap was never reachable and 10–25MB uploads arrived corrupt (multipart parse failure).
- **New streaming `PUT` on `/api/upload`** (drag-drop + composer attachments use it): raw body piped to disk in chunks, **1GB cap** — instant 413 via `Content-Length` before any bytes are stored, plus a mid-stream byte counter that unlinks partial files. Editor paste keeps the buffering POST.
- **`/api/upload` excluded from the proxy matcher** so bodies are never cloned: 300MB upload now costs ~110MB transient RSS vs ~720MB before — matters for memory-capped cloud tenants.
- **Auth preserved**: the proxy's exact gate (cloud Supabase-JWT + local KB_PASSWORD) extracted to `lib/auth/request-gate`, used by both the proxy and all three upload handlers directly. Fail-closed precedence covered by tests.

## Verification
- Driven live in the app: file + folder drops on sidebar/composer, progress pill, mixed-batch skip toast, 30MB drop through the UI.
- 300MB upload byte-perfect (md5 match) with flat memory; 1.1GB rejected in 0.14s with nothing written, surfacing as "Skipped: huge.bin — File exceeds 1GB size limit" in the UI.
- Unit tests for folder recursion/batching and the auth gate; full suite 357/357.

## Notes for cloud
- Host agent / ingress may impose its own request-size limit — verify in the platform repo before advertising 1GB there.
- Sidebar imports still auto-commit to the room's git; huge binaries will grow history. Follow-up candidate: skip auto-commit above a size threshold.