### PR TITLE
fix(deps): declare highlight.js and sync package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "emoji-mart": "^5.6.0",
         "flexsearch": "^0.8.212",
         "gray-matter": "^4.0.3",
+        "highlight.js": "^11.11.1",
         "html-to-image": "^1.11.13",
         "i18next": "^26.1.0",
         "i18next-browser-languagedetector": "^8.2.1",
@@ -11082,6 +11083,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
     "node_modules/encoding-japanese": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-2.2.0.tgz",
@@ -11089,6 +11101,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/end-of-stream": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "emoji-mart": "^5.6.0",
     "flexsearch": "^0.8.212",
     "gray-matter": "^4.0.3",
+    "highlight.js": "^11.11.1",
     "html-to-image": "^1.11.13",
     "i18next": "^26.1.0",
     "i18next-browser-languagedetector": "^8.2.1",


### PR DESCRIPTION
Reopened from closed PR #195 — same commit (`a725ff66`), now pushed inside the org so CI runs with full permissions.

## Problem

Two related dependency-correctness issues on `main`.

### 1. `highlight.js` is a phantom dependency

`src/components/editor/extensions.ts` imports 13 language grammars from `highlight.js`, but the package is not declared in `package.json`. It resolves today only because npm flat-hoists it out of `lowlight`.

That makes it a phantom dependency: under any strict `node_modules` layout (pnpm, yarn PnP) it disappears and every route 500s with `Module not found: Can't resolve 'highlight.js/lib/languages/yaml'`.

### 2. `package.json` and `package-lock.json` are out of sync

`@electron-forge/cli` floats at `^7.8.1` and now resolves to `7.11.2`, which pulls in `encoding` + `iconv-lite` as optional transitives of `node-fetch@2`. The committed lockfile predates that resolution.

**This does not break CI today** — npm 10 (what Node 22 CI uses) is lenient about missing optional transitives. But:

- `npm ci` fails outright for any contributor on Node 24 (`npm error Missing: encoding@0.1.13 from lock file`).
- CI breaks the moment the runner moves to Node 24.

## Changes

1. Declare `highlight.js: ^11.11.1`. Same version `lowlight` already resolves, so the dependency tree is unchanged; this only makes the existing import honest.
2. Sync `package-lock.json`. No dependency ranges changed.

## Verification

Against a clean worktree, `npm ci` tested under both npm majors:

| | npm 10.9.2 (Node 22 — CI) | npm 11.8.0 (Node 24) |
|---|---|---|
| `main` today | passes | fails (`Missing: encoding`) |
| this PR | passes | passes |

Strictly additive: CI stays green, Node 24 installs start working.

## Notes

- Original PR #195 had a force-push clarifying that the release pipeline was NOT broken (npm 10 tolerates the drift). Same clarification stands here.
- #194 already landed the ci.yml on `main`, so the earlier ci.yml commit from #195 is dropped. This PR is only the two dep fixes, +27/-0.

Ref: closes the drift condition documented in the original #195.