### PR TITLE
fix: count symlinked directories in the big-tree startup guard (#131)

### DIFF
--- a/server/cabinet-daemon.ts
+++ b/server/cabinet-daemon.ts
@@ -42,7 +42,8 @@ import yaml from "js-yaml";
 import chokidar from "chokidar";
 import matter from "gray-matter";
 import { getDb, closeDb } from "./db";
-import { DATA_DIR, isHiddenEntry } from "../src/lib/storage/path-utils";
+import { DATA_DIR } from "../src/lib/storage/path-utils";
+import { countWatchableDirs } from "../src/lib/storage/watchable-dirs";
 import { discoverCabinetPathsSync } from "../src/lib/cabinets/discovery";
 import { resolveCabinetDir } from "../src/lib/cabinets/server-paths";
 import {
@@ -164,28 +165,6 @@ function probeWatcherBackend(): WatcherBackend {
 // we stop counting as soon as we cross the threshold.
 const BIG_TREE_DIR_THRESHOLD = 1500;
 
-async function countWatchableDirs(maxBeforeAbort: number): Promise<number> {
-  let count = 0;
-  const stack: string[] = [DATA_DIR];
-  while (stack.length > 0) {
-    const dir = stack.pop()!;
-    count += 1;
-    if (count > maxBeforeAbort) return count;
-    let entries: fs.Dirent[];
-    try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    for (const entry of entries) {
-      if (!entry.isDirectory()) continue;
-      if (isHiddenEntry(entry.name)) continue;
-      stack.push(path.join(dir, entry.name));
-    }
-  }
-  return count;
-}
-
 function getOpenFileLimit(): number | null {
   // posix_getrlimit isn't in Node's stdlib. We could shell out to `ulimit`,
   // but the simplest check is: try to read it from `process.getrlimit?.()`
@@ -204,7 +183,7 @@ function getOpenFileLimit(): number | null {
 async function guardAgainstBigTree(): Promise<void> {
   const backend = probeWatcherBackend();
   if (!backend.fdPerDir) return; // FSEvents/ReadDirectoryChangesW are O(1) in fds
-  const dirCount = await countWatchableDirs(BIG_TREE_DIR_THRESHOLD);
+  const dirCount = countWatchableDirs(DATA_DIR, BIG_TREE_DIR_THRESHOLD);
   const ulimit = getOpenFileLimit();
   const ulimitTooLow = ulimit !== null && ulimit < 4096;
   if (dirCount <= BIG_TREE_DIR_THRESHOLD && !ulimitTooLow) return;

--- a/src/lib/storage/watchable-dirs.test.ts
+++ b/src/lib/storage/watchable-dirs.test.ts
@@ -1,0 +1,93 @@
+import test, { before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { countWatchableDirs } from "./watchable-dirs";
+
+// Fixtures live outside DATA_DIR: countWatchableDirs takes an explicit root.
+let TMP: string;
+
+function mkdirs(root: string, count: number): void {
+  for (let i = 0; i < count; i += 1) {
+    fs.mkdirSync(path.join(root, `d${String(i).padStart(4, "0")}`), { recursive: true });
+  }
+}
+
+before(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), "watchable-dirs-"));
+});
+
+after(() => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+});
+
+test("counts plain nested directories", () => {
+  const root = path.join(TMP, "plain");
+  fs.mkdirSync(path.join(root, "a", "b"), { recursive: true });
+  fs.mkdirSync(path.join(root, "c"), { recursive: true });
+  // root + a + a/b + c
+  assert.equal(countWatchableDirs(root, 1000), 4);
+});
+
+test("skips hidden and ignored directories", () => {
+  const root = path.join(TMP, "ignored");
+  fs.mkdirSync(path.join(root, ".git", "objects"), { recursive: true });
+  fs.mkdirSync(path.join(root, "node_modules", "pkg"), { recursive: true });
+  fs.mkdirSync(path.join(root, "real"), { recursive: true });
+  // root + real only
+  assert.equal(countWatchableDirs(root, 1000), 2);
+});
+
+test("stops counting once the threshold is crossed", () => {
+  const root = path.join(TMP, "early-exit");
+  fs.mkdirSync(root, { recursive: true });
+  mkdirs(root, 50);
+  const count = countWatchableDirs(root, 10);
+  assert.ok(count > 10, `expected >10, got ${count}`);
+  assert.ok(count <= 12, `expected early exit near the threshold, got ${count}`);
+});
+
+// The issue-#131 repro: the same tree is refused when passed directly but was
+// waved through when reached via a symlink, because Dirent.isDirectory() is
+// false for a symlink. The indexer's walkDataDir follows it regardless.
+test("counts a large tree reached through a symlink the same as a direct one", () => {
+  const bigtree = path.join(TMP, "bigtree");
+  fs.mkdirSync(bigtree, { recursive: true });
+  mkdirs(bigtree, 40); // bigtree + 40 children = 41
+
+  const workspace = path.join(TMP, "workspace");
+  fs.mkdirSync(workspace, { recursive: true });
+  fs.symlinkSync(bigtree, path.join(workspace, "link"), "dir");
+
+  const direct = countWatchableDirs(bigtree, 1000);
+  assert.equal(direct, 41);
+
+  // workspace + everything behind the symlink
+  const throughSymlink = countWatchableDirs(workspace, 1000);
+  assert.equal(throughSymlink, direct + 1);
+});
+
+test("terminates on a symlink cycle without unbounded recursion", () => {
+  const root = path.join(TMP, "cycle");
+  const inner = path.join(root, "inner");
+  fs.mkdirSync(inner, { recursive: true });
+  // inner/loop -> root, and a self-referential link too
+  fs.symlinkSync(root, path.join(inner, "loop"), "dir");
+  fs.symlinkSync(root, path.join(root, "self"), "dir");
+
+  // Each real directory is counted once: root + inner.
+  const count = countWatchableDirs(root, 1000);
+  assert.equal(count, 2);
+});
+
+test("ignores symlinks that do not resolve to a directory", () => {
+  const root = path.join(TMP, "file-links");
+  fs.mkdirSync(root, { recursive: true });
+  const target = path.join(root, "note.md");
+  fs.writeFileSync(target, "# note\n");
+  fs.symlinkSync(target, path.join(root, "note-link.md"));
+  fs.symlinkSync(path.join(root, "missing"), path.join(root, "broken"));
+
+  assert.equal(countWatchableDirs(root, 1000), 1);
+});

--- a/src/lib/storage/watchable-dirs.ts
+++ b/src/lib/storage/watchable-dirs.ts
@@ -1,0 +1,60 @@
+import fs from "fs";
+import path from "path";
+import { isHiddenEntry } from "./path-utils";
+
+function resolvesToDir(p: string): boolean {
+  try {
+    // fs.stat follows symlinks; Dirent.isDirectory() does not.
+    return fs.statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Count the directories a watcher would have to watch under `rootDir`, using the
+ * same ignore rules as the indexer. Stops as soon as the count exceeds
+ * `maxBeforeAbort`, so it stays cheap (~tens of ms) even on huge trees.
+ *
+ * Symlinked directories are followed, because the indexer's `walkDataDir` follows
+ * them: counting only real dirs let a big tree hide behind a single symlink and
+ * defeat the guard entirely (issue #131). Real paths already counted are tracked
+ * so symlink cycles terminate and a tree reachable twice is only counted once.
+ */
+export function countWatchableDirs(rootDir: string, maxBeforeAbort: number): number {
+  let count = 0;
+  const visited = new Set<string>();
+  const stack: string[] = [rootDir];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+
+    let real: string;
+    try {
+      real = fs.realpathSync(dir);
+    } catch {
+      continue;
+    }
+    if (visited.has(real)) continue;
+    visited.add(real);
+
+    count += 1;
+    if (count > maxBeforeAbort) return count;
+
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (isHiddenEntry(entry.name)) continue;
+      const childPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(childPath);
+      } else if (entry.isSymbolicLink() && resolvesToDir(childPath)) {
+        stack.push(childPath);
+      }
+    }
+  }
+  return count;
+}


### PR DESCRIPTION
Reopened from closed PR #210 — same commit (\`755f13f8\`), pushed inside the org so CI runs with full permissions.

Fixes #131.

## Problem

\`countWatchableDirs\` in \`server/cabinet-daemon.ts\` filtered entries on \`Dirent.isDirectory()\`, which is **false for a symlink-to-directory**. So a tree large enough to be refused when reached directly was waved straight through when reached via a symlink.

That is not a cosmetic inconsistency: the indexer's \`walkDataDir\` resolves with \`fs.stat\` and walks symlinked trees regardless. The guard and the indexer disagreed, so the daemon went on to index the very tree the guard existed to stop.

## Fix

Extract the counter into \`src/lib/storage/watchable-dirs.ts\` and make it agree with \`walkDataDir\`:

- Resolve symlinked entries with \`fs.stat\` (which follows links) instead of trusting \`Dirent.isDirectory()\`.
- Track visited **real** paths in a \`Set\`, so symlink cycles terminate and a tree reachable by two paths is counted once rather than inflating the count.
- Preserve the threshold early-exit, so the walk stays bounded and cheap (~tens of ms) even on huge trees.

Moving it out of the daemon also makes it directly unit-testable under the repo's \`tsx --test\` runner.

## Verification

- \`npx tsx --test src/lib/storage/watchable-dirs.test.ts\` — **6 pass / 0 fail**.
- \`npm test\` on this branch — **359 pass / 1 fail**. The +6 over the 353 baseline are the new tests; the single failure is a pre-existing red at \`test/cabinet-v2.test.ts:111\`.
- \`npx tsc --noEmit\` — exit 0. \`eslint\` on changed files — exit 0.

## Risk

The guard now follows symlinks, so a cabinet that deliberately symlinks a large external directory will be counted where previously it was not — which is the intended behavior change, since the indexer was already walking it.