### PR TITLE
test(#103): regression tests for Windows-backslash path traversal

### DIFF
--- a/src/lib/storage/path-utils.test.ts
+++ b/src/lib/storage/path-utils.test.ts
@@ -38,3 +38,33 @@ test("resolveAgentCwd resolves workdir relative to the room, with a stale-workdi
   // No cabinet → DATA_DIR root.
   assert.equal(resolveAgentCwd(undefined, "/data"), DATA_DIR);
 });
+
+// #103: a Windows backslash arriving at the storage layer used to crash all
+// asset viewers with "Path traversal detected", because `path.resolve` treats
+// `\foo` as drive-root-relative on Windows and escapes DATA_DIR. Both entry
+// points go through normalizeVirtualPath now — pin that behaviour so any
+// regression surfaces as a test failure rather than a 500 in the browser.
+test("resolveContentPath normalizes Windows-style backslash inputs (#103)", () => {
+  const { resolveContentPath, DATA_DIR } = mod;
+  const expected = path.join(DATA_DIR, "Cabinet_AI_Introduction.pptx");
+
+  assert.equal(resolveContentPath("\\Cabinet_AI_Introduction.pptx"), expected);
+  assert.equal(resolveContentPath("Cabinet_AI_Introduction.pptx"), expected);
+  assert.equal(
+    resolveContentPath("\\personal-os_jp\\brain\\dashboard"),
+    path.join(DATA_DIR, "personal-os_jp/brain/dashboard")
+  );
+
+  // A genuine escape attempt must still throw — normalization is not a bypass.
+  assert.throws(() => resolveContentPath("..\\..\\etc\\passwd"), /Path traversal detected/);
+});
+
+test("virtualPathFromFs returns forward-slash paths regardless of separator (#103)", () => {
+  const { virtualPathFromFs, DATA_DIR } = mod;
+  const nested = path.join(DATA_DIR, "personal-os_jp", "brain", "dashboard");
+  assert.equal(virtualPathFromFs(nested), "personal-os_jp/brain/dashboard");
+  assert.equal(virtualPathFromFs(path.join(DATA_DIR, "Cabinet_AI_Introduction.pptx")), "Cabinet_AI_Introduction.pptx");
+  // No leading separator leaks through — the URL layer relies on this.
+  assert.equal(virtualPathFromFs(DATA_DIR).startsWith("/"), false);
+  assert.equal(virtualPathFromFs(DATA_DIR).startsWith("\\"), false);
+});


### PR DESCRIPTION
## Summary

Issue #103 reports that a Windows backslash (`\` / `%5C`) in an asset URL crashes every viewer with `500 Path traversal detected`. Walking the diff since the report, the three bugs it identified are all resolved on `main`:

1. **`resolveContentPath`** now runs its input through `normalizeVirtualPath` (`src/lib/storage/path-utils.ts:41`), which collapses `[\\/]+` to `/` and strips leading separators — so `\Cabinet_AI_Introduction.pptx` no longer becomes drive-root-relative and no longer escapes `DATA_DIR`.
2. **`virtualPathFromFs`** does the same on the way out (`src/lib/storage/path-utils.ts:50`), so tree API responses can no longer emit `\`-prefixed paths that the URL layer would then re-encode as `%5C`.
3. **`app-shell.tsx`** already gates the room-redirect effect on `section.type !== "page"` (line 368), so `#/p/...` no longer gets hijacked into the default room.

This PR does not change behaviour — it just adds regression tests around the storage boundary so a future regression fails a unit test rather than a Windows user's PPTX viewer.

## What's in this PR

- Two new tests in `src/lib/storage/path-utils.test.ts`:
  - `resolveContentPath` maps the exact `\Cabinet_AI_Introduction.pptx` input from the bug to a path inside `DATA_DIR`, and still throws on a genuine `..\..\etc\passwd` escape (so normalization isn't mistaken for a bypass).
  - `virtualPathFromFs` returns forward-slash paths with no leading separator on any platform.

## Test plan

- [x] `npm test` — 359/359 pass
- [x] `npm run lint` — no new warnings
- [ ] Windows verification: navigate to `#/p/%5CCabinet_AI_Introduction.pptx` on a Windows install and confirm the viewer loads (fix is in `main`, just uncovered by tests here). CI is Linux-only, so this is a manual check.

Closes #103 once the Windows spot-check passes.