### PR TITLE
fix(security): sanitize HTML in markdown renderer (#66)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,8 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-i18next": "^17.0.7",
+        "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
         "rehype-stringify": "^10.0.1",
         "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
@@ -11082,6 +11084,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
     "node_modules/encoding-japanese": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-2.2.0.tgz",
@@ -11089,6 +11102,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/end-of-stream": {
@@ -11112,6 +11139,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -13208,6 +13247,79 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
@@ -13231,6 +13343,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -13238,6 +13369,23 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -17897,6 +18045,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -19069,6 +19229,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rehype-raw": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-raw": "^9.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/rehype-stringify": {
@@ -22178,6 +22367,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/vfile-message": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
@@ -22228,6 +22431,16 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/package.json
+++ b/package.json
@@ -105,6 +105,8 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-i18next": "^17.0.7",
+    "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "rehype-stringify": "^10.0.1",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",

--- a/src/lib/markdown/sanitize.test.ts
+++ b/src/lib/markdown/sanitize.test.ts
@@ -1,0 +1,80 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { markdownToHtml } from "@/lib/markdown/to-html";
+
+// #66: raw HTML pass-through used to reach the browser verbatim, and the output
+// is rendered via dangerouslySetInnerHTML on chat / agent messages. Any of the
+// payloads below could smuggle JS into Cabinet's origin — where the daemon auth
+// token lives — so lock in the sanitizer.
+
+test("strips onerror/onclick event handlers on injected tags", async () => {
+  const html = await markdownToHtml('<img src="x" onerror="alert(1)">');
+  assert.ok(!html.includes("onerror"), `event handler survived sanitize: ${html}`);
+  assert.ok(!html.toLowerCase().includes("alert"), `alert() payload survived: ${html}`);
+});
+
+test("strips javascript: URLs from links", async () => {
+  const html = await markdownToHtml('<a href="javascript:alert(1)">click</a>');
+  assert.ok(!html.toLowerCase().includes("javascript:"), `javascript: href survived: ${html}`);
+  assert.ok(!html.toLowerCase().includes("alert"), `alert() survived: ${html}`);
+});
+
+test("drops <script> tags entirely", async () => {
+  const html = await markdownToHtml("Hello <script>alert(1)</script> world");
+  assert.ok(!html.toLowerCase().includes("<script"), `script tag survived: ${html}`);
+  assert.ok(!html.toLowerCase().includes("alert"), `alert() survived: ${html}`);
+});
+
+test("drops <iframe> from raw HTML (embed path adds trusted iframes downstream)", async () => {
+  const html = await markdownToHtml('<iframe src="https://evil.example.com"></iframe>');
+  assert.ok(!html.toLowerCase().includes("<iframe"), `raw iframe survived: ${html}`);
+});
+
+test("drops inline <style> and on* attributes on legitimate tags", async () => {
+  const html = await markdownToHtml('<div onclick="alert(1)" style="x:y">hi</div>');
+  assert.ok(!html.toLowerCase().includes("onclick"), `onclick survived: ${html}`);
+  assert.ok(!html.toLowerCase().includes("alert"), `alert() survived: ${html}`);
+});
+
+// The pieces the pipeline legitimately produces must still make it through
+// sanitize; otherwise everything from wiki-links to task lists to LaTeX embeds
+// silently degrades on agent-authored text.
+
+test("wiki-link markup survives sanitize", async () => {
+  const html = await markdownToHtml("See [[Some Page]] for context");
+  assert.ok(html.includes('data-wiki-link="true"'), `wiki-link marker stripped: ${html}`);
+  assert.ok(html.includes('data-page-name="Some Page"'), `page name stripped: ${html}`);
+  assert.ok(html.includes("wiki-link"), `wiki-link class stripped: ${html}`);
+});
+
+test("LaTeX embed marker survives sanitize", async () => {
+  const html = await markdownToHtml("![[proof.tex]]");
+  assert.ok(html.includes('data-latex-embed="true"'), `latex marker stripped: ${html}`);
+  assert.ok(html.includes('data-path="proof.tex"'), `latex path stripped: ${html}`);
+});
+
+test("GFM task-list checkbox input survives sanitize (post-processing depends on it)", async () => {
+  const html = await markdownToHtml("- [ ] todo\n- [x] done\n");
+  // The task-list post-processor runs after sanitize; if the input got stripped
+  // here, downstream Tiptap-shape wrappers would render an empty label.
+  assert.ok(html.includes('data-type="taskItem"'), `taskItem wrapper missing: ${html}`);
+  assert.ok(html.includes('data-checked="true"'), `checked state missing: ${html}`);
+  assert.ok(html.includes('type="checkbox"'), `checkbox input missing: ${html}`);
+});
+
+test("safe href protocols round-trip: http/https/mailto", async () => {
+  const html = await markdownToHtml(
+    "[web](https://example.com) [mail](mailto:a@b.co) [rel](/api/foo)"
+  );
+  assert.ok(html.includes('href="https://example.com"'), `https href stripped: ${html}`);
+  assert.ok(html.includes('href="mailto:a@b.co"'), `mailto href stripped: ${html}`);
+  assert.ok(html.includes('href="/api/foo"'), `relative href stripped: ${html}`);
+});
+
+test("standard prose markup still renders", async () => {
+  const html = await markdownToHtml("**bold** _italic_ `code`\n\n> quote");
+  assert.ok(/<strong>bold<\/strong>/.test(html), `bold stripped: ${html}`);
+  assert.ok(/<em>italic<\/em>/.test(html), `italic stripped: ${html}`);
+  assert.ok(/<code>code<\/code>/.test(html), `code stripped: ${html}`);
+  assert.ok(/<blockquote/.test(html), `blockquote stripped: ${html}`);
+});

--- a/src/lib/markdown/to-html.ts
+++ b/src/lib/markdown/to-html.ts
@@ -2,7 +2,10 @@ import { unified } from "unified";
 import remarkParse from "remark-parse";
 import remarkGfm from "remark-gfm";
 import remarkRehype from "remark-rehype";
+import rehypeRaw from "rehype-raw";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import rehypeStringify from "rehype-stringify";
+import type { Schema } from "hast-util-sanitize";
 import { detectEmbed } from "@/lib/embeds/detect";
 import { slugifyPageName } from "@/lib/markdown/wiki-links";
 import { addHeadingIds } from "@/lib/markdown/heading-slug";
@@ -173,6 +176,55 @@ function resolveRelativeUrls(html: string, pagePath: string): string {
   return html;
 }
 
+// Sanitization schema (#66): the pipeline used to trust raw HTML pass-through
+// and stringify it verbatim, which meant any agent output containing markup
+// like `<img src=x onerror=…>` or `<a href="javascript:…">` executed inside
+// Cabinet's origin — where the daemon auth token and `/api/daemon/pty` live.
+// Extend hast-util-sanitize's default allowlist to cover the markup this
+// pipeline legitimately produces (GFM task lists, wiki-link/LaTeX/embed
+// data-attributes, the `<video>` tags that `upgradeProviderVideos` heals
+// downstream) while leaving event handlers, `javascript:` URLs, `<script>`,
+// `<style>`, and `<iframe>` for the raw-HTML path stripped out.
+//
+// Trusted post-processing (task-list transform, video→iframe upgrade, heading
+// ids, PDF-link marker, relative-URL resolution) runs AFTER sanitize on
+// already-sanitized HTML, so nothing it adds needs to survive the allowlist.
+const sanitizeSchema: Schema = {
+  ...defaultSchema,
+  tagNames: [
+    ...(defaultSchema.tagNames ?? []),
+    "mark",
+    "kbd",
+    "video",
+  ],
+  attributes: {
+    ...defaultSchema.attributes,
+    // Any `data-*` attribute survives — the pipeline itself and downstream
+    // React components rely on data-latex-embed, data-wiki-link, data-embed,
+    // data-provider, data-src, etc. These are inert as far as HTML execution
+    // is concerned; scripting attributes like `on*` are still stripped by
+    // the default deny-list.
+    "*": [...(defaultSchema.attributes?.["*"] ?? []), "className", "dir", "data*"],
+    a: [...(defaultSchema.attributes?.a ?? []), "target", "rel"],
+    input: [
+      ...(defaultSchema.attributes?.input ?? []),
+      ["type", "checkbox"],
+      "checked",
+      "disabled",
+    ],
+    // `<video src=…>` is a legitimate authoring shape that the healer in
+    // upgradeProviderVideos turns into a trusted embed iframe. Allow the
+    // source URL through so healing can inspect it, and cap the protocols
+    // to http(s) so raw HTML can't smuggle a `javascript:` src.
+    video: ["src", "controls", "width", "height", "poster"],
+  },
+  protocols: {
+    ...defaultSchema.protocols,
+    href: ["http", "https", "mailto", "tel"],
+    src: ["http", "https"],
+  },
+};
+
 // Unified's plugin resolution + processor freeze runs on every `unified()`
 // call. Reuse a single frozen pipeline across every page render so
 // navigation doesn't pay that cost on the hot path.
@@ -180,7 +232,9 @@ const processor = unified()
   .use(remarkParse)
   .use(remarkGfm)
   .use(remarkRehype, { allowDangerousHtml: true })
-  .use(rehypeStringify, { allowDangerousHtml: true })
+  .use(rehypeRaw)
+  .use(rehypeSanitize, sanitizeSchema)
+  .use(rehypeStringify)
   .freeze();
 
 export async function markdownToHtml(markdown: string, pagePath?: string): Promise<string> {


### PR DESCRIPTION
## Summary

`src/lib/markdown/to-html.ts` set `allowDangerousHtml: true` on both `remark-rehype` and `rehype-stringify`, and the resulting HTML is rendered via `dangerouslySetInnerHTML` in chat / agent-message components. Since #52 extended that path to agent output, any externally-sourced text an agent echoes — file contents, MCP tool output, prompt-injected content in shared cabinet templates — could land as executable HTML in Cabinet's origin, next to the daemon auth token and `/api/daemon/pty`.

This PR wires `rehype-raw` + `rehype-sanitize` into the shared pipeline with an allowlist tailored to what the pipeline legitimately produces.

## What survives the allowlist (and why)

- **GFM task lists** — the post-processor that rewrites `<ul class="contains-task-list">` into Tiptap's `data-type="taskItem"` shape depends on the `<input type="checkbox">` still being present when it runs.
- **Wiki-link markers** (`<a data-wiki-link data-page-name href="#page:…">`), **LaTeX embed markers** (`<div data-latex-embed data-path>`), and any other `data-*` attributes — allowed via a `data*` wildcard on all tags, since the runtime relies on them and they're inert as far as HTML execution goes.
- **`<video src=…>`** — the `upgradeProviderVideos` post-processor turns these into trusted embed iframes; the source URL is restricted to http(s) so raw HTML can't smuggle a `javascript:` src.
- **Standard prose** — headings, lists, blockquote, code, tables, strong/em, links to http/https/mailto/relative.

## What gets stripped

- `<img src=x onerror=…>`, `<div onclick=…>`, any `on*` attribute — handled by `hast-util-sanitize`'s built-in deny-list.
- `<a href=\"javascript:…\">` — protocol allowlist drops it.
- `<script>`, `<style>` — tag allowlist drops both.
- Raw `<iframe>` from source markdown — added later via trusted post-processing only.
- Inline `style=\"…\"` on legitimate tags.

Trusted post-processing (task-list transform, video→iframe upgrade, heading ids, PDF-link marker, relative-URL resolution) runs AFTER sanitize on already-sanitized HTML, so anything it adds sidesteps the allowlist.

## Tests

`src/lib/markdown/sanitize.test.ts` (10 cases):

- XSS vectors: onerror, javascript:, `<script>`, `<iframe>`, on-attributes on legitimate tags
- Positive: wiki-link markup, LaTeX embed marker, GFM task-list input, safe href protocols, standard prose

Also runs the pre-existing task-list round-trip suite to prove Tiptap re-parses the sanitized output.

## Out of scope

The parallel `markdownToHtml` in `src/app/api/registry/[slug]/route.ts` renders README content without `allowDangerousHtml`, so raw HTML there is already escaped and doesn't need this treatment. Editor rendering (Tiptap) has its own pipeline and is a separate audit — noted in #66 but left for a follow-up.

## Test plan

- [x] \`npm test\` — 367/367 pass
- [x] \`npm run lint\` — no new warnings
- [x] \`npm run build\` — production build succeeds
- [ ] Manual: paste \`<img src=x onerror=alert(1)>\` into an agent-visible file and confirm no alert fires when the agent echoes it back
- [ ] Manual: verify existing pages with wiki-links, LaTeX embeds, and video-URL embeds still render as before

Closes #66.