### PR TITLE
fix(dialog): cap DialogContent at viewport with internal scroll (#34)

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -55,8 +55,12 @@ function DialogContent({
       <DialogOverlay />
       <DialogPrimitive.Popup
         data-slot="dialog-content"
+        // Cap the popup at the viewport so tall content (e.g. long forms on
+        // a laptop) is scrollable inside the dialog rather than being cropped
+        // by the fixed centered positioning (#34). Consumers can still override
+        // via className — twMerge picks the last max-h / overflow class.
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-background p-4 text-sm ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] max-h-[calc(100dvh-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto rounded-xl bg-background p-4 text-sm ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className
         )}
         {...props}


### PR DESCRIPTION
## Summary

The shared \`DialogContent\` popup had no max-height, so any dialog taller than the viewport (the new-job form in the screenshot on #34, but also any long form on a laptop) got clipped top and bottom by the fixed centered positioning, with no way to scroll to reach action buttons.

Add \`max-h-[calc(100dvh-2rem)] overflow-y-auto\` to the base classes — matching the existing \`max-w-[calc(100%-2rem)]\` inset — so the popup always fits and internal content scrolls when it doesn't.

## Why this is safe for the ~117 DialogContent call sites

- Consumers that already set bespoke height/overflow (\`org-chart-modal\` with \`overflow-hidden\`, \`edit-agent-dialog\` / \`create-agent-dialog\` with their own \`max-h-[85vh] overflow-y-auto\`, \`new-agent-dialog\` with \`max-h-[85vh]\`) still win — \`cn()\` runs \`twMerge\`, last class per Tailwind conflict group wins.
- Dialogs that were previously fitting on-screen keep their shape: \`overflow-y-auto\` only shows a scrollbar when content overflows.

## Test plan

- [x] \`npm test\` — 357/357 pass (no unit-test coverage of layout; asserted no regressions elsewhere)
- [ ] Manual: shrink browser to ~800px height, open the new-job dialog, confirm the buttons are reachable via scroll and no clipping
- [ ] Manual: confirm existing pinned dialogs (\`org-chart-modal\`, \`move-to-dialog\`) still render as before

Closes #34.