### PR TITLE
fix(cli): prefer newer installed app over stale CLI VERSION (#97)

### DIFF
--- a/cabinetai/src/commands/run.ts
+++ b/cabinetai/src/commands/run.ts
@@ -3,7 +3,7 @@ import path from "path";
 import fs from "fs";
 import os from "os";
 import { log, success, error, warning } from "../lib/log.js";
-import { ensureApp } from "../lib/app-manager.js";
+import { ensureApp, latestInstalledVersion, compareSemver } from "../lib/app-manager.js";
 import { openBrowser, spawnChild } from "../lib/process.js";
 import {
   bootstrapCabinetAt,
@@ -246,7 +246,22 @@ async function runCabinet(opts: {
     success(`Bootstrapped "${name}" at ${cabinetDir}`);
   }
 
-  const version = opts.appVersion || VERSION;
+  // #97: `cabinetai update` downloads a newer app bundle but doesn't touch the
+  // CLI's compile-time VERSION. Without this, `run` would boot the older app
+  // forever — or, worse, retry a broken half-installed source tree from the
+  // stale version. Prefer whichever fully-installed version is newest.
+  // `--app-version` still wins so an explicit pin overrides the auto-pick.
+  const installedLatest = latestInstalledVersion();
+  const version =
+    opts.appVersion ||
+    (installedLatest && compareSemver(installedLatest, VERSION) > 0
+      ? installedLatest
+      : VERSION);
+  if (!opts.appVersion && installedLatest && installedLatest !== VERSION) {
+    if (compareSemver(installedLatest, VERSION) > 0) {
+      log(`Using installed app v${installedLatest} (CLI is v${VERSION} — re-install cabinetai to update the CLI too).`);
+    }
+  }
 
   console.log(`
   ┌─────────────────────────────┐

--- a/cabinetai/src/lib/app-manager.test.ts
+++ b/cabinetai/src/lib/app-manager.test.ts
@@ -1,0 +1,94 @@
+import test, { before } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// The module reads `CABINET_HOME` from `~/.cabinet` at import time (via
+// `paths.ts`). Redirect HOME to a temp dir before importing so the test
+// filesystem is isolated from a real developer install.
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "cabinet-app-manager-test-"));
+process.env.HOME = tmpHome;
+if (process.platform === "win32") {
+  process.env.USERPROFILE = tmpHome;
+}
+
+let mod: typeof import("./app-manager");
+let appDir: string;
+
+before(async () => {
+  mod = await import("./app-manager.js");
+  const paths = await import("./paths.js");
+  appDir = path.join(paths.CABINET_HOME, "app");
+});
+
+// Simulate a fully-installed prebuilt bundle for a given version — every check
+// in `hasProductionRuntime` must pass or `isAppInstalled` filters the version
+// out.
+function seedInstalledBundle(version: string): void {
+  const versionDir = path.join(appDir, `v${version}`);
+  fs.mkdirSync(path.join(versionDir, ".next", "static"), { recursive: true });
+  fs.mkdirSync(path.join(versionDir, "server"), { recursive: true });
+  fs.mkdirSync(path.join(versionDir, ".native", "node-pty"), { recursive: true });
+  fs.writeFileSync(path.join(versionDir, "server.js"), "// stub");
+  fs.writeFileSync(path.join(versionDir, "server", "cabinet-daemon.cjs"), "// stub");
+  fs.writeFileSync(
+    path.join(versionDir, ".native", "node-pty", "package.json"),
+    "{}"
+  );
+}
+
+// A half-installed directory: created (e.g. by a failed download) but nothing
+// runnable inside. `listInstalledVersions()` still sees it; `isAppInstalled`
+// rejects it.
+function seedPartialInstall(version: string): void {
+  fs.mkdirSync(path.join(appDir, `v${version}`), { recursive: true });
+}
+
+function clearApps(): void {
+  fs.rmSync(appDir, { recursive: true, force: true });
+  fs.mkdirSync(appDir, { recursive: true });
+}
+
+test.beforeEach(() => clearApps());
+
+test("compareSemver orders release versions numerically, not lexicographically", () => {
+  const { compareSemver } = mod;
+  assert.ok(compareSemver("0.4.10", "0.4.9") > 0, "0.4.10 must sort after 0.4.9");
+  assert.ok(compareSemver("0.5.0", "0.4.9") > 0);
+  assert.equal(compareSemver("0.4.3", "0.4.3"), 0);
+  assert.ok(compareSemver("0.4.2", "0.4.3") < 0);
+  // Leading `v` is tolerated so callers can pass version dir names directly.
+  assert.equal(compareSemver("v0.4.3", "0.4.3"), 0);
+});
+
+test("latestInstalledVersion returns null when no app is installed", () => {
+  const { latestInstalledVersion } = mod;
+  assert.equal(latestInstalledVersion(), null);
+});
+
+test("latestInstalledVersion returns the highest fully-installed semver", () => {
+  const { latestInstalledVersion } = mod;
+  seedInstalledBundle("0.4.2");
+  seedInstalledBundle("0.4.3");
+  seedInstalledBundle("0.4.10");
+  assert.equal(latestInstalledVersion(), "0.4.10");
+});
+
+// The #97 scenario: `cabinetai update` downloaded v0.4.3 but `npm install`
+// failed inside the fresh dir, leaving it half-installed. The user's CLI is
+// still v0.4.2. `run` must NOT pick the broken v0.4.3 — it must fall back
+// to VERSION (0.4.2) so the caller can either fix or wipe the partial dir.
+test("latestInstalledVersion ignores half-installed version directories", () => {
+  const { latestInstalledVersion } = mod;
+  seedInstalledBundle("0.4.2");
+  seedPartialInstall("0.4.3");
+  assert.equal(latestInstalledVersion(), "0.4.2");
+});
+
+test("listInstalledVersions still surfaces partial installs (used by `cabinetai list`)", () => {
+  const { listInstalledVersions } = mod;
+  seedInstalledBundle("0.4.2");
+  seedPartialInstall("0.4.3");
+  assert.deepEqual(listInstalledVersions().sort(), ["0.4.2", "0.4.3"]);
+});

--- a/cabinetai/src/lib/app-manager.ts
+++ b/cabinetai/src/lib/app-manager.ts
@@ -335,7 +335,8 @@ async function cloneFallback(version: string, appDir: string, tempDir: string): 
 }
 
 /**
- * List installed app versions.
+ * List installed app versions (any `~/.cabinet/app/vX.Y.Z/` directory,
+ * including partial or broken installs).
  */
 export function listInstalledVersions(): string[] {
   const appParent = path.join(CABINET_HOME, "app");
@@ -346,4 +347,38 @@ export function listInstalledVersions(): string[] {
     .filter((e) => e.isDirectory() && e.name.startsWith("v"))
     .map((e) => e.name.slice(1))
     .sort();
+}
+
+/**
+ * Compare two semver-shaped strings numerically.
+ * Returns a negative number if `a < b`, positive if `a > b`, zero if equal.
+ * Ignores pre-release suffixes — we only care about ordering release lines.
+ */
+export function compareSemver(a: string, b: string): number {
+  const partsA = a.replace(/^v/, "").split("-")[0].split(".").map(Number);
+  const partsB = b.replace(/^v/, "").split("-")[0].split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (partsA[i] || 0) - (partsB[i] || 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/**
+ * Highest fully-installed app version under `~/.cabinet/app/`, or `null`
+ * when none is installed.
+ *
+ * Callers use this to survive the case in #97: `cabinetai update` downloads
+ * a newer app bundle, but the CLI's compile-time `VERSION` is still the old
+ * one — so `cabinetai run` would keep booting the older install (possibly a
+ * broken half-installed source tree) instead of the just-downloaded app.
+ * Preferring the newest fully-installed version breaks that stuck state.
+ *
+ * Half-installed directories (created but never populated with a runnable
+ * bundle / node_modules) are filtered out via `isAppInstalled`.
+ */
+export function latestInstalledVersion(): string | null {
+  const versions = listInstalledVersions().filter(isAppInstalled);
+  if (versions.length === 0) return null;
+  return versions.sort(compareSemver).at(-1) ?? null;
 }


### PR DESCRIPTION
## Summary

Fixes the stuck state described in #97: \`cabinetai update\` downloads a newer app bundle into \`~/.cabinet/app/vX/\`, but the CLI's compile-time \`VERSION\` still points at whatever release was on npm when the user did \`npm install -g cabinetai\`. When npm publishing lagged the GitHub release (0.4.3 was the specific incident), \`run\` kept booting the old app forever — or a broken half-installed source tree from the stale version — with no way out short of \`--app-version 0.4.3\` or patching \`node_modules/cabinetai/dist/index.js\` by hand.

## What changes

- \`app-manager.ts\` gains \`latestInstalledVersion()\` and a shared \`compareSemver\` (previously duplicated inside \`update.ts\` — kept the local copy there to keep this PR small).
- \`run.ts\` picks: \`opts.appVersion → newest fully-installed version if it's > VERSION → VERSION\`. Half-installed directories (fs mkdir'd but no runnable bundle inside) are filtered out via the existing \`isAppInstalled\` check, so a v0.4.3 that failed mid-install can't pull the user back onto its broken tree.
- Logs the picked version when it differs from VERSION so users can see when the CLI itself is stale and needs \`npm install -g cabinetai\`.

## What this does not fix (worth follow-ups)

The issue also called out three related weak points; leaving them here since each needs its own thinking:

1. \`ensureApp\` doesn't clean up \`appDir\` when \`npm install\` fails after tarball extraction, so subsequent runs keep hitting the same partial state. \`downloadAndExtractSource\` already deletes on error but \`installFromSource\` doesn't wrap the install step.
2. \`update\` doesn't prune older \`~/.cabinet/app/vX/\` directories.
3. \`ensureApp\` runs \`npm install\` with \`stdio: \"inherit\"\` and reports the generic \"Failed to install dependencies\", making Windows-build-tools / node-gyp failures hard to diagnose.

Happy to do those as separate PRs if you want them prioritized.

## Test plan

- [x] \`cd cabinetai && npx tsx --test src/lib/app-manager.test.ts\` — 5/5 pass (semver order, empty state, highest-picked, partial-install filter, list surfaces partials)
- [x] \`cd cabinetai && npm run build\` — esbuild succeeds
- [x] \`cd cabinetai && npx tsc --noEmit\` — clean
- [ ] Manual: with CLI v0.5.0 installed and \`~/.cabinet/app/v0.6.0/\` present (via update), confirm \`cabinetai run\` picks v0.6.0 and logs it
- [ ] Manual: with a half-installed \`v0.6.0/\` (dir exists but no server.js), confirm \`cabinetai run\` falls back to VERSION rather than crashing on the broken tree

Closes #97 (primary VERSION-mismatch cause). Follow-ups above track the remaining sharp edges.