### PR TITLE
fix(agents): detect codex/CLIs installed via pnpm or bun (#39)

### DIFF
--- a/src/lib/agents/provider-cli.test.ts
+++ b/src/lib/agents/provider-cli.test.ts
@@ -141,6 +141,7 @@ test("buildRuntimePath uses Windows delimiters and npm global bin paths", () => 
     [
       "C:\\Users\\TestUser\\AppData\\Roaming\\npm",
       "C:\\Users\\TestUser\\.local\\bin",
+      "C:\\Users\\TestUser\\.bun\\bin",
       "C:\\Windows\\System32",
     ].join(";")
   );
@@ -162,6 +163,7 @@ test("buildRuntimePath uses requested platform path semantics even on a differen
     [
       "C:\\Users\\TestUser\\AppData\\Roaming\\npm",
       "C:\\Users\\TestUser\\.local\\bin",
+      "C:\\Users\\TestUser\\.bun\\bin",
       "C:\\Users\\TestUser\\.nvm\\bin",
       "C:/Windows/System32",
     ].join(";")
@@ -184,10 +186,60 @@ test("buildRuntimePath uses POSIX separators when a POSIX platform is requested"
       "/home/test-user/.local/bin",
       "/usr/local/bin",
       "/opt/homebrew/bin",
+      "/home/test-user/.local/share/pnpm",
+      "/home/test-user/.bun/bin",
       "/home/test-user/.nvm/versions/node/v22/bin",
       "/usr/bin",
     ].join(":")
   );
+});
+
+// #39: a codex CLI installed via pnpm lands in `~/Library/pnpm/codex` on
+// macOS. Cabinet's daemon starts without a login shell so `$PATH` alone can
+// miss it. `buildRuntimePath` bakes the platform defaults in so detection
+// works out of the box.
+test("buildRuntimePath includes pnpm + bun global-bin dirs on macOS", () => {
+  const runtimePath = buildRuntimePath({
+    platform: "darwin",
+    env: testEnv({
+      HOME: "/Users/test-user",
+      PATH: "/usr/bin",
+    }),
+    nvmBin: null,
+  });
+
+  assert.ok(runtimePath.includes("/Users/test-user/Library/pnpm"), runtimePath);
+  assert.ok(runtimePath.includes("/Users/test-user/.bun/bin"), runtimePath);
+});
+
+test("buildRuntimePath honours an explicit PNPM_HOME env var", () => {
+  const runtimePath = buildRuntimePath({
+    platform: "linux",
+    env: testEnv({
+      HOME: "/home/test-user",
+      PATH: "/usr/bin",
+      PNPM_HOME: "/opt/pnpm-custom",
+    }),
+    nvmBin: null,
+  });
+
+  assert.ok(runtimePath.includes("/opt/pnpm-custom"), runtimePath);
+});
+
+test("buildRuntimePath includes pnpm + bun global-bin dirs on Windows", () => {
+  const runtimePath = buildRuntimePath({
+    platform: "win32",
+    env: testEnv({
+      USERPROFILE: "C:/Users/TestUser",
+      APPDATA: "C:/Users/TestUser/AppData/Roaming",
+      LOCALAPPDATA: "C:/Users/TestUser/AppData/Local",
+      PATH: "C:/Windows/System32",
+    }),
+    nvmBin: null,
+  });
+
+  assert.ok(runtimePath.includes("C:\\Users\\TestUser\\AppData\\Local\\pnpm"), runtimePath);
+  assert.ok(runtimePath.includes("C:\\Users\\TestUser\\.bun\\bin"), runtimePath);
 });
 
 test("buildCommandCandidates only returns Windows cmd paths plus bare command", () => {
@@ -204,9 +256,26 @@ test("buildCommandCandidates only returns Windows cmd paths plus bare command", 
   assert.deepEqual(candidates, [
     "C:\\Users\\TestUser\\AppData\\Roaming\\npm\\codex.cmd",
     "C:\\Users\\TestUser\\.local\\bin\\codex.cmd",
+    "C:\\Users\\TestUser\\.bun\\bin\\codex.cmd",
     "C:\\Users\\TestUser\\.nvm\\bin\\codex.cmd",
     "codex",
   ]);
+});
+
+// #39: without pnpm bins in the candidate list, an explicit-path detection of
+// `codex` installed via `pnpm add -g` at `~/Library/pnpm/codex` never fires.
+test("buildCommandCandidates surfaces pnpm + bun global bins on macOS", () => {
+  const candidates = buildCommandCandidates("codex", {
+    platform: "darwin",
+    env: testEnv({
+      HOME: "/Users/test-user",
+      PATH: "/usr/bin",
+    }),
+    nvmBin: null,
+  });
+
+  assert.ok(candidates.includes("/Users/test-user/Library/pnpm/codex"), candidates.join("\n"));
+  assert.ok(candidates.includes("/Users/test-user/.bun/bin/codex"), candidates.join("\n"));
 });
 
 test("resolveCliCommand prefers a bare Windows command when it is on PATH", () => {

--- a/src/lib/agents/provider-cli.ts
+++ b/src/lib/agents/provider-cli.ts
@@ -55,6 +55,44 @@ function getPlatformPathTools(platform: NodeJS.Platform) {
   };
 }
 
+/**
+ * Well-known global-bin directories for package managers whose installers
+ * write CLIs outside `/usr/local/bin` and outside `$PATH` when a shell profile
+ * hasn't sourced them (Electron ships with an environment closer to launchd's
+ * than a login shell's).
+ *
+ * `PNPM_HOME` is set by `pnpm setup` and is authoritative when present. Fall
+ * back to platform defaults so a pnpm install that predates `setup` still
+ * gets detected. Bun's `~/.bun/bin` follows the same pattern for symmetry so
+ * a bun-installed CLI (#39-flavoured issue) is visible too.
+ */
+function packageManagerBinDirs(
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+  pathApi: typeof path.posix | typeof path.win32,
+): string[] {
+  const homeDir = resolveHomeDir(env);
+  const dirs: string[] = [];
+
+  const pnpmHome = env.PNPM_HOME?.trim();
+  if (pnpmHome) dirs.push(pathApi.normalize(pnpmHome));
+
+  if (platform === "win32") {
+    if (env.LOCALAPPDATA) dirs.push(pathApi.join(env.LOCALAPPDATA, "pnpm"));
+    dirs.push(pathApi.join(homeDir, ".bun", "bin"));
+  } else if (platform === "darwin") {
+    dirs.push(pathApi.join(homeDir, "Library", "pnpm"));
+    dirs.push(pathApi.join(homeDir, ".local", "share", "pnpm")); // linux-style fallback
+    dirs.push(pathApi.join(homeDir, ".bun", "bin"));
+  } else {
+    dirs.push(pathApi.join(homeDir, ".local", "share", "pnpm"));
+    dirs.push(pathApi.join(homeDir, ".bun", "bin"));
+  }
+
+  // Dedupe so `PNPM_HOME` pointing at the platform default doesn't repeat.
+  return Array.from(new Set(dirs.filter(Boolean)));
+}
+
 export function buildRuntimePath(options?: {
   platform?: NodeJS.Platform;
   env?: NodeJS.ProcessEnv;
@@ -64,12 +102,14 @@ export function buildRuntimePath(options?: {
   const env = options?.env || process.env;
   const runtimeNvmBin = options?.nvmBin === undefined ? nvmBin : options.nvmBin;
   const { api: pathApi, delimiter } = getPlatformPathTools(platform);
+  const pmDirs = packageManagerBinDirs(platform, env, pathApi);
 
   if (platform === "win32") {
     const homeDir = resolveHomeDir(env);
     return [
       env.APPDATA ? pathApi.join(env.APPDATA, "npm") : "",
       pathApi.join(homeDir, ".local", "bin"),
+      ...pmDirs,
       ...(runtimeNvmBin ? [pathApi.normalize(runtimeNvmBin)] : []),
       env.PATH || "",
     ].filter(Boolean).join(delimiter);
@@ -79,6 +119,7 @@ export function buildRuntimePath(options?: {
     `${env.HOME || ""}/.local/bin`,
     "/usr/local/bin",
     "/opt/homebrew/bin",
+    ...pmDirs,
     ...(runtimeNvmBin ? [pathApi.normalize(runtimeNvmBin)] : []),
     env.PATH || "",
   ].filter(Boolean).join(delimiter);
@@ -130,13 +171,16 @@ export function buildCommandCandidates(
   const env = options?.env || process.env;
   const runtimeNvmBin = options?.nvmBin ?? null;
   const { api: pathApi } = getPlatformPathTools(platform);
+  const suffix = platform === "win32" ? ".cmd" : "";
+  const pmDirs = packageManagerBinDirs(platform, env, pathApi);
 
   if (platform === "win32") {
     const homeDir = resolveHomeDir(env);
     return [
-      env.APPDATA ? pathApi.join(env.APPDATA, "npm", `${command}.cmd`) : "",
-      pathApi.join(homeDir, ".local", "bin", `${command}.cmd`),
-      ...(runtimeNvmBin ? [pathApi.join(runtimeNvmBin, `${command}.cmd`)] : []),
+      env.APPDATA ? pathApi.join(env.APPDATA, "npm", `${command}${suffix}`) : "",
+      pathApi.join(homeDir, ".local", "bin", `${command}${suffix}`),
+      ...pmDirs.map((dir) => pathApi.join(dir, `${command}${suffix}`)),
+      ...(runtimeNvmBin ? [pathApi.join(runtimeNvmBin, `${command}${suffix}`)] : []),
       command,
     ].filter(Boolean);
   }
@@ -145,6 +189,7 @@ export function buildCommandCandidates(
     `${env.HOME || ""}/.local/bin/${command}`,
     `/usr/local/bin/${command}`,
     `/opt/homebrew/bin/${command}`,
+    ...pmDirs.map((dir) => pathApi.join(dir, command)),
     ...(runtimeNvmBin ? [pathApi.join(runtimeNvmBin, command)] : []),
     command,
   ].filter(Boolean);


### PR DESCRIPTION
## Summary

#39 reports that Cabinet doesn't detect \`codex\` when installed via \`pnpm add -g codex\` (the primary reporter) or even after reinstalling via \`npm install -g codex\` (secondary reporter). The daemon spawns adapter CLIs through \`buildRuntimePath\`, which only listed npm-style locations (\`~/.local/bin\`, \`/usr/local/bin\`, \`/opt/homebrew/bin\`, and \`%APPDATA%\\npm\` on Windows).

pnpm's global installs go to a different tree:

- macOS: \`~/Library/pnpm\`
- Linux: \`~/.local/share/pnpm\`
- Windows: \`%LOCALAPPDATA%\\pnpm\`
- Any: \`\$PNPM_HOME\` when \`pnpm setup\` has run

Electron doesn't inherit the login-shell PATH that would normally surface these — so pnpm-installed CLIs stay invisible to Cabinet even when they work fine from a terminal.

## What changes

- \`buildRuntimePath\` and \`buildCommandCandidates\` both consult a new \`packageManagerBinDirs()\` helper that returns the platform's pnpm defaults (honouring \`\$PNPM_HOME\` first) plus \`~/.bun/bin\` for symmetry.
- Duplicates are deduped so a \`PNPM_HOME\` pointing at the platform default doesn't repeat.

## Test plan

- [x] \`npm test\` — 361/361 pass (existing runtime-path expectations updated to include the new default bin dirs; four new regressions cover pnpm/bun on macOS + Windows and the \$PNPM_HOME override)
- [ ] Manual: \`pnpm add -g @openai/codex\` on macOS, restart Cabinet, confirm codex is listed as installed
- [ ] Manual: same on Windows with \`pnpm add -g @openai/codex\` under \`%LOCALAPPDATA%\\pnpm\`
- [ ] Manual: \`pnpm setup\` with a non-default \`PNPM_HOME\` — codex must still be detected

Closes #39.