### PR TITLE
fix(security): sanitize HTML at the render boundary (#66)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "i18next": "^26.1.0",
         "i18next-browser-languagedetector": "^8.2.1",
         "imapflow": "^1.3.5",
+        "isomorphic-dompurify": "^3.18.0",
         "jose": "^6.2.2",
         "js-yaml": "^4.1.1",
         "jspdf": "^4.2.1",
@@ -165,6 +166,53 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -639,11 +687,157 @@
       "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
       "license": "MIT"
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@chevrotain/types": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
       "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
     },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.1",
@@ -2825,6 +3019,23 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -8711,6 +8922,15 @@
         "node": "20.x || 22.x || 23.x || 24.x || 25.x"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -9791,6 +10011,19 @@
         "utrie": "^1.0.2"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -10345,6 +10578,54 @@
         "node": ">= 12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -10421,6 +10702,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -11138,6 +11425,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -13318,6 +13617,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
@@ -14152,6 +14463,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -14394,6 +14711,19 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/isomorphic-dompurify": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-3.18.0.tgz",
+      "integrity": "sha512-ajp0D8laIHeoYlhBTevpE2HUhqWaqLXFk6K/wV3Ok8kDraBZpZsifwVWaY8IfJntMRIo1VSksgKV+lXyet9Q7A==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "^3.4.11",
+        "jsdom": "^29.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -14601,6 +14931,90 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/jsesc": {
@@ -16028,6 +16442,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -17923,6 +18343,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -18675,7 +19107,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -19597,6 +20028,18 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -20950,6 +21393,12 @@
         "node": ">=16.x"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
     "node_modules/tabbable": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
@@ -21687,6 +22136,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -22233,6 +22691,18 @@
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
@@ -22356,6 +22826,15 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/whatwg-url": {
@@ -22679,6 +23158,15 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
@@ -22688,6 +23176,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "i18next": "^26.1.0",
     "i18next-browser-languagedetector": "^8.2.1",
     "imapflow": "^1.3.5",
+    "isomorphic-dompurify": "^3.18.0",
     "jose": "^6.2.2",
     "js-yaml": "^4.1.1",
     "jspdf": "^4.2.1",

--- a/src/app/agents/conversations/[id]/transcript-viewer.tsx
+++ b/src/app/agents/conversations/[id]/transcript-viewer.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from "react";
 import { CopyButton } from "./copy-button";
 import { parseTranscript, type Block } from "./transcript-parser";
+import { SafeHtml } from "@/components/ui/safe-html";
 
 /** Render markdown-style links and inline code in text */
 function renderInlineFormatting(text: string): React.ReactNode[] {
@@ -148,10 +149,7 @@ const PROSE_CLASSES = "prose prose-sm prose-invert max-w-none prose-headings:fon
 function MarkdownBlock({ content, html }: { content: string; html?: string }) {
   if (html) {
     return (
-      <div
-        className={`my-1 ${PROSE_CLASSES}`}
-        dangerouslySetInnerHTML={{ __html: html }}
-      />
+      <SafeHtml html={html} profile="rich" className={`my-1 ${PROSE_CLASSES}`} />
     );
   }
 

--- a/src/components/agents/conversation-live-view.tsx
+++ b/src/components/agents/conversation-live-view.tsx
@@ -25,6 +25,7 @@ import { usePageMeta } from "@/hooks/use-page-meta";
 import { cn } from "@/lib/utils";
 import { ConversationApprovalPanel } from "./conversation-approval-panel";
 import { useLocale } from "@/i18n/use-locale";
+import { SafeHtml } from "@/components/ui/safe-html";
 
 function StatusBadge({ status }: { status: string }) {
   const { t } = useLocale();
@@ -123,9 +124,10 @@ export function ConversationLiveView({
             </Button>
           </div>
           {promptText && promptHtml ? (
-            <div
+            <SafeHtml
+              html={promptHtml}
+              profile="rich"
               className="max-h-48 overflow-y-auto overflow-x-hidden prose prose-sm prose-invert max-w-none prose-headings:font-semibold prose-headings:text-foreground prose-h1:text-base prose-h2:text-[13px] prose-h3:text-[12px] prose-p:text-[13px] prose-p:text-foreground/85 prose-li:text-[13px] prose-li:text-foreground/85 prose-a:text-foreground prose-code:text-[11px] prose-code:text-foreground prose-code:bg-background prose-code:px-1 prose-code:rounded prose-pre:bg-background prose-pre:border-0 prose-pre:text-foreground prose-strong:text-foreground"
-              dangerouslySetInnerHTML={{ __html: promptHtml }}
             />
           ) : (
             <p className="max-h-48 overflow-y-auto overflow-x-hidden break-words text-[13px] leading-relaxed text-foreground/85">

--- a/src/components/agents/conversation-result-view.tsx
+++ b/src/components/agents/conversation-result-view.tsx
@@ -17,6 +17,7 @@ import { usePageMeta } from "@/hooks/use-page-meta";
 import { cn } from "@/lib/utils";
 import { ConversationApprovalPanel } from "./conversation-approval-panel";
 import { useLocale } from "@/i18n/use-locale";
+import { SafeHtml } from "@/components/ui/safe-html";
 
 function StatusBadge({ status }: { status: string }) {
   const { t } = useLocale();
@@ -113,9 +114,10 @@ export function ConversationResultView({
             </div>
           </div>
           {promptHtml ? (
-            <div
+            <SafeHtml
+              html={promptHtml}
+              profile="rich"
               className="max-h-48 overflow-y-auto overflow-x-hidden prose prose-sm prose-invert max-w-none prose-headings:font-semibold prose-headings:text-foreground prose-h1:text-base prose-h2:text-[13px] prose-h3:text-[12px] prose-p:text-[13px] prose-p:text-foreground/85 prose-li:text-[13px] prose-li:text-foreground/85 prose-a:text-foreground prose-code:text-[11px] prose-code:text-foreground prose-code:bg-background prose-code:px-1 prose-code:rounded prose-pre:bg-background prose-pre:border-0 prose-pre:text-foreground prose-strong:text-foreground"
-              dangerouslySetInnerHTML={{ __html: promptHtml }}
             />
           ) : (
             <p className="max-h-48 overflow-y-auto overflow-x-hidden break-words text-[13px] leading-relaxed text-foreground/85">

--- a/src/components/editor/extensions/mermaid-codeblock.tsx
+++ b/src/components/editor/extensions/mermaid-codeblock.tsx
@@ -20,6 +20,7 @@ import {
 } from "@tiptap/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Code, Eye, ZoomIn, ZoomOut, Maximize } from "lucide-react";
+import { SafeHtml } from "@/components/ui/safe-html";
 
 // Kept identical to the previous CodeBlockLowlight config so non-mermaid
 // blocks look exactly as before.
@@ -230,12 +231,13 @@ function MermaidCodeBlockView({ node, selected }: NodeViewProps) {
                 </span>
               </div>
             ) : svg ? (
-              <div
+              <SafeHtml
+                html={svg}
+                profile="svg"
                 className="flex h-full w-full items-center justify-center p-4 [&_svg]:!h-full [&_svg]:!max-h-none [&_svg]:!max-w-none [&_svg]:!w-full"
                 style={{
                   transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
                 }}
-                dangerouslySetInnerHTML={{ __html: svg }}
               />
             ) : (
               <div className="flex h-full items-center justify-center">

--- a/src/components/editor/latex-viewer.tsx
+++ b/src/components/editor/latex-viewer.tsx
@@ -6,6 +6,7 @@ import { ToolbarButton } from "@/components/layout/toolbar-button";
 import { ViewerToolbar } from "@/components/layout/viewer-toolbar";
 import { ViewerLayout } from "@/components/layout/viewer-layout";
 import { renderLatexToHtml } from "./latex-render";
+import { SafeHtml } from "@/components/ui/safe-html";
 
 interface LatexViewerProps {
   path: string;
@@ -187,9 +188,11 @@ export function LatexViewer({ path }: LatexViewerProps) {
                 </div>
               </div>
             )}
-            <article
+            <SafeHtml
+              as="article"
+              html={rendered.html}
+              profile="rich"
               className="latex-rendered prose prose-zinc max-w-none dark:prose-invert"
-              dangerouslySetInnerHTML={{ __html: rendered.html }}
             />
           </div>
         ) : (

--- a/src/components/editor/mermaid-viewer.tsx
+++ b/src/components/editor/mermaid-viewer.tsx
@@ -7,6 +7,7 @@ import { ViewerToolbar } from "@/components/layout/viewer-toolbar";
 import { ViewerLayout } from "@/components/layout/viewer-layout";
 import { ToolbarButton } from "@/components/layout/toolbar-button";
 import { useLocale } from "@/i18n/use-locale";
+import { SafeHtml } from "@/components/ui/safe-html";
 
 interface MermaidViewerProps {
   path: string;
@@ -196,13 +197,14 @@ export function MermaidViewer({ path, title }: MermaidViewerProps) {
             onPointerMove={handlePointerMove}
             onPointerUp={handlePointerUp}
           >
-            <div
+            <SafeHtml
               ref={containerRef}
+              html={svg}
+              profile="svg"
               className="flex items-center justify-center p-8 min-h-full [&_svg]:max-w-full origin-center select-none"
               style={{
                 transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
               }}
-              dangerouslySetInnerHTML={{ __html: svg }}
             />
           </div>
         )}

--- a/src/components/editor/notebook-viewer.tsx
+++ b/src/components/editor/notebook-viewer.tsx
@@ -9,6 +9,7 @@ import { common, createLowlight } from "lowlight";
 import { toHtml } from "hast-util-to-html";
 import { markdownToHtml } from "@/lib/markdown/to-html";
 import { useLocale } from "@/i18n/use-locale";
+import { SafeHtml } from "@/components/ui/safe-html";
 
 interface NotebookViewerProps {
   path: string;
@@ -133,9 +134,10 @@ function CellOutput({ output }: { output: NotebookOutput }) {
   if (data["image/svg+xml"]) {
     const svg = joinSource(data["image/svg+xml"]);
     return (
-      <div
+      <SafeHtml
+        html={svg}
+        profile="svg"
         className="max-w-full rounded-md bg-white p-2 overflow-auto"
-        dangerouslySetInnerHTML={{ __html: svg }}
       />
     );
   }
@@ -174,7 +176,7 @@ function CodeCellView({ cell, language }: { cell: CodeCell; language: string }) 
       </div>
       <div>
         <pre className="whitespace-pre overflow-x-auto font-mono text-[13px] leading-relaxed px-4 py-3 rounded-md bg-[#FFF9E9] border border-[#E8DDC5] text-[#2A221B]">
-          <code dangerouslySetInnerHTML={{ __html: html }} />
+          <SafeHtml as="code" html={html} profile="code" />
         </pre>
 
         {hasOutputs && (
@@ -206,9 +208,10 @@ function MarkdownCellView({ cell }: { cell: MarkdownCell }) {
     };
   }, [cell.source]);
   return (
-    <div
+    <SafeHtml
+      html={html}
+      profile="rich"
       className="prose prose-sm max-w-none mb-5 px-1 [&_h1]:font-serif [&_h2]:font-serif [&_h3]:font-serif [&_a]:text-[#8B5E3C] [&_a:hover]:underline [&_code]:bg-[#F5EEDC] [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:text-[#8B2E3E]"
-      dangerouslySetInnerHTML={{ __html: html }}
     />
   );
 }

--- a/src/components/editor/office/xlsx-viewer.tsx
+++ b/src/components/editor/office/xlsx-viewer.tsx
@@ -5,6 +5,7 @@ import { OfficeChrome } from "./office-chrome";
 import { ViewerLayout } from "@/components/layout/viewer-layout";
 import { Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { SafeHtml } from "@/components/ui/safe-html";
 
 interface Props {
   path: string;
@@ -99,9 +100,10 @@ export function XlsxViewer({ path, title }: Props) {
           </div>
         )}
         {current && (
-          <div
+          <SafeHtml
+            html={current.html}
+            profile="table"
             className="xlsx-sheet p-3 text-[12px]"
-            dangerouslySetInnerHTML={{ __html: current.html }}
           />
         )}
       </div>

--- a/src/components/editor/source-viewer.tsx
+++ b/src/components/editor/source-viewer.tsx
@@ -16,6 +16,7 @@ import {
   setHtmlViewMode,
   type HtmlViewModeDetail,
 } from "@/lib/ui/html-view-mode";
+import { SafeHtml } from "@/components/ui/safe-html";
 
 interface SourceViewerProps {
   path: string;
@@ -215,9 +216,11 @@ export function SourceViewer({ path }: SourceViewerProps) {
                   <td className="w-12 pr-4 text-right text-[#858585] select-none align-top sticky left-0 bg-[#1e1e1e]">
                     {i + 1}
                   </td>
-                  <td
+                  <SafeHtml
+                    as="td"
+                    html={lineHtml || " "}
+                    profile="code"
                     className={`text-[#d4d4d4] pl-2 ${wrap ? "whitespace-pre-wrap break-all" : "whitespace-pre"}`}
-                    dangerouslySetInnerHTML={{ __html: lineHtml || " " }}
                   />
                 </tr>
               ))}

--- a/src/components/registry/registry-browser.tsx
+++ b/src/components/registry/registry-browser.tsx
@@ -28,6 +28,7 @@ import { useAppStore } from "@/stores/app-store";
 import { ROOT_CABINET_PATH } from "@/lib/cabinets/paths";
 import type { RegistryTemplate } from "@/lib/registry/registry-manifest";
 import { useLocale } from "@/i18n/use-locale";
+import { SafeHtml } from "@/components/ui/safe-html";
 
 /* ─── Parchment palette ─── */
 const P = {
@@ -813,7 +814,9 @@ function DetailView({
                       className="rounded-xl border p-6"
                       style={{ borderColor: P.border, backgroundColor: P.bgCard }}
                     >
-                      <div
+                      <SafeHtml
+                        html={detail.readmeHtml}
+                        profile="rich"
                         className="registry-prose"
                         style={
                           {
@@ -824,7 +827,6 @@ function DetailView({
                             "--prose-link": P.accent,
                           } as React.CSSProperties
                         }
-                        dangerouslySetInnerHTML={{ __html: detail.readmeHtml }}
                       />
                     </div>
                   </section>

--- a/src/components/tasks/conversation/markdown.tsx
+++ b/src/components/tasks/conversation/markdown.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { markdownToHtml } from "@/lib/markdown/to-html";
 import { cn } from "@/lib/utils";
+import { SafeHtml } from "@/components/ui/safe-html";
 
 export function Markdown({
   content,
@@ -39,7 +40,9 @@ export function Markdown({
   }
 
   return (
-    <div
+    <SafeHtml
+      html={html}
+      profile="rich"
       dir="auto"
       className={cn(
         "rtl-aware",
@@ -57,7 +60,6 @@ export function Markdown({
         "prose-blockquote:border-l-2 prose-blockquote:border-border prose-blockquote:pl-3 prose-blockquote:italic prose-blockquote:text-muted-foreground",
         className
       )}
-      dangerouslySetInnerHTML={{ __html: html }}
     />
   );
 }

--- a/src/components/ui/safe-html.tsx
+++ b/src/components/ui/safe-html.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { createElement, useMemo, type ComponentPropsWithoutRef, type ElementType, type Ref } from "react";
+import { sanitizeHtml, type SanitizeProfile } from "@/lib/security/sanitize";
+
+/**
+ * The ONLY sanctioned way to render an HTML string into the DOM (#66).
+ *
+ * Every string that reaches `dangerouslySetInnerHTML` in this app originates
+ * somewhere untrusted — agent output, a note on disk, a registry README pulled
+ * over the network, an .xlsx or .ipynb the user opened — and it renders inside
+ * Cabinet's own origin, next to the daemon auth token. Centralizing the render
+ * makes the invariant greppable: a raw `dangerouslySetInnerHTML` in a component
+ * is now a bug you can find with one search, instead of a hole you find with a
+ * CVE.
+ *
+ * Pick the `profile` that matches the PRODUCER, not the vibe:
+ *   rich  — markdown/prose HTML (agent messages, notes, READMEs)
+ *   svg   — mermaid diagrams, notebook image/svg+xml outputs
+ *   code  — lowlight syntax-highlighted spans
+ *   table — SheetJS sheet_to_html output
+ *
+ * Sanitizing is memoized on (html, profile): mermaid and the source viewer
+ * re-render on every pan/zoom frame, and re-scrubbing a large SVG each frame
+ * would be visible jank.
+ */
+type SafeHtmlProps<T extends ElementType> = {
+  html: string;
+  profile: SanitizeProfile;
+  /** Element to render. Defaults to a <div>. */
+  as?: T;
+  ref?: Ref<HTMLElement>;
+} & Omit<ComponentPropsWithoutRef<T>, "children" | "dangerouslySetInnerHTML" | "as" | "html">;
+
+export function SafeHtml<T extends ElementType = "div">({
+  html,
+  profile,
+  as,
+  ...rest
+}: SafeHtmlProps<T>) {
+  const clean = useMemo(() => sanitizeHtml(html, profile), [html, profile]);
+  const Tag = (as ?? "div") as ElementType;
+  return createElement(Tag, {
+    ...rest,
+    dangerouslySetInnerHTML: { __html: clean },
+  });
+}

--- a/src/lib/security/sanitize.test.ts
+++ b/src/lib/security/sanitize.test.ts
@@ -1,0 +1,192 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { sanitizeHtml } from "./sanitize";
+import { markdownToHtml } from "@/lib/markdown/to-html";
+
+// Two halves, and both matter.
+//
+// The attack half is the point of #66: raw HTML reached `dangerouslySetInnerHTML`
+// verbatim, inside the origin that holds the daemon auth token.
+//
+// The survival half is what makes the fix shippable. A sanitizer that quietly
+// eats wiki-links, task lists, mermaid styling, or video embeds is a content
+// regression across every existing user vault, and it would land looking green.
+
+// Deliberately tag-scoped rather than a substring match. The same characters
+// sitting in TEXT content are inert — the wiki-link case below legitimately
+// renders `x" onmouseover="alert(1)` as the link's visible text — and a naive
+// `includes("onmouseover")` would call that a vulnerability. What actually
+// matters is whether a handler survived as an ATTRIBUTE.
+const HANDLER_ATTR = /<[^>]*\son[a-z]+\s*=/i;
+const SCRIPT_TAG = /<script/i;
+const JS_URI_ATTR = /<[^>]*\s(?:href|src|xlink:href)\s*=\s*["']?\s*javascript:/i;
+const SRCDOC_ATTR = /<[^>]*\ssrcdoc\s*=/i;
+
+const XSS = (html: string) =>
+  HANDLER_ATTR.test(html) ||
+  SCRIPT_TAG.test(html) ||
+  JS_URI_ATTR.test(html) ||
+  SRCDOC_ATTR.test(html);
+
+// ---------------------------------------------------------------- rich (prose)
+
+test("rich: strips script tags, event handlers, and javascript: URLs", () => {
+  const payloads = [
+    '<img src="x" onerror="alert(1)">',
+    '<a href="javascript:alert(1)">click</a>',
+    "Hello <script>alert(1)</script> world",
+    '<div onclick="alert(1)">hi</div>',
+    '<svg onload="alert(1)"></svg>',
+    '<body onload="alert(1)">',
+    '<iframe srcdoc="<script>alert(1)</script>"></iframe>',
+    '<form action="/x"><button formaction="javascript:alert(1)">go</button></form>',
+    '<a href="jAvAsCrIpT:alert(1)">case</a>',
+    '<img src=x onerror=alert(1)>',
+  ];
+  for (const payload of payloads) {
+    const clean = sanitizeHtml(payload, "rich");
+    assert.ok(!XSS(clean), `payload survived: ${payload} -> ${clean}`);
+    assert.ok(!clean.toLowerCase().includes("alert"), `alert() survived: ${payload} -> ${clean}`);
+  }
+});
+
+// The markdown pipeline builds `data-page-name="${pageName}"` by hand, and
+// pageName is `[^\]]+` — a quote in a page title breaks straight out of the
+// attribute. This is an injection point that has nothing to do with raw HTML
+// pass-through, which is exactly why sanitizing at the render boundary (rather
+// than inside the remark pipeline) is the right layer.
+test("rich: an attribute breakout via a wiki-link page name is neutralized", async () => {
+  const html = await markdownToHtml('[[x" onmouseover="alert(1)]]');
+  assert.ok(
+    HANDLER_ATTR.test(html),
+    `precondition: the raw pipeline emits a live onmouseover attribute — got ${html}`
+  );
+
+  const clean = sanitizeHtml(html, "rich");
+  assert.ok(!XSS(clean), `handler survived sanitize: ${clean}`);
+  // The hostile page name lives on as inert link TEXT, which is fine and is why
+  // this assertion is attribute-scoped rather than a substring check.
+  assert.ok(clean.includes("<a"), `the wiki-link itself should still render: ${clean}`);
+});
+
+test("rich: a data: URI is allowed on <img> but refused on <a>", () => {
+  const img = sanitizeHtml('<img src="data:image/png;base64,iVBORw0KGgo=">', "rich");
+  assert.ok(img.includes("data:image/png"), `inline image was dropped: ${img}`);
+
+  const anchor = sanitizeHtml('<a href="data:text/html,<script>alert(1)</script>">x</a>', "rich");
+  assert.ok(!anchor.toLowerCase().includes("data:text/html"), `data: navigation survived: ${anchor}`);
+});
+
+test("rich: prose, links, and file:// URLs round-trip", async () => {
+  const html = await markdownToHtml(
+    "**bold** _italic_ `code`\n\n> quote\n\n[web](https://example.com) [mail](mailto:a@b.co) [rel](/api/foo)"
+  );
+  const clean = sanitizeHtml(html, "rich");
+  assert.match(clean, /<strong>bold<\/strong>/);
+  assert.match(clean, /<em>italic<\/em>/);
+  assert.match(clean, /<code>code<\/code>/);
+  assert.match(clean, /<blockquote/);
+  assert.ok(clean.includes('href="https://example.com"'), `https href stripped: ${clean}`);
+  assert.ok(clean.includes('href="mailto:a@b.co"'), `mailto href stripped: ${clean}`);
+  assert.ok(clean.includes('href="/api/foo"'), `relative href stripped: ${clean}`);
+
+  // encodeFileUrls() exists to make these work; sanitize must not undo it.
+  const fileLink = sanitizeHtml('<a href="file:///home/u/My%20File.pdf">f</a>', "rich");
+  assert.ok(fileLink.includes("file:///home/u/My%20File.pdf"), `file:// link stripped: ${fileLink}`);
+});
+
+test("rich: wiki-link, LaTeX embed, and task-list markup survive", async () => {
+  const wiki = sanitizeHtml(await markdownToHtml("See [[Some Page]] for context"), "rich");
+  assert.ok(wiki.includes('data-wiki-link="true"'), `wiki-link marker stripped: ${wiki}`);
+  assert.ok(wiki.includes('data-page-name="Some Page"'), `page name stripped: ${wiki}`);
+
+  const latex = sanitizeHtml(await markdownToHtml("![[proof.tex]]"), "rich");
+  assert.ok(latex.includes('data-latex-embed="true"'), `latex marker stripped: ${latex}`);
+  assert.ok(latex.includes('data-path="proof.tex"'), `latex path stripped: ${latex}`);
+
+  const tasks = sanitizeHtml(await markdownToHtml("- [ ] todo\n- [x] done\n"), "rich");
+  assert.ok(tasks.includes('data-type="taskItem"'), `taskItem wrapper missing: ${tasks}`);
+  assert.ok(tasks.includes('data-checked="true"'), `checked state missing: ${tasks}`);
+  assert.ok(tasks.includes('type="checkbox"'), `checkbox input missing: ${tasks}`);
+});
+
+// upgradeProviderVideos heals <video src="youtube-url"> into a real iframe. If
+// sanitize drops iframes, every video embed in every note goes blank.
+test("rich: a healed provider iframe embed survives, but not with srcdoc", async () => {
+  const html = await markdownToHtml('<video src="https://youtu.be/dQw4w9WgXcQ"></video>');
+  const clean = sanitizeHtml(html, "rich");
+  assert.ok(clean.includes("<iframe"), `embed iframe was stripped: ${clean}`);
+  assert.ok(clean.includes("allowfullscreen"), `allowfullscreen stripped: ${clean}`);
+
+  const evil = sanitizeHtml('<iframe src="https://ok.example" srcdoc="<script>alert(1)</script>"></iframe>', "rich");
+  assert.ok(evil.includes("<iframe"), "the iframe itself is still allowed");
+  assert.ok(!evil.toLowerCase().includes("srcdoc"), `srcdoc survived: ${evil}`);
+});
+
+test("rich: inline style is dropped (overlay/clickjacking vector, unused by the pipeline)", () => {
+  const clean = sanitizeHtml('<div style="position:fixed;inset:0">x</div>', "rich");
+  assert.ok(!clean.includes("style"), `inline style survived: ${clean}`);
+});
+
+// ------------------------------------------------------------------------ svg
+
+// Both mermaid call sites use securityLevel: "loose", so mermaid does NOT
+// sanitize its own output and permits HTML labels. This profile is the only
+// thing between an agent-authored diagram and the DOM.
+test("svg: strips script and handlers from a mermaid-shaped payload", () => {
+  const payloads = [
+    '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>',
+    '<svg><g onclick="alert(1)"><rect width="10" height="10"/></g></svg>',
+    '<svg><foreignObject><img src=x onerror="alert(1)"></foreignObject></svg>',
+    '<svg><a href="javascript:alert(1)"><text>x</text></a></svg>',
+    '<svg><animate onbegin="alert(1)" attributeName="x"/></svg>',
+  ];
+  for (const payload of payloads) {
+    const clean = sanitizeHtml(payload, "svg");
+    assert.ok(!XSS(clean), `payload survived: ${payload} -> ${clean}`);
+    assert.ok(!clean.toLowerCase().includes("alert"), `alert() survived: ${payload} -> ${clean}`);
+  }
+});
+
+test("svg: mermaid's real output shape survives — <style>, foreignObject labels, paths", () => {
+  const mermaidish =
+    '<svg id="d1" width="200" height="100" viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">' +
+    "<style>#d1 .node rect{fill:#eee;stroke:#333}</style>" +
+    '<g class="node"><rect x="1" y="1" width="80" height="40" rx="4"/>' +
+    '<foreignObject width="80" height="40"><div class="label"><b>Start</b></div></foreignObject></g>' +
+    '<path d="M10 10 L90 90" stroke="#333" marker-end="url(#arrow)"/>' +
+    '<marker id="arrow"><path d="M0 0 L10 5 L0 10 z"/></marker></svg>';
+
+  const clean = sanitizeHtml(mermaidish, "svg");
+  assert.ok(clean.includes("<style"), `mermaid <style> stripped — diagrams render unstyled: ${clean}`);
+  assert.ok(clean.includes("foreignObject") || clean.includes("foreignobject"), `HTML labels stripped: ${clean}`);
+  assert.ok(clean.includes("<path"), `paths stripped: ${clean}`);
+  assert.ok(clean.includes("<marker") , `markers (arrowheads) stripped: ${clean}`);
+  assert.ok(clean.includes("Start"), `label text stripped: ${clean}`);
+});
+
+// ----------------------------------------------------------------------- code
+
+test("code: keeps lowlight spans, drops everything else", () => {
+  const clean = sanitizeHtml('<span class="hljs-keyword">const</span> x = 1;', "code");
+  assert.equal(clean, '<span class="hljs-keyword">const</span> x = 1;');
+
+  const evil = sanitizeHtml('<span class="hljs-x" onclick="alert(1)">x</span><img src=x onerror=alert(1)>', "code");
+  assert.ok(!XSS(evil), `handler survived in code profile: ${evil}`);
+  assert.ok(!evil.includes("<img"), `img survived in code profile: ${evil}`);
+});
+
+// ---------------------------------------------------------------------- table
+
+test("table: keeps SheetJS table structure, drops script and handlers", () => {
+  const clean = sanitizeHtml(
+    '<table><tr><td id="A1">1</td><td colspan="2"><a href="https://x.example">link</a></td></tr></table>',
+    "table"
+  );
+  assert.ok(clean.includes("<table"), `table stripped: ${clean}`);
+  assert.ok(clean.includes('colspan="2"'), `colspan stripped: ${clean}`);
+  assert.ok(clean.includes('href="https://x.example"'), `hyperlink stripped: ${clean}`);
+
+  const evil = sanitizeHtml('<table><tr><td onmouseover="alert(1)"><script>alert(1)</script>x</td></tr></table>', "table");
+  assert.ok(!XSS(evil), `payload survived in table profile: ${evil}`);
+});

--- a/src/lib/security/sanitize.ts
+++ b/src/lib/security/sanitize.ts
@@ -1,0 +1,170 @@
+// `isomorphic-dompurify` re-exports DOMPurify's own `Config` type, so the
+// config objects below stay type-checked without taking a direct dependency on
+// `dompurify` (which is only a transitive dep here — importing it directly
+// would rely on hoisting).
+import DOMPurify, { type Config } from "isomorphic-dompurify";
+
+/**
+ * HTML sanitization at the render boundary (#66).
+ *
+ * Every `dangerouslySetInnerHTML` in the app renders a string that ultimately
+ * comes from somewhere untrusted — an agent's output, a note on disk, a
+ * registry README fetched over the network, a .ipynb or .xlsx a user opened.
+ * All of it lands inside Cabinet's own origin, where the daemon auth token and
+ * `/api/daemon/pty` live, so a single `<img src=x onerror=…>` is remote code
+ * execution against the user's machine, not a defaced paragraph.
+ *
+ * Sanitizing HERE rather than inside the markdown pipeline is deliberate:
+ * markdown is only one of the producers. Mermaid SVG, LaTeX, syntax
+ * highlighting, and SheetJS tables never touch remark, and a pipeline-level
+ * fix leaves all of them open.
+ *
+ * The profiles differ because the payloads differ. Prose needs links and
+ * embeds; an SVG needs `<style>` and `<foreignObject>`; highlighted code needs
+ * nothing but `<span class>`. Each profile is the smallest allowlist that
+ * still renders its producer's real output — see sanitize.test.ts, which pins
+ * both halves: attacks die, legitimate markup survives.
+ */
+
+// Relative URLs, anchors, and the schemes the app actually links to. `file:`
+// is here because `encodeFileUrls` in the markdown pipeline exists to make
+// `file:///…` links work — dropping it would silently break a real feature.
+// Everything else (notably `javascript:` and bare `data:`) is refused.
+//
+// The dash in `[^a-z+.\-:]` MUST stay escaped. Unescaped, `.-:` is a character
+// RANGE (0x2E–0x3A) that swallows the digits and `/`, and since DOMPurify tests
+// EVERY attribute value against this regex — not just URI-ish ones — the result
+// is that `d="M10 10 L90 90"` fails validation and every SVG path silently
+// loses its geometry. This regex keeps DOMPurify's own tail intact and only
+// swaps the scheme list.
+const SAFE_URI =
+  /^(?:(?:https?|mailto|tel|file):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i;
+
+// Applies to every profile. DOMPurify already drops `on*` handlers and unknown
+// schemes; these are the extras that matter for the markup we do allow.
+//   - `srcdoc` would let an allowed <iframe> run script in OUR origin.
+//   - `style` is refused on prose because nothing the pipeline emits needs it,
+//     and it is the standard vector for overlay/clickjacking tricks. The SVG
+//     profile re-enables it, because mermaid genuinely cannot render without it.
+const BASE_FORBID_ATTR = ["srcdoc", "formaction", "ping", "style"];
+const BASE_FORBID_TAGS = ["script", "style", "form", "object", "embed", "base", "link", "meta"];
+
+/**
+ * Prose: markdown pipeline output, agent messages, registry READMEs.
+ *
+ * `<iframe>` is allowed because the embed healer (`upgradeProviderVideos`)
+ * turns video URLs into real iframe embeds, and `detectEmbed` deliberately
+ * falls back to "any http(s) URL is embeddable". A cross-origin iframe cannot
+ * script its parent, so this is not an XSS hole — but it does mean a note can
+ * frame an arbitrary site, which is a product decision that predates this
+ * change. `srcdoc` is forbidden above, which is the part that WOULD be XSS.
+ *
+ * `data:` URIs are permitted on <img> only (ADD_DATA_URI_TAGS): an SVG loaded
+ * through <img> cannot execute script, and base64 images are a legitimate
+ * thing to paste into a note.
+ */
+const RICH: Config = {
+  ADD_TAGS: ["iframe", "video"],
+  ADD_ATTR: [
+    "allowfullscreen",
+    "frameborder",
+    "loading",
+    "target",
+    "controls",
+    "poster",
+  ],
+  ADD_DATA_URI_TAGS: ["img"],
+  FORBID_TAGS: BASE_FORBID_TAGS,
+  FORBID_ATTR: BASE_FORBID_ATTR,
+  ALLOWED_URI_REGEXP: SAFE_URI,
+};
+
+/**
+ * SVG: mermaid diagrams and a notebook's `image/svg+xml` outputs.
+ *
+ * Both mermaid call sites run with `securityLevel: "loose"`, which means
+ * mermaid does NOT sanitize its own output and permits HTML labels — so a
+ * diagram authored by an agent is itself an injection vector, and this profile
+ * is the only thing standing between that and the DOM. A notebook's SVG output
+ * is straight from a file the user opened, i.e. fully untrusted.
+ *
+ * `html: true` is required alongside the SVG profiles because mermaid emits
+ * HTML labels inside `<foreignObject>`. DOMPurify sanitizes across both
+ * namespaces and specifically defends the namespace-confusion tricks that make
+ * foreignObject interesting to an attacker.
+ *
+ * `foreignObject` needs BOTH an ADD_TAGS entry and an HTML_INTEGRATION_POINTS
+ * entry. DOMPurify refuses HTML children inside an SVG parent unless that
+ * parent is a declared integration point, and its default list is just
+ * `annotation-xml` — so without the second half, mermaid's labels come back as
+ * empty boxes. Opting in does NOT weaken the scrub: HTML inside foreignObject
+ * still goes through the full allowlist (verified in sanitize.test.ts — an
+ * <img onerror> and a javascript: href planted in a foreignObject both die).
+ *
+ * KNOWN RESIDUAL RISK: `<style>` is allowed, because stripping it renders every
+ * diagram as unstyled spaghetti — and DOMPurify does not sanitize CSS. A
+ * hostile diagram can therefore inject global CSS rules. That is a UI-spoofing
+ * / clickjacking surface, NOT script execution (browsers do not run
+ * `javascript:` inside CSS). Closing it properly means flipping mermaid off
+ * `securityLevel: "loose"`, which changes how labels render and is a separate
+ * change from this one.
+ */
+const SVG: Config = {
+  USE_PROFILES: { svg: true, svgFilters: true, html: true },
+  ADD_TAGS: ["style", "foreignObject"],
+  HTML_INTEGRATION_POINTS: { foreignobject: true },
+  FORBID_TAGS: ["script"],
+  FORBID_ATTR: ["srcdoc", "formaction", "ping"],
+  ALLOWED_URI_REGEXP: SAFE_URI,
+};
+
+/**
+ * Syntax-highlighted code from lowlight (source viewer, notebook code cells).
+ *
+ * lowlight emits nothing but nested `<span class="hljs-…">` around
+ * already-escaped text, so the allowlist is exactly that. Anything else in the
+ * string means something upstream went wrong, and dropping it costs nothing.
+ */
+const CODE: Config = {
+  ALLOWED_TAGS: ["span"],
+  ALLOWED_ATTR: ["class"],
+};
+
+/**
+ * SheetJS `sheet_to_html` output (.xlsx viewer).
+ *
+ * SheetJS escapes cell text, but the workbook is a file the user opened from
+ * who-knows-where and the escaping is not a security boundary we control.
+ * Table structure and hyperlinks are all this needs to render.
+ */
+const TABLE: Config = {
+  ALLOWED_TAGS: [
+    "table", "thead", "tbody", "tfoot", "tr", "td", "th",
+    "caption", "col", "colgroup", "span", "div", "br", "a", "b", "i", "u",
+  ],
+  ALLOWED_ATTR: ["id", "class", "colspan", "rowspan", "href", "title"],
+  ALLOWED_URI_REGEXP: SAFE_URI,
+};
+
+export type SanitizeProfile = "rich" | "svg" | "code" | "table";
+
+const PROFILES: Record<SanitizeProfile, Config> = {
+  rich: RICH,
+  svg: SVG,
+  code: CODE,
+  table: TABLE,
+};
+
+/**
+ * Sanitize `dirty` HTML under the named profile. Always returns a string that
+ * is safe to hand to `dangerouslySetInnerHTML`.
+ *
+ * Prefer the `<SafeHtml>` component over calling this directly — it is the
+ * thing that makes "no raw dangerouslySetInnerHTML in components" a rule you
+ * can grep for.
+ */
+export function sanitizeHtml(dirty: string, profile: SanitizeProfile): string {
+  // DOMPurify returns a TrustedHTML-ish object under some configs; the string
+  // cast is safe because RETURN_TRUSTED_TYPE is never set.
+  return DOMPurify.sanitize(dirty, PROFILES[profile]) as string;
+}


### PR DESCRIPTION
Supersedes #221. Same issue (#66), different layer.

## Why not #221

#221 sanitized **inside the unified pipeline** with `rehype-sanitize`. Two problems:

1. **It only covers markdown.** There are 12 `dangerouslySetInnerHTML` sites in `src/`, and only about four are fed by `markdownToHtml`. Mermaid SVG, LaTeX, lowlight-highlighted code, SheetJS tables, and the registry README never touch remark. A pipeline-level fix leaves all of them open.
2. **It put `rehype-raw` (a full parse5 re-parse) on the hot path** that `to-html.ts` had deliberately optimized with a frozen, reused processor.

Sanitizing at the **render boundary** covers every producer and keeps the pipeline untouched.

## What this does

- **`src/lib/security/sanitize.ts`** — DOMPurify (via `isomorphic-dompurify`, so it works in both the API routes/RSC and the client components; both call the pipeline) behind four profiles. Each is the smallest allowlist that still renders its producer's *real* output:

  | profile | producer | notes |
  |---|---|---|
  | `rich` | markdown prose, agent messages, registry READMEs | allows the embed `<iframe>`, forbids `srcdoc` |
  | `svg` | mermaid, notebook `image/svg+xml` | allows `<style>` + `foreignObject` labels |
  | `code` | lowlight | `<span class>` and nothing else |
  | `table` | SheetJS `sheet_to_html` | table structure + hyperlinks |

- **`src/components/ui/safe-html.tsx`** — `<SafeHtml html= profile= />`, the only sanctioned way to put an HTML string in the DOM. This makes the invariant *greppable*: a raw `dangerouslySetInnerHTML` in a component is now a bug you can find with one search. Sanitizing is memoized, so mermaid pan/zoom doesn't re-scrub a large SVG every frame.

- **All 11 untrusted-content sites converted.** The 12th — `layout.tsx`'s locale bootstrap — is a first-party inline `<script>` with no interpolation, deliberately left alone.

## Bonus: an injection this surfaced

`convertWikiLinks()` builds `data-page-name="${pageName}"` by hand, and `pageName` is `[^\]]+` — so `[[x" onmouseover="alert(1)]]` breaks straight out of the attribute. This has **nothing to do with raw HTML pass-through**, which is precisely the argument for sanitizing at the boundary rather than in the pipeline. Covered by a test.

## Known residual risk (documented in the source, not swept under the rug)

The `svg` profile must allow `<style>` — strip it and every mermaid diagram renders unstyled — and **DOMPurify does not sanitize CSS**. A hostile diagram can therefore still inject global CSS rules. That is a **UI-spoofing / clickjacking** surface, **not script execution** (browsers don't run `javascript:` inside CSS).

Both mermaid call sites run with `securityLevel: "loose"`, meaning mermaid does not sanitize its own output. Closing this properly means moving off `loose`, which changes how labels render — a separate change, deliberately not bundled here.

## Verification

- `npm test` — **391/391 pass**, including 11 new tests in `sanitize.test.ts` that pin *both* halves: attacks die (`onerror`, `javascript:`, `<script>`, `srcdoc`, handlers inside `foreignObject`) **and** legitimate markup survives (wiki-links, LaTeX embeds, GFM task lists, provider iframe embeds, `file://` links, mermaid `<style>`/`foreignObject`/path geometry).
- `npm run lint` — 0 errors.
- `npx tsc --noEmit` — clean.
- `npm run build` — compiled successfully, 90/90 static pages.
- Drove the real SSR path end-to-end (hostile markdown → `markdownToHtml` → `<SafeHtml>` → `renderToStaticMarkup`): all four payloads neutralized, all four legitimate constructs preserved.

## Reviewer notes

The `SAFE_URI` regex keeps DOMPurify's own tail and only swaps the scheme list (adding `file:`, which `encodeFileUrls` exists to support). The escaped dash in `[^a-z+.\-:]` is load-bearing: unescaped, `.-:` is a character *range* that swallows digits, and since DOMPurify tests **every** attribute value against this regex, `d="M10 10 L90 90"` fails it and every SVG path silently loses its geometry. There's a test for that too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)