### PR TITLE
fix(integrations): show catalog-wired connectors as beta

### DIFF
--- a/src/app/api/agents/config/mcp-catalog/route.ts
+++ b/src/app/api/agents/config/mcp-catalog/route.ts
@@ -40,6 +40,19 @@ export async function GET(): Promise<NextResponse> {
     : MCP_CATALOG;
 
   const approved = catalog.map((entry) => {
+    const authBackend = resolveAuthBackend(entry, mode);
+    const credentials = credentialStatus(entry.credentials.map((c) => c.envKey));
+    const connectedProviderIds = connectedProvidersForEntry(entry);
+    const missingRequiredCredential = entry.credentials.some(
+      (credential) => credential.required && !credentials[credential.envKey]?.hasValue,
+    );
+    const connectionStatus =
+      connectedProviderIds.length === 0
+        ? "not-connected"
+        : (authBackend === "token" || authBackend === "user-app") &&
+            missingRequiredCredential
+          ? "needs-attention"
+          : "connected";
     const supportedProviderIds = MCP_PROVIDERS.filter(
       (p) => p.mcpConfig?.transports.includes(entry.transport),
     ).map((p) => p.id);
@@ -57,10 +70,11 @@ export async function GET(): Promise<NextResponse> {
       transport: entry.transport,
       verifiedTier: verifyTier(entry.trustTier, entry.registryId, presence),
       vendorName: entry.vendorName,
-      authBackend: resolveAuthBackend(entry, mode),
+      authBackend,
       supportedProviderIds,
-      connectedProviderIds: connectedProvidersForEntry(entry),
-      credentialStatus: credentialStatus(entry.credentials.map((c) => c.envKey)),
+      connectedProviderIds,
+      connectionStatus,
+      credentialStatus: credentials,
       // How (if at all) the connect panel can sign in at connect time:
       // "http" → driven through Claude Code; "stdio" → daemon runs the server's
       // own browser-OAuth loopback (connectAuth); null → deferred/none.

--- a/src/components/integrations/hub/integration-detail-page.tsx
+++ b/src/components/integrations/hub/integration-detail-page.tsx
@@ -104,9 +104,15 @@ export function IntegrationDetailPage({
                   {item.name}
                 </h1>
                 {item.implemented ? (
-                  <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2.5 py-0.5 text-[11px] font-medium text-emerald-600 dark:text-emerald-400">
-                    <Check className="h-3 w-3" /> Available now
-                  </span>
+                  item.availability === "beta" ? (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-sky-500/10 px-2.5 py-0.5 text-[11px] font-medium text-sky-700 dark:text-sky-400">
+                      <Sparkles className="h-3 w-3" /> Beta
+                    </span>
+                  ) : (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2.5 py-0.5 text-[11px] font-medium text-emerald-600 dark:text-emerald-400">
+                      <Check className="h-3 w-3" /> Available now
+                    </span>
+                  )
                 ) : (
                   <span className="inline-flex items-center rounded-full bg-foreground/[0.04] px-2.5 py-0.5 text-[11px] font-medium text-muted-foreground/80">
                     Coming soon
@@ -120,6 +126,13 @@ export function IntegrationDetailPage({
               <p className="mt-2 text-[12px] font-medium uppercase tracking-wide text-muted-foreground/70">
                 {category}
               </p>
+              {item.availability === "beta" && (
+                <p className="mt-3 max-w-xl rounded-xl bg-sky-500/10 px-3 py-2 text-[12px] leading-relaxed text-sky-800 dark:text-sky-200">
+                  This connector is wired in Cabinet&apos;s MCP catalog. You can
+                  connect it now, but the team has not fully verified the setup
+                  flow yet.
+                </p>
+              )}
             </div>
           </div>
         </div>

--- a/src/components/integrations/hub/integration-detail-page.tsx
+++ b/src/components/integrations/hub/integration-detail-page.tsx
@@ -1,7 +1,16 @@
 "use client";
 
 import { useState, type ReactNode } from "react";
-import { ArrowLeft, Check, Lock, Asterisk, ShieldCheck, Bell, ChevronDown } from "lucide-react";
+import {
+  ArrowLeft,
+  Bell,
+  Check,
+  ChevronDown,
+  Lock,
+  ShieldCheck,
+  Sparkles,
+  Asterisk,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { showSuccess } from "@/lib/ui/toast";

--- a/src/components/integrations/hub/integrations-hub-page.tsx
+++ b/src/components/integrations/hub/integrations-hub-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
@@ -52,40 +52,57 @@ export function IntegrationsHubPage() {
   // Which connectors (and suites) are actually connected — drives the only badge
   // we show. Re-checked when returning from a detail (a connect may have landed).
   const [connectedIds, setConnectedIds] = useState<Set<string>>(new Set());
+  const [connectionStatusById, setConnectionStatusById] = useState<
+    Map<string, "connected" | "needs-attention" | "not-connected">
+  >(new Map());
   // Whether the connected Microsoft 365 account is work/school (has its own
   // Entra app credentials, i.e. `--org-mode`) rather than personal. Teams and
   // SharePoint have no data on a personal Microsoft account, so their
   // "Connected" badge must reflect this instead of just riding on
   // microsoft-365's connected state.
   const [msWorkAccountConnected, setMsWorkAccountConnected] = useState(false);
+  const refreshConnectionState = useCallback(async () => {
+    const res = await fetch("/api/agents/config/mcp-catalog", { cache: "no-store" });
+    if (!res.ok) return;
+    const data = await res.json();
+    if (!data?.approved) return;
+    const approved = data.approved as {
+      id: string;
+      connectedProviderIds?: string[];
+      connectionStatus?: "connected" | "needs-attention" | "not-connected";
+      credentialStatus?: Record<string, { hasValue: boolean }>;
+    }[];
+    setConnectionStatusById(
+      new Map(
+        approved.map((a) => [
+          a.id,
+          a.connectionStatus ?? "not-connected",
+        ]),
+      ),
+    );
+    setConnectedIds(
+      new Set(
+        approved
+          .filter((a) => (a.connectedProviderIds?.length ?? 0) > 0)
+          .map((a) => a.id),
+      ),
+    );
+    const m365 = approved.find((a) => a.id === "microsoft-365");
+    setMsWorkAccountConnected(
+      !!m365?.credentialStatus?.MS365_MCP_CLIENT_ID?.hasValue,
+    );
+  }, []);
+
   useEffect(() => {
-    let alive = true;
-    fetch("/api/agents/config/mcp-catalog", { cache: "no-store" })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((data) => {
-        if (!alive || !data?.approved) return;
-        const approved = data.approved as {
-          id: string;
-          connectedProviderIds?: string[];
-          credentialStatus?: Record<string, { hasValue: boolean }>;
-        }[];
-        setConnectedIds(
-          new Set(
-            approved
-              .filter((a) => (a.connectedProviderIds?.length ?? 0) > 0)
-              .map((a) => a.id),
-          ),
-        );
-        const m365 = approved.find((a) => a.id === "microsoft-365");
-        setMsWorkAccountConnected(
-          !!m365?.credentialStatus?.MS365_MCP_CLIENT_ID?.hasValue,
-        );
-      })
-      .catch(() => {});
-    return () => {
-      alive = false;
+    refreshConnectionState().catch(() => {});
+    const onFocus = () => {
+      refreshConnectionState().catch(() => {});
     };
-  }, [selectedId]);
+    window.addEventListener("focus", onFocus);
+    return () => {
+      window.removeEventListener("focus", onFocus);
+    };
+  }, [refreshConnectionState, selectedId]);
 
   const isMac =
     typeof navigator !== "undefined" &&
@@ -176,6 +193,7 @@ export function IntegrationsHubPage() {
           <LayoutGallery
             items={filtered}
             connectedIds={connectedIds}
+            connectionStatusById={connectionStatusById}
             msWorkAccountConnected={msWorkAccountConnected}
             onOpen={(id) => {
               // Google Drive (Drive-for-Desktop) and Gmail (IMAP) each have

--- a/src/components/integrations/hub/layouts/layout-gallery.tsx
+++ b/src/components/integrations/hub/layouts/layout-gallery.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { Check, Loader2, Asterisk } from "lucide-react";
+import { AlertTriangle, Check, Loader2, Asterisk } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { showError, showSuccess } from "@/lib/ui/toast";
@@ -54,19 +54,21 @@ function persistRequested(ids: Set<string>): void {
  * Evokes a marketing "Connect to everything" section — large logo tiles laid
  * out in airy, flex-wrapped rows under generous category headers. Each tile
  * lifts on hover and casts a soft glow in the integration's own brand colour
- * (an eased shadow fade, not a hard border). Coming-soon items are dimmed via
- * DimWhenComingSoon, disabled (not clickable), and carry a "Soon" badge.
+ * (an eased shadow fade, not a hard border). Planned items are dimmed and use
+ * the request flow; catalog-wired beta items remain clickable.
  */
 export function LayoutGallery({
   items,
   onOpen,
   connectedIds,
+  connectionStatusById,
   msWorkAccountConnected,
 }: {
   items: IntegrationItem[];
   onOpen: (id: string) => void;
   /** Ids (incl. suite ids) that are currently connected. */
   connectedIds: Set<string>;
+  connectionStatusById: Map<string, "connected" | "needs-attention" | "not-connected">;
   /** Whether the connected Microsoft 365 account is work/school, not personal. */
   msWorkAccountConnected: boolean;
 }) {
@@ -139,6 +141,7 @@ export function LayoutGallery({
                         revealIndex={revealIndex++}
                         onOpen={onOpen}
                         connectedIds={connectedIds}
+                        connectionStatusById={connectionStatusById}
                         msWorkAccountConnected={msWorkAccountConnected}
                         requested={requestedIds.has(item.id)}
                         requesting={requestingId === item.id}
@@ -193,6 +196,7 @@ function GalleryTile({
   revealIndex,
   onOpen,
   connectedIds,
+  connectionStatusById,
   msWorkAccountConnected,
   requested,
   requesting,
@@ -203,6 +207,7 @@ function GalleryTile({
   revealIndex: number;
   onOpen: (id: string) => void;
   connectedIds: Set<string>;
+  connectionStatusById: Map<string, "connected" | "needs-attention" | "not-connected">;
   /** Whether the connected Microsoft 365 account is work/school, not personal. */
   msWorkAccountConnected: boolean;
   /** This coming-soon connector has already been requested from the team. */
@@ -215,6 +220,10 @@ function GalleryTile({
   const suiteConnected =
     connectedIds.has(item.id) ||
     (!!item.coveredBy && connectedIds.has(item.coveredBy));
+  const connectionStatus =
+    connectionStatusById.get(item.id) ??
+    (!!item.coveredBy ? connectionStatusById.get(item.coveredBy) : undefined) ??
+    "not-connected";
   // Teams / SharePoint ride on the microsoft-365 suite connection, but a
   // personal Microsoft account can't actually reach either — only badge them
   // "Connected" once the work/school credentials are in place.
@@ -241,7 +250,8 @@ function GalleryTile({
     animRef.current = null;
   };
 
-  const soon = !item.implemented;
+  const soon = item.availability === "planned";
+  const beta = item.availability === "beta";
   // A soon tile is still actionable: clicking it asks the team to prioritize
   // the connector. Once requested (or while sending) it goes inert.
   const soonActionable = soon && !requested && !requesting;
@@ -278,7 +288,7 @@ function GalleryTile({
         soonActionable || !soon ? "cursor-pointer" : "cursor-default",
       )}
     >
-      {/* Visual stack — coming-soon tiles are dimmed and inert. */}
+      {/* Visual stack — planned tiles are dimmed and use the request flow. */}
       <DimWhenComingSoon
         implemented={item.implemented}
         className="flex w-full flex-col items-center gap-2.5"
@@ -306,10 +316,7 @@ function GalleryTile({
         </span>
       </DimWhenComingSoon>
 
-      {/* Coming-soon always reads "Soon" — even with a live connection from an
-          earlier build — so gated tiles never advertise a state you can't open.
-          "Connected" is reserved for launched integrations. Once the user pings
-          the team, the badge flips to "Requested". */}
+      {/* Planned cards stay request-only. Beta cards open the connect panel. */}
       {soon ? (
         requesting ? (
           <span className="inline-flex items-center gap-1 rounded-full bg-foreground/[0.04] px-2 py-0.5 text-[10px] font-medium text-muted-foreground/80">
@@ -322,9 +329,17 @@ function GalleryTile({
         ) : (
           <StatusBadge implemented={false} />
         )
+      ) : connected && connectionStatus === "needs-attention" ? (
+        <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium text-amber-700 dark:text-amber-400">
+          <AlertTriangle className="h-2.5 w-2.5" /> Needs attention
+        </span>
       ) : connected ? (
         <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400">
           <Check className="h-2.5 w-2.5" /> Connected
+        </span>
+      ) : beta ? (
+        <span className="inline-flex items-center rounded-full bg-sky-500/10 px-2 py-0.5 text-[10px] font-medium text-sky-700 dark:text-sky-400">
+          Beta
         </span>
       ) : null}
     </button>

--- a/src/lib/integrations/preview-catalog.ts
+++ b/src/lib/integrations/preview-catalog.ts
@@ -28,6 +28,8 @@ export type IntegrationCategory =
   | "hr"
   | "automation";
 
+export type IntegrationAvailability = "stable" | "beta" | "planned";
+
 export interface IntegrationItem {
   /** Stable slug; also the i18n/analytics key. */
   id: string;
@@ -43,6 +45,8 @@ export interface IntegrationItem {
   brand: string;
   /** false → rendered dimmed as "coming soon". */
   implemented: boolean;
+  /** stable = launched, beta = catalog-wired, planned = no connector wiring yet. */
+  availability?: IntegrationAvailability;
   /**
    * Cabinet-native integration: configured by an in-app UI (the detail page
    * renders a custom panel), NOT an MCP/OAuth connector. Always treated as
@@ -749,10 +753,8 @@ const COVERED_BY: Record<string, string> = {
   confluence: "jira", // the Atlassian server covers Jira + Confluence
 };
 
-// Launch gate: only these connectors are live right now. Everything else is
-// shown grayed-out + unclickable with a "Soon" badge, even if it already has
-// an MCP catalog entry. Widen this set (or drop it back to the CONNECTABLE
-// derivation below) as connectors are ready to ship.
+// Launch gate: these connectors have been fully verified in the hub. Other
+// catalog-wired connectors are still connectable, but shown as beta.
 const LAUNCHED = new Set([
   "telegram",
   "discord",
@@ -776,12 +778,17 @@ export const PREVIEW_INTEGRATIONS: IntegrationItem[] = RAW_INTEGRATIONS.map((i) 
   const coveredBy = COVERED_BY[i.id];
   const connectable =
     CONNECTABLE.has(i.id) || (!!coveredBy && CONNECTABLE.has(coveredBy));
+  const launched = i.native || LAUNCHED.has(i.id) || (!!coveredBy && LAUNCHED.has(coveredBy));
+  const availability: IntegrationAvailability = launched
+    ? "stable"
+    : connectable
+      ? "beta"
+      : "planned";
   return {
     ...i,
     coveredBy,
-    // Native integrations are always available (in-app UI). MCP/OAuth connectors
-    // are gated by the launch list until their connect flow is ready.
-    implemented: i.native ? true : connectable && LAUNCHED.has(i.id),
+    availability,
+    implemented: i.native ? true : connectable,
   };
 });
 


### PR DESCRIPTION
## Summary
- show MCP catalog-wired integrations as connectable beta entries instead of Coming soon
- keep integrations with no catalog wiring in the request-only flow
- expose connectionStatus from the catalog API and refresh hub connection state on focus

## Testing
- npm run lint
- npx tsc --noEmit
- npm run build

Refs #198