### PR TITLE
fix: sidebar can get stuck collapsed after restart

### DIFF
--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -799,19 +799,29 @@ export function AppShell() {
   const effectiveUpdateDialogOpen =
     updateDialogOpen || hasPersistentUpdateState || shouldPromptForUpdate;
 
-  // Auto-collapse sidebar + AI panel when entering app mode
+  // Auto-collapse sidebar + AI panel when entering app mode, and restore
+  // whatever they were before on the way out — whether that's via the
+  // explicit exit-fullscreen button or by just navigating to a non-app node.
+  // Previously only the button restored state, so leaving any other way left
+  // the sidebar collapsed (and persisted collapsed) indefinitely.
   const prevIsApp = useRef(false);
+  const preAppSidebarCollapsed = useRef(sidebarCollapsed);
+  const preAppAiPanelCollapsed = useRef(false);
   useEffect(() => {
     if (isApp && !prevIsApp.current) {
+      preAppSidebarCollapsed.current = useAppStore.getState().sidebarCollapsed;
       setSidebarCollapsed(true);
       setAiPanelCollapsed(true);
+    } else if (!isApp && prevIsApp.current) {
+      setSidebarCollapsed(preAppSidebarCollapsed.current);
+      setAiPanelCollapsed(preAppAiPanelCollapsed.current);
     }
     prevIsApp.current = !!isApp;
   }, [isApp, setSidebarCollapsed, setAiPanelCollapsed]);
 
   const handleExitApp = () => {
-    setSidebarCollapsed(false);
-    setAiPanelCollapsed(false);
+    setSidebarCollapsed(preAppSidebarCollapsed.current);
+    setAiPanelCollapsed(preAppAiPanelCollapsed.current);
   };
 
   // Determine what to render in the main area

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -128,8 +128,20 @@ export function Sidebar() {
     };
   }, []);
 
+  // Mobile forces the sidebar into a closed drawer. Restore whatever the
+  // user had before crossing the breakpoint instead of leaving `true`
+  // persisted forever (e.g. a briefly-narrowed desktop window shouldn't
+  // permanently collapse the sidebar).
+  const wasMobile = useRef(isMobile);
+  const preMobileCollapsed = useRef(collapsed);
   useEffect(() => {
-    if (isMobile) setCollapsed(true);
+    if (isMobile && !wasMobile.current) {
+      preMobileCollapsed.current = useAppStore.getState().sidebarCollapsed;
+      setCollapsed(true);
+    } else if (!isMobile && wasMobile.current) {
+      setCollapsed(preMobileCollapsed.current);
+    }
+    wasMobile.current = isMobile;
   }, [isMobile, setCollapsed]);
 
   function startResize(event: ReactPointerEvent<HTMLDivElement>) {


### PR DESCRIPTION
## Summary
- Auto-collapse on narrow/mobile width and on opening an "app"-type file wrote `collapsed: true` straight to the persisted sidebar flag with no restore path.
- Navigating away any way other than the one explicit exit-fullscreen button left the sidebar (and AI panel) collapsed indefinitely, surviving app restarts since the flag is persisted to localStorage.
- Both auto-collapse sites now snapshot the prior state and restore it once the condition clears.

Reported on Discord.

## Test plan
- [ ] Resize the Electron window below 768px wide, then back above it — sidebar should return to its prior expanded/collapsed state, not stay collapsed.
- [ ] Open an "app"-type file (collapses sidebar + AI panel), then navigate to a different sidebar item without clicking exit-fullscreen — sidebar/AI panel should restore instead of staying collapsed.
- [ ] Open an "app"-type file, click the exit-fullscreen button — same restore behavior as before.
- [ ] Manually collapsing the sidebar via its own toggle and restarting the app should still keep it collapsed (that persistence is intentional).