### PR TITLE
docs: add root CLAUDE.md orienting agents to the three-process split

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,26 @@
+# CLAUDE.md
+
+Cabinet is a self-hosted, AI-first knowledge base and "startup OS". Knowledge-base content lives as
+markdown files on disk; AI agents (backed by local CLI providers) read and
+write those files on schedules or on demand. Humans define intent, agents do the work
+
+`docs/CLAUDE.md` holds a longer, feature-by-feature ruleset (skills, knowledge sources, registry,
+editor). Read it when you touch those subsystems. This file covers the parts you need for almost any
+task.
+
+Three processes and a data directory. Understanding the split is most of the battle.
+
+**1. Next.js app
+**2. Daemon
+**3. Electron shell 
+
+## PROGRESS.md
+
+After every change to this project, append an entry to `PROGRESS.md`:
+
+```
+[YYYY-MM-DD] Brief description of what changed.
+```
+
+This is mandatory and is the project's running changelog. Existing entries are detailed (what changed,
+why, what was verified) — match that.


### PR DESCRIPTION
## Why

The repo ships `docs/CLAUDE.md` — the long, feature-by-feature ruleset — but no
**root** `CLAUDE.md`, which is the file an agent loads first for almost any task.
Without it, every session starts by reverse-engineering the process layout.

## What

A short root `CLAUDE.md` covering only what you need before touching any
subsystem:

- what Cabinet is (self-hosted, AI-first KB / "startup OS")
- the three-process + data-dir split (Next.js app · daemon · Electron shell)
- a pointer to `docs/CLAUDE.md` for the deeper per-feature rules
- the mandatory `PROGRESS.md` changelog convention

Kept deliberately small; the detailed rules stay in `docs/CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)