### PR TITLE
Add Cursus passkey control plane

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,14 @@ KB_PASSWORD=
 # Optional: domain for the app
 DOMAIN=localhost
 
+# Cursus control plane (required only when serving Cursus from this Cabinet
+# instance). Store the service bearer and receipt-signing secret in the
+# deployment secret manager; RP ID and allowed origins are public configuration.
+# CABINET_CURSUS_SERVICE_BEARER_SECRET=
+# CURSUS_WEBAUTHN_RP_ID=cursuspublicus.trade
+# CURSUS_WEBAUTHN_ALLOWED_ORIGINS=https://cursuspublicus.trade,https://cursuspublicus.us
+# CURSUS_APPROVAL_RECEIPT_SECRET=
+
 # Optional: override the shared data directory.
 # Defaults to ./data for source installs, or a managed app-data path in Electron.
 # CABINET_DATA_DIR=

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@emoji-mart/data": "^1.2.1",
+        "@simplewebauthn/server": "^13.3.2",
         "@tailwindcss/typography": "^0.5.19",
         "@tiptap/extension-bubble-menu": "^3.27.1",
         "@tiptap/extension-code-block-lowlight": "^3.27.1",
@@ -3084,6 +3085,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@hexagon/base64": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
+      "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
+      "license": "MIT"
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
@@ -4822,6 +4829,12 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "license": "MIT"
     },
+    "node_modules/@levischuck/tiny-cbor": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
+      "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
+      "license": "MIT"
+    },
     "node_modules/@listr2/prompt-adapter-inquirer": {
       "version": "2.0.22",
       "resolved": "https://registry.npmjs.org/@listr2/prompt-adapter-inquirer/-/prompt-adapter-inquirer-2.0.22.tgz",
@@ -5610,6 +5623,174 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "license": "MIT"
     },
+    "node_modules/@peculiar/asn1-android": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.8.0.tgz",
+      "integrity": "sha512-skLbS+IOGv1lUgDqtChr8xvtvEr3HMse/JGBaL2r1J1o/n7a8wqOrovMtlRq/UXLhxvmLaONP67hwtshgzwfzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
+      "integrity": "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-x509-attr": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.8.0.tgz",
+      "integrity": "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
+      "integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.8.0.tgz",
+      "integrity": "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.8.0",
+        "@peculiar/asn1-pkcs8": "^2.8.0",
+        "@peculiar/asn1-rsa": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.8.0.tgz",
+      "integrity": "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.8.0.tgz",
+      "integrity": "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.8.0",
+        "@peculiar/asn1-pfx": "^2.8.0",
+        "@peculiar/asn1-pkcs8": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-x509-attr": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz",
+      "integrity": "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+      "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
+      "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz",
+      "integrity": "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
@@ -5683,6 +5864,25 @@
       "license": "MIT",
       "dependencies": {
         "@simple-git/args-pathspec": "^1.0.3"
+      }
+    },
+    "node_modules/@simplewebauthn/server": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-13.3.2.tgz",
+      "integrity": "sha512-KEDhfcGP1PAKRVSDjA3npTQFqS2b/srm+ipoNBNHdkzrHAlaRQUTE+a5f4ywsx6thxAw1NU2rYcLEY1949RGbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.1",
+        "@peculiar/asn1-rsa": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/x509": "^1.14.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -8745,6 +8945,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/ast-types": {
@@ -19175,6 +19389,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/qs": {
       "version": "6.15.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
@@ -19539,6 +19771,12 @@
       "engines": {
         "node": ">= 10.13.0"
       }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -21979,6 +22217,24 @@
       "optionalDependencies": {
         "fsevents": "~2.3.3"
       }
+    },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@emoji-mart/data": "^1.2.1",
+    "@simplewebauthn/server": "^13.3.2",
     "@tailwindcss/typography": "^0.5.19",
     "@tiptap/extension-bubble-menu": "^3.27.1",
     "@tiptap/extension-code-block-lowlight": "^3.27.1",

--- a/server/migrations/002_cursus_control_plane.sql
+++ b/server/migrations/002_cursus_control_plane.sql
@@ -1,0 +1,73 @@
+-- Dedicated Cursus control-plane state. Cabinet is the canonical authority.
+CREATE TABLE IF NOT EXISTS cursus_workspaces (
+  workspace_id TEXT PRIMARY KEY,
+  snapshot_json TEXT NOT NULL DEFAULT '{}',
+  revision INTEGER NOT NULL DEFAULT 0 CHECK(revision >= 0),
+  bootstrap_capability_hash TEXT NOT NULL UNIQUE,
+  bootstrap_expires_at INTEGER NOT NULL,
+  bootstrap_consumed_at INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS cursus_principals (
+  principal_id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL REFERENCES cursus_workspaces(workspace_id) ON DELETE CASCADE,
+  display_name TEXT NOT NULL,
+  is_owner INTEGER NOT NULL DEFAULT 0 CHECK(is_owner IN (0, 1)),
+  created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_cursus_principals_workspace ON cursus_principals(workspace_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_cursus_single_owner ON cursus_principals(workspace_id) WHERE is_owner = 1;
+
+CREATE TABLE IF NOT EXISTS cursus_passkey_credentials (
+  credential_id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL REFERENCES cursus_workspaces(workspace_id) ON DELETE CASCADE,
+  principal_id TEXT NOT NULL REFERENCES cursus_principals(principal_id) ON DELETE CASCADE,
+  public_key BLOB NOT NULL,
+  counter INTEGER NOT NULL CHECK(counter >= 0),
+  transports_json TEXT,
+  device_type TEXT NOT NULL,
+  backed_up INTEGER NOT NULL CHECK(backed_up IN (0, 1)),
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_cursus_credentials_workspace ON cursus_passkey_credentials(workspace_id);
+CREATE INDEX IF NOT EXISTS idx_cursus_credentials_principal ON cursus_passkey_credentials(principal_id);
+
+CREATE TABLE IF NOT EXISTS cursus_webauthn_challenges (
+  challenge_id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL REFERENCES cursus_workspaces(workspace_id) ON DELETE CASCADE,
+  principal_id TEXT,
+  display_name TEXT,
+  ceremony_type TEXT NOT NULL CHECK(ceremony_type IN ('registration', 'authentication')),
+  challenge TEXT NOT NULL UNIQUE,
+  expires_at INTEGER NOT NULL,
+  consumed_at INTEGER,
+  created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_cursus_challenges_active ON cursus_webauthn_challenges(challenge_id, expires_at, consumed_at);
+
+CREATE TABLE IF NOT EXISTS cursus_workspace_authorization_sessions (
+  token_hash TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL REFERENCES cursus_workspaces(workspace_id) ON DELETE CASCADE,
+  principal_id TEXT NOT NULL REFERENCES cursus_principals(principal_id) ON DELETE CASCADE,
+  credential_id TEXT NOT NULL REFERENCES cursus_passkey_credentials(credential_id) ON DELETE CASCADE,
+  expires_at INTEGER NOT NULL,
+  revoked_at INTEGER,
+  created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_cursus_authorizations_workspace ON cursus_workspace_authorization_sessions(workspace_id, expires_at);
+
+CREATE TABLE IF NOT EXISTS cursus_approval_receipts (
+  receipt_id TEXT PRIMARY KEY,
+  receipt_hash TEXT NOT NULL UNIQUE,
+  workspace_id TEXT NOT NULL REFERENCES cursus_workspaces(workspace_id) ON DELETE CASCADE,
+  principal_id TEXT NOT NULL REFERENCES cursus_principals(principal_id) ON DELETE CASCADE,
+  action TEXT NOT NULL,
+  payload_json TEXT,
+  expires_at INTEGER NOT NULL,
+  consumed_at INTEGER,
+  created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_cursus_receipts_workspace ON cursus_approval_receipts(workspace_id, expires_at, consumed_at);

--- a/server/migrations/003_cursus_bootstrap_claim.sql
+++ b/server/migrations/003_cursus_bootstrap_claim.sql
@@ -1,0 +1,2 @@
+-- Bind a bootstrap capability to exactly one pending owner-registration ceremony.
+ALTER TABLE cursus_workspaces ADD COLUMN bootstrap_claim_id TEXT;

--- a/server/migrations/004_cursus_verification_receipts.sql
+++ b/server/migrations/004_cursus_verification_receipts.sql
@@ -1,0 +1,14 @@
+-- Server-issued verification evidence for Cursus completion transitions.
+CREATE TABLE IF NOT EXISTS cursus_verification_receipts (
+  receipt_id TEXT PRIMARY KEY,
+  receipt_hash TEXT NOT NULL UNIQUE,
+  workspace_id TEXT NOT NULL REFERENCES cursus_workspaces(workspace_id) ON DELETE CASCADE,
+  report_json TEXT NOT NULL,
+  snapshot_revision INTEGER NOT NULL CHECK(snapshot_revision >= 0),
+  snapshot_hash TEXT NOT NULL,
+  expires_at INTEGER NOT NULL,
+  consumed_at INTEGER,
+  created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_cursus_verification_receipts_workspace
+  ON cursus_verification_receipts(workspace_id, expires_at, consumed_at);

--- a/src/app/api/control/cursus/[[...path]]/route.ts
+++ b/src/app/api/control/cursus/[[...path]]/route.ts
@@ -1,0 +1,132 @@
+import { timingSafeEqual } from "crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { CursusControlPlaneError, getCursusControlPlane } from "@/lib/cursus/control-plane";
+
+export const runtime = "nodejs";
+
+type RouteParams = { params: Promise<{ path?: string[] }> };
+type RequestBody = Record<string, unknown>;
+
+function routeError(error: unknown): NextResponse {
+  if (error instanceof CursusControlPlaneError) {
+    return NextResponse.json({ error: error.code, message: error.message, ...error.details }, { status: error.status });
+  }
+  return NextResponse.json({ error: "control_plane_failure", message: "Cursus control-plane operation failed" }, { status: 500 });
+}
+
+function bodyValue(body: RequestBody, field: string): string | undefined {
+  const value = body[field];
+  return typeof value === "string" ? value : undefined;
+}
+
+function authorizationToken(request: NextRequest): string | undefined {
+  return request.headers.get("x-cursus-workspace-authorization") ?? undefined;
+}
+
+function bootstrapCapability(request: NextRequest): string | undefined {
+  return request.headers.get("x-cursus-workspace-bootstrap") ?? undefined;
+}
+
+function serviceAuthorized(request: NextRequest): boolean {
+  const expected = process.env.CABINET_CURSUS_SERVICE_BEARER_SECRET;
+  const header = request.headers.get("authorization");
+  if (!expected || !header?.startsWith("Bearer ")) return false;
+  const supplied = Buffer.from(header.slice("Bearer ".length));
+  const secret = Buffer.from(expected);
+  return supplied.length === secret.length && timingSafeEqual(supplied, secret);
+}
+
+async function requestBody(request: NextRequest): Promise<RequestBody> {
+  const parsed: unknown = await request.json();
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new CursusControlPlaneError("invalid_request", 400, "Request body must be an object");
+  }
+  return Object.fromEntries(Object.entries(parsed));
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
+  if (!serviceAuthorized(request)) return NextResponse.json({ error: "service_unauthorized" }, { status: 401 });
+  try {
+    const path = (await params).path?.join("/");
+    const workspaceId = new URL(request.url).searchParams.get("workspaceId") ?? "";
+    const controlPlane = getCursusControlPlane();
+    if (path === "workspaces/snapshot" || path === "workspaces/run-status") {
+      return NextResponse.json(controlPlane.readSnapshot(workspaceId, authorizationToken(request) ?? ""));
+    }
+    throw new CursusControlPlaneError("route_not_found", 404, "Cursus control-plane route was not found");
+  } catch (error) {
+    return routeError(error);
+  }
+}
+
+export async function PUT(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
+  if (!serviceAuthorized(request)) return NextResponse.json({ error: "service_unauthorized" }, { status: 401 });
+  try {
+    if ((await params).path?.join("/") !== "workspaces/snapshot") {
+      throw new CursusControlPlaneError("route_not_found", 404, "Cursus control-plane route was not found");
+    }
+    const body = await requestBody(request);
+    return NextResponse.json(getCursusControlPlane().writeSnapshot({
+      workspaceId: bodyValue(body, "workspaceId") ?? "",
+      expectedRevision: body.expectedRevision,
+      snapshot: body.snapshot,
+      authorizationToken: authorizationToken(request) ?? "",
+    }));
+  } catch (error) {
+    return routeError(error);
+  }
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
+  if (!serviceAuthorized(request)) return NextResponse.json({ error: "service_unauthorized" }, { status: 401 });
+  try {
+    const path = (await params).path?.join("/");
+    const body = await requestBody(request);
+    const controlPlane = getCursusControlPlane();
+    switch (path) {
+      case "workspaces/bootstrap":
+        return NextResponse.json(controlPlane.createWorkspace());
+      case "passkeys/registration/options":
+        return NextResponse.json(await controlPlane.beginRegistration({
+          workspaceId: bodyValue(body, "workspaceId") ?? "",
+          principalId: bodyValue(body, "principalId") ?? "",
+          displayName: bodyValue(body, "displayName") ?? "",
+          authorizationToken: authorizationToken(request),
+          bootstrapCapability: bootstrapCapability(request),
+        }));
+      case "passkeys/registration/finish":
+        return NextResponse.json(await controlPlane.finishRegistration({
+          workspaceId: bodyValue(body, "workspaceId") ?? "",
+          challengeId: bodyValue(body, "challengeId") ?? "",
+          response: body.response,
+          bootstrapCapability: bootstrapCapability(request),
+        }));
+      case "passkeys/authentication/options":
+        return NextResponse.json(await controlPlane.beginAuthentication({ workspaceId: bodyValue(body, "workspaceId") ?? "" }));
+      case "passkeys/authentication/finish":
+        return NextResponse.json(await controlPlane.finishAuthentication({
+          workspaceId: bodyValue(body, "workspaceId") ?? "",
+          challengeId: bodyValue(body, "challengeId") ?? "",
+          response: body.response,
+        }));
+      case "approval-receipts":
+        return NextResponse.json(controlPlane.issueReceipt({
+          workspaceId: bodyValue(body, "workspaceId") ?? "",
+          authorizationToken: authorizationToken(request) ?? "",
+          action: bodyValue(body, "action") ?? "",
+          payload: body.payload,
+          expiresInSeconds: typeof body.expiresInSeconds === "number" ? body.expiresInSeconds : undefined,
+        }));
+      case "approval-receipts/consume":
+        return NextResponse.json(controlPlane.consumeReceipt({
+          workspaceId: bodyValue(body, "workspaceId") ?? "",
+          authorizationToken: authorizationToken(request) ?? "",
+          receipt: bodyValue(body, "receipt") ?? "",
+        }));
+      default:
+        throw new CursusControlPlaneError("route_not_found", 404, "Cursus control-plane route was not found");
+    }
+  } catch (error) {
+    return routeError(error);
+  }
+}

--- a/src/app/api/control/cursus/[[...path]]/route.ts
+++ b/src/app/api/control/cursus/[[...path]]/route.ts
@@ -50,8 +50,11 @@ export async function GET(request: NextRequest, { params }: RouteParams): Promis
     const path = (await params).path?.join("/");
     const workspaceId = new URL(request.url).searchParams.get("workspaceId") ?? "";
     const controlPlane = getCursusControlPlane();
-    if (path === "workspaces/snapshot" || path === "workspaces/run-status") {
+    if (path === "workspaces/snapshot") {
       return NextResponse.json(controlPlane.readSnapshot(workspaceId, authorizationToken(request) ?? ""));
+    }
+    if (path === "workspaces/run-status") {
+      return NextResponse.json(controlPlane.readWorkspaceRunStatus(workspaceId, authorizationToken(request) ?? ""));
     }
     throw new CursusControlPlaneError("route_not_found", 404, "Cursus control-plane route was not found");
   } catch (error) {
@@ -122,6 +125,15 @@ export async function POST(request: NextRequest, { params }: RouteParams): Promi
           workspaceId: bodyValue(body, "workspaceId") ?? "",
           authorizationToken: authorizationToken(request) ?? "",
           receipt: bodyValue(body, "receipt") ?? "",
+          expectedAction: bodyValue(body, "expectedAction") ?? "",
+        }));
+      case "verification-receipts":
+        return NextResponse.json(controlPlane.issueVerificationReceipt({
+          workspaceId: bodyValue(body, "workspaceId") ?? "",
+          authorizationToken: authorizationToken(request) ?? "",
+          report: body.report,
+          expectedRevision: body.expectedRevision,
+          snapshotHash: bodyValue(body, "snapshotHash"),
         }));
       default:
         throw new CursusControlPlaneError("route_not_found", 404, "Cursus control-plane route was not found");

--- a/src/lib/cursus/control-plane.ts
+++ b/src/lib/cursus/control-plane.ts
@@ -1,0 +1,503 @@
+import { createHash, createHmac, randomBytes, randomUUID, timingSafeEqual } from "crypto";
+import type DatabaseConstructor from "better-sqlite3";
+import {
+  generateAuthenticationOptions,
+  generateRegistrationOptions,
+  verifyAuthenticationResponse,
+  verifyRegistrationResponse,
+} from "@simplewebauthn/server";
+import type {
+  AuthenticationResponseJSON,
+  AuthenticatorTransportFuture,
+  RegistrationResponseJSON,
+  WebAuthnCredential,
+} from "@simplewebauthn/server";
+import { getDb } from "@/lib/db";
+
+type Database = DatabaseConstructor.Database;
+
+type ChallengeType = "registration" | "authentication";
+
+type CredentialRecord = {
+  credential_id: string;
+  workspace_id: string;
+  principal_id: string;
+  public_key: Buffer;
+  counter: number;
+  transports_json: string | null;
+  device_type: string;
+  backed_up: number;
+};
+
+type PrincipalRecord = {
+  principal_id: string;
+  workspace_id: string;
+  is_owner: number;
+};
+
+type ChallengeRecord = {
+  challenge_id: string;
+  workspace_id: string;
+  principal_id: string | null;
+  display_name: string | null;
+  ceremony_type: ChallengeType;
+  challenge: string;
+  expires_at: number;
+};
+
+type AuthorizationRecord = {
+  workspace_id: string;
+  principal_id: string;
+  credential_id: string;
+  expires_at: number;
+  revoked_at: number | null;
+};
+
+export type CursusControlPlaneConfig = {
+  rpID: string;
+  allowedOrigins: readonly string[];
+  receiptSigningSecret: string;
+  challengeTtlMs?: number;
+  authorizationTtlMs?: number;
+  receiptTtlMs?: number;
+};
+
+export type WorkspaceBootstrap = {
+  workspaceId: string;
+  bootstrapCapability: string;
+  expiresAt: number;
+};
+
+export type RegistrationVerification = {
+  verified: boolean;
+  registrationInfo?: {
+    credentialID: string;
+    credentialPublicKey: Uint8Array;
+    counter: number;
+    credentialDeviceType: string;
+    credentialBackedUp: boolean;
+    transports?: AuthenticatorTransportFuture[];
+  };
+};
+
+export type AuthenticationVerification = {
+  verified: boolean;
+  authenticationInfo?: { newCounter: number };
+};
+
+export type CeremonyOptions = { challenge: string; [key: string]: unknown };
+
+export type WebAuthnOperations = {
+  registrationOptions(input: {
+    rpID: string;
+    rpName: string;
+    userID: Uint8Array<ArrayBuffer>;
+    userName: string;
+    userDisplayName: string;
+    excludeCredentials: { id: string; transports?: AuthenticatorTransportFuture[] }[];
+  }): Promise<CeremonyOptions>;
+  authenticationOptions(input: {
+    rpID: string;
+    allowCredentials: { id: string; transports?: AuthenticatorTransportFuture[] }[];
+  }): Promise<CeremonyOptions>;
+  verifyRegistration(input: {
+    response: unknown;
+    expectedChallenge: string;
+    expectedOrigin: readonly string[];
+    expectedRPID: string;
+  }): Promise<RegistrationVerification>;
+  verifyAuthentication(input: {
+    response: unknown;
+    expectedChallenge: string;
+    expectedOrigin: readonly string[];
+    expectedRPID: string;
+    credential: WebAuthnCredential;
+  }): Promise<AuthenticationVerification>;
+};
+
+const productionWebAuthn: WebAuthnOperations = {
+  async registrationOptions(input) {
+    const options = await generateRegistrationOptions({
+      rpName: input.rpName,
+      rpID: input.rpID,
+      userID: input.userID,
+      userName: input.userName,
+      userDisplayName: input.userDisplayName,
+      excludeCredentials: input.excludeCredentials,
+      authenticatorSelection: { userVerification: "required" },
+    });
+    return { ...options };
+  },
+  async authenticationOptions(input) {
+    const options = await generateAuthenticationOptions({
+      rpID: input.rpID,
+      allowCredentials: input.allowCredentials,
+      userVerification: "required",
+    });
+    return { ...options };
+  },
+  async verifyRegistration(input) {
+    // SimpleWebAuthn performs the protocol-level runtime validation.
+    const response = input.response as RegistrationResponseJSON;
+    return (await verifyRegistrationResponse({
+      response,
+      expectedChallenge: input.expectedChallenge,
+      expectedOrigin: [...input.expectedOrigin],
+      expectedRPID: input.expectedRPID,
+      requireUserVerification: true,
+    })) as RegistrationVerification;
+  },
+  async verifyAuthentication(input) {
+    // SimpleWebAuthn performs the protocol-level runtime validation.
+    const response = input.response as AuthenticationResponseJSON;
+    return (await verifyAuthenticationResponse({
+      response,
+      expectedChallenge: input.expectedChallenge,
+      expectedOrigin: [...input.expectedOrigin],
+      expectedRPID: input.expectedRPID,
+      credential: input.credential,
+      requireUserVerification: true,
+    })) as AuthenticationVerification;
+  },
+};
+
+export class CursusControlPlaneError extends Error {
+  constructor(
+    public readonly code: string,
+    public readonly status: number,
+    message: string,
+    public readonly details?: Record<string, unknown>
+  ) {
+    super(message);
+  }
+}
+
+function fail(code: string, status: number, message: string, details?: Record<string, unknown>): never {
+  throw new CursusControlPlaneError(code, status, message, details);
+}
+
+function requireNonEmpty(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim() === "") fail("invalid_request", 400, `${field} is required`);
+  return value;
+}
+
+function encodeUserID(principalId: string): Uint8Array<ArrayBuffer> {
+  return Uint8Array.from(new TextEncoder().encode(principalId));
+}
+
+function tokenHash(token: string): string {
+  return createHash("sha256").update(token).digest("base64url");
+}
+
+function nowMs(): number {
+  return Date.now();
+}
+
+function parseTransports(value: string | null): AuthenticatorTransportFuture[] | undefined {
+  if (!value) return undefined;
+  const parsed: unknown = JSON.parse(value);
+  const supported: Record<AuthenticatorTransportFuture, true> = {
+    ble: true,
+    cable: true,
+    hybrid: true,
+    internal: true,
+    nfc: true,
+    "smart-card": true,
+    usb: true,
+  };
+  return Array.isArray(parsed) && parsed.every((item) => typeof item === "string" && item in supported)
+    ? parsed as AuthenticatorTransportFuture[]
+    : undefined;
+}
+
+function configFromEnvironment(): CursusControlPlaneConfig {
+  const rpID = process.env.CURSUS_WEBAUTHN_RP_ID?.trim();
+  const allowedOrigins = process.env.CURSUS_WEBAUTHN_ALLOWED_ORIGINS?.split(",").map((origin) => origin.trim()).filter(Boolean) ?? [];
+  const receiptSigningSecret = process.env.CURSUS_APPROVAL_RECEIPT_SECRET;
+  if (!rpID || allowedOrigins.length === 0 || !receiptSigningSecret) {
+    fail("control_plane_misconfigured", 503, "Cursus WebAuthn and receipt signing configuration is required");
+  }
+  return { rpID, allowedOrigins, receiptSigningSecret };
+}
+
+export class CursusControlPlane {
+  private readonly challengeTtlMs: number;
+  private readonly authorizationTtlMs: number;
+  private readonly receiptTtlMs: number;
+  private readonly bootstrapTtlMs: number;
+
+  constructor(
+    private readonly db: Database,
+    private readonly config: CursusControlPlaneConfig,
+    private readonly webauthn: WebAuthnOperations = productionWebAuthn
+  ) {
+    if (!config.rpID || config.allowedOrigins.length === 0 || !config.receiptSigningSecret) {
+      fail("control_plane_misconfigured", 503, "Cursus WebAuthn and receipt signing configuration is required");
+    }
+    this.challengeTtlMs = config.challengeTtlMs ?? 5 * 60_000;
+    this.authorizationTtlMs = config.authorizationTtlMs ?? 15 * 60_000;
+    this.receiptTtlMs = config.receiptTtlMs ?? 5 * 60_000;
+    this.bootstrapTtlMs = 10 * 60_000;
+  }
+
+  createWorkspace(): WorkspaceBootstrap {
+    const workspaceId = randomUUID();
+    const bootstrapCapability = randomBytes(32).toString("base64url");
+    const now = nowMs();
+    const expiresAt = now + this.bootstrapTtlMs;
+    this.db.prepare("INSERT INTO cursus_workspaces (workspace_id, bootstrap_capability_hash, bootstrap_expires_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?)").run(workspaceId, tokenHash(bootstrapCapability), expiresAt, now, now);
+    return { workspaceId, bootstrapCapability, expiresAt };
+  }
+
+  async beginRegistration(input: {
+    workspaceId: string;
+    principalId: string;
+    displayName: string;
+    authorizationToken?: string;
+    bootstrapCapability?: string;
+  }): Promise<{ challengeId: string; options: CeremonyOptions }> {
+    const workspaceId = requireNonEmpty(input.workspaceId, "workspaceId");
+    const principalId = requireNonEmpty(input.principalId, "principalId");
+    const displayName = requireNonEmpty(input.displayName, "displayName");
+    const now = nowMs();
+
+    const principal = this.db.transaction(() => {
+      const workspace = this.db.prepare("SELECT workspace_id FROM cursus_workspaces WHERE workspace_id = ?").get(workspaceId) as { workspace_id: string } | undefined;
+      if (!workspace) fail("workspace_not_found", 404, "Workspace must be created by the Cursus control plane");
+      const owner = this.db.prepare("SELECT principal_id FROM cursus_principals WHERE workspace_id = ? AND is_owner = 1").get(workspaceId) as { principal_id: string } | undefined;
+      if (!owner) {
+        this.mustBootstrap(workspaceId, requireNonEmpty(input.bootstrapCapability, "workspace bootstrap capability"), now);
+        const existing = this.db.prepare("SELECT workspace_id FROM cursus_principals WHERE principal_id = ?").get(principalId) as { workspace_id: string } | undefined;
+        if (existing) fail("principal_workspace_mismatch", 409, "Principal already belongs to a workspace");
+        return { principal_id: principalId, workspace_id: workspaceId, is_owner: 1 };
+      }
+      const authorizationToken = requireNonEmpty(input.authorizationToken, "workspace authorization");
+      const authorization = this.mustAuthorize(workspaceId, authorizationToken, now);
+      const authorizedOwner = this.db.prepare("SELECT is_owner FROM cursus_principals WHERE principal_id = ? AND workspace_id = ?").get(authorization.principal_id, workspaceId) as { is_owner: number } | undefined;
+      if (!authorizedOwner?.is_owner) fail("owner_authorization_required", 403, "Only a workspace owner can register a principal");
+      const existing = this.db.prepare("SELECT workspace_id FROM cursus_principals WHERE principal_id = ?").get(principalId) as { workspace_id: string } | undefined;
+      if (existing && existing.workspace_id !== workspaceId) fail("principal_workspace_mismatch", 409, "Principal belongs to another workspace");
+      if (!existing) {
+        this.db.prepare("INSERT INTO cursus_principals (principal_id, workspace_id, display_name, is_owner, created_at) VALUES (?, ?, ?, 0, ?)").run(principalId, workspaceId, displayName, now);
+      }
+      return this.db.prepare("SELECT principal_id, workspace_id, is_owner FROM cursus_principals WHERE principal_id = ? AND workspace_id = ?").get(principalId, workspaceId) as PrincipalRecord;
+    })();
+
+    const credentials = this.db.prepare("SELECT credential_id, transports_json FROM cursus_passkey_credentials WHERE principal_id = ? AND workspace_id = ?").all(principal.principal_id, workspaceId) as Pick<CredentialRecord, "credential_id" | "transports_json">[];
+    const options = await this.webauthn.registrationOptions({
+      rpID: this.config.rpID,
+      rpName: "Cursus",
+      userID: encodeUserID(principalId),
+      userName: principalId,
+      userDisplayName: displayName,
+      excludeCredentials: credentials.map((credential) => ({ id: credential.credential_id, transports: parseTransports(credential.transports_json) })),
+    });
+    const challengeId = randomUUID();
+    this.db.prepare("INSERT INTO cursus_webauthn_challenges (challenge_id, workspace_id, principal_id, display_name, ceremony_type, challenge, expires_at, created_at) VALUES (?, ?, ?, ?, 'registration', ?, ?, ?)").run(challengeId, workspaceId, principalId, displayName, options.challenge, now + this.challengeTtlMs, now);
+    return { challengeId, options };
+  }
+
+  async finishRegistration(input: { workspaceId: string; challengeId: string; response: unknown; bootstrapCapability?: string }): Promise<{ principalId: string }> {
+    const workspaceId = requireNonEmpty(input.workspaceId, "workspaceId");
+    const challenge = this.consumeChallenge(workspaceId, requireNonEmpty(input.challengeId, "challengeId"), "registration");
+    if (!challenge.principal_id) fail("invalid_challenge", 409, "Registration challenge has no principal");
+    let verification: RegistrationVerification;
+    try {
+      verification = await this.webauthn.verifyRegistration({
+        response: input.response,
+        expectedChallenge: challenge.challenge,
+        expectedOrigin: this.config.allowedOrigins,
+        expectedRPID: this.config.rpID,
+      });
+    } catch {
+      fail("registration_verification_failed", 403, "Passkey registration verification failed");
+    }
+    const info = verification.verified ? verification.registrationInfo : undefined;
+    if (!info) fail("registration_verification_failed", 403, "Passkey registration verification failed");
+    const now = nowMs();
+    try {
+      this.db.transaction(() => {
+        const principal = this.db.prepare("SELECT is_owner FROM cursus_principals WHERE principal_id = ? AND workspace_id = ?").get(challenge.principal_id, workspaceId) as { is_owner: number } | undefined;
+        if (!principal) {
+          this.consumeBootstrap(workspaceId, requireNonEmpty(input.bootstrapCapability, "workspace bootstrap capability"), now);
+          this.db.prepare("INSERT INTO cursus_principals (principal_id, workspace_id, display_name, is_owner, created_at) VALUES (?, ?, ?, 1, ?)").run(challenge.principal_id, workspaceId, challenge.display_name ?? challenge.principal_id, now);
+        }
+        this.db.prepare("INSERT INTO cursus_passkey_credentials (credential_id, workspace_id, principal_id, public_key, counter, transports_json, device_type, backed_up, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(info.credentialID, workspaceId, challenge.principal_id, Buffer.from(info.credentialPublicKey), info.counter, info.transports ? JSON.stringify(info.transports) : null, info.credentialDeviceType, info.credentialBackedUp ? 1 : 0, now, now);
+      })();
+    } catch (error) {
+      if (error instanceof CursusControlPlaneError) throw error;
+      fail("credential_exists", 409, "Passkey credential already exists");
+    }
+    return { principalId: challenge.principal_id };
+  }
+
+  async beginAuthentication(input: { workspaceId: string }): Promise<{ challengeId: string; options: CeremonyOptions }> {
+    const workspaceId = requireNonEmpty(input.workspaceId, "workspaceId");
+    const credentials = this.db.prepare("SELECT credential_id, transports_json FROM cursus_passkey_credentials WHERE workspace_id = ?").all(workspaceId) as Pick<CredentialRecord, "credential_id" | "transports_json">[];
+    if (credentials.length === 0) fail("no_passkeys", 404, "Workspace has no registered passkeys");
+    const options = await this.webauthn.authenticationOptions({
+      rpID: this.config.rpID,
+      allowCredentials: credentials.map((credential) => ({ id: credential.credential_id, transports: parseTransports(credential.transports_json) })),
+    });
+    const now = nowMs();
+    const challengeId = randomUUID();
+    this.db.prepare("INSERT INTO cursus_webauthn_challenges (challenge_id, workspace_id, ceremony_type, challenge, expires_at, created_at) VALUES (?, ?, 'authentication', ?, ?, ?)").run(challengeId, workspaceId, options.challenge, now + this.challengeTtlMs, now);
+    return { challengeId, options };
+  }
+
+  async finishAuthentication(input: { workspaceId: string; challengeId: string; response: unknown }): Promise<{ workspaceAuthorization: string; expiresAt: number; principalId: string }> {
+    const workspaceId = requireNonEmpty(input.workspaceId, "workspaceId");
+    const challenge = this.consumeChallenge(workspaceId, requireNonEmpty(input.challengeId, "challengeId"), "authentication");
+    const credentialId = this.responseCredentialId(input.response);
+    const credential = this.db.prepare("SELECT credential_id, workspace_id, principal_id, public_key, counter, transports_json, device_type, backed_up FROM cursus_passkey_credentials WHERE credential_id = ? AND workspace_id = ?").get(credentialId, workspaceId) as CredentialRecord | undefined;
+    if (!credential) fail("unknown_credential", 403, "Passkey credential is not registered for this workspace");
+    let verification: AuthenticationVerification;
+    try {
+      verification = await this.webauthn.verifyAuthentication({
+        response: input.response,
+        expectedChallenge: challenge.challenge,
+        expectedOrigin: this.config.allowedOrigins,
+        expectedRPID: this.config.rpID,
+        credential: {
+          id: credential.credential_id,
+          publicKey: Uint8Array.from(credential.public_key),
+          counter: credential.counter,
+          transports: parseTransports(credential.transports_json),
+        },
+      });
+    } catch {
+      fail("authentication_verification_failed", 403, "Passkey authentication verification failed");
+    }
+    const newCounter = verification.verified ? verification.authenticationInfo?.newCounter : undefined;
+    if (newCounter === undefined || !Number.isInteger(newCounter) || newCounter < credential.counter) {
+      fail("authentication_verification_failed", 403, "Passkey authentication verification failed");
+    }
+    const workspaceAuthorization = randomBytes(32).toString("base64url");
+    const expiresAt = nowMs() + this.authorizationTtlMs;
+    this.db.transaction(() => {
+      const update = this.db.prepare("UPDATE cursus_passkey_credentials SET counter = ?, updated_at = ? WHERE credential_id = ? AND counter = ?").run(newCounter, nowMs(), credential.credential_id, credential.counter);
+      if (update.changes !== 1) fail("credential_counter_conflict", 409, "Passkey credential changed during authentication");
+      this.db.prepare("INSERT INTO cursus_workspace_authorization_sessions (token_hash, workspace_id, principal_id, credential_id, expires_at, created_at) VALUES (?, ?, ?, ?, ?, ?)").run(tokenHash(workspaceAuthorization), workspaceId, credential.principal_id, credential.credential_id, expiresAt, nowMs());
+    })();
+    return { workspaceAuthorization, expiresAt, principalId: credential.principal_id };
+  }
+
+  readSnapshot(workspaceId: string, authorizationToken: string): { workspaceId: string; revision: number; snapshot: unknown } {
+    this.mustAuthorize(requireNonEmpty(workspaceId, "workspaceId"), requireNonEmpty(authorizationToken, "workspace authorization"), nowMs());
+    const row = this.db.prepare("SELECT revision, snapshot_json FROM cursus_workspaces WHERE workspace_id = ?").get(workspaceId) as { revision: number; snapshot_json: string } | undefined;
+    if (!row) fail("workspace_not_found", 404, "Workspace does not exist");
+    return { workspaceId, revision: row.revision, snapshot: JSON.parse(row.snapshot_json) };
+  }
+
+  writeSnapshot(input: { workspaceId: string; expectedRevision: unknown; snapshot: unknown; authorizationToken: string }): { workspaceId: string; revision: number } {
+    const workspaceId = requireNonEmpty(input.workspaceId, "workspaceId");
+    if (typeof input.expectedRevision !== "number" || !Number.isInteger(input.expectedRevision) || input.expectedRevision < 0) fail("invalid_request", 400, "expectedRevision must be a non-negative integer");
+    const expectedRevision = input.expectedRevision;
+    this.mustAuthorize(workspaceId, requireNonEmpty(input.authorizationToken, "workspace authorization"), nowMs());
+    let snapshotJson: string;
+    try {
+      snapshotJson = JSON.stringify(input.snapshot);
+    } catch {
+      fail("invalid_snapshot", 400, "snapshot must be JSON serializable");
+    }
+    if (snapshotJson === undefined) fail("invalid_snapshot", 400, "snapshot must be JSON serializable");
+    const result = this.db.prepare("UPDATE cursus_workspaces SET snapshot_json = ?, revision = revision + 1, updated_at = ? WHERE workspace_id = ? AND revision = ?").run(snapshotJson, nowMs(), workspaceId, expectedRevision);
+    if (result.changes !== 1) {
+      const row = this.db.prepare("SELECT revision FROM cursus_workspaces WHERE workspace_id = ?").get(workspaceId) as { revision: number } | undefined;
+      if (!row) fail("workspace_not_found", 404, "Workspace does not exist");
+      fail("revision_conflict", 409, "Workspace snapshot revision is stale", { revision: row.revision });
+    }
+    return { workspaceId, revision: expectedRevision + 1 };
+  }
+
+  issueReceipt(input: { workspaceId: string; authorizationToken: string; action: string; payload?: unknown; expiresInSeconds?: number }): { receipt: string; expiresAt: number } {
+    const workspaceId = requireNonEmpty(input.workspaceId, "workspaceId");
+    const authorization = this.mustAuthorize(workspaceId, requireNonEmpty(input.authorizationToken, "workspace authorization"), nowMs());
+    const action = requireNonEmpty(input.action, "action");
+    let payloadJson: string | null = null;
+    if (input.payload !== undefined) {
+      try {
+        payloadJson = JSON.stringify(input.payload);
+      } catch {
+        fail("invalid_request", 400, "payload must be JSON serializable");
+      }
+      if (payloadJson === undefined) fail("invalid_request", 400, "payload must be JSON serializable");
+    }
+    const expiresInMs = input.expiresInSeconds === undefined ? this.receiptTtlMs : input.expiresInSeconds * 1000;
+    if (!Number.isFinite(expiresInMs) || expiresInMs <= 0 || expiresInMs > this.receiptTtlMs) fail("invalid_request", 400, "expiresInSeconds is invalid");
+    const receiptId = randomUUID();
+    const receipt = `${receiptId}.${this.sign(receiptId)}`;
+    const expiresAt = nowMs() + expiresInMs;
+    this.db.prepare("INSERT INTO cursus_approval_receipts (receipt_id, receipt_hash, workspace_id, principal_id, action, payload_json, expires_at, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)").run(receiptId, tokenHash(receipt), workspaceId, authorization.principal_id, action, payloadJson, expiresAt, nowMs());
+    return { receipt, expiresAt };
+  }
+
+  consumeReceipt(input: { workspaceId: string; authorizationToken: string; receipt: string }): { workspaceId: string; principalId: string; action: string; payload: unknown } {
+    const workspaceId = requireNonEmpty(input.workspaceId, "workspaceId");
+    this.mustAuthorize(workspaceId, requireNonEmpty(input.authorizationToken, "workspace authorization"), nowMs());
+    const receipt = requireNonEmpty(input.receipt, "receipt");
+    const [receiptId, signature, ...extra] = receipt.split(".");
+    if (!receiptId || !signature || extra.length !== 0 || !this.signatureMatches(receiptId, signature)) fail("invalid_receipt", 403, "Approval receipt is invalid");
+    const now = nowMs();
+    const result = this.db.prepare("UPDATE cursus_approval_receipts SET consumed_at = ? WHERE receipt_id = ? AND receipt_hash = ? AND workspace_id = ? AND consumed_at IS NULL AND expires_at > ?").run(now, receiptId, tokenHash(receipt), workspaceId, now);
+    if (result.changes !== 1) {
+      const row = this.db.prepare("SELECT workspace_id, consumed_at, expires_at FROM cursus_approval_receipts WHERE receipt_id = ? AND receipt_hash = ?").get(receiptId, tokenHash(receipt)) as { workspace_id: string; consumed_at: number | null; expires_at: number } | undefined;
+      if (row?.workspace_id !== workspaceId) fail("workspace_authorization_denied", 403, "Approval receipt is not valid for this workspace");
+      if (row?.consumed_at) fail("receipt_already_consumed", 409, "Approval receipt was already consumed");
+      if (row && row.expires_at <= now) fail("receipt_expired", 409, "Approval receipt has expired");
+      fail("invalid_receipt", 403, "Approval receipt is invalid");
+    }
+    const row = this.db.prepare("SELECT principal_id, action, payload_json FROM cursus_approval_receipts WHERE receipt_id = ?").get(receiptId) as { principal_id: string; action: string; payload_json: string | null };
+    return { workspaceId, principalId: row.principal_id, action: row.action, payload: row.payload_json ? JSON.parse(row.payload_json) : null };
+  }
+
+  private consumeChallenge(workspaceId: string, challengeId: string, type: ChallengeType): ChallengeRecord {
+    const now = nowMs();
+    const row = this.db.prepare("SELECT challenge_id, workspace_id, principal_id, display_name, ceremony_type, challenge, expires_at FROM cursus_webauthn_challenges WHERE challenge_id = ? AND workspace_id = ? AND ceremony_type = ?").get(challengeId, workspaceId, type) as ChallengeRecord | undefined;
+    const result = this.db.prepare("UPDATE cursus_webauthn_challenges SET consumed_at = ? WHERE challenge_id = ? AND workspace_id = ? AND ceremony_type = ? AND consumed_at IS NULL AND expires_at > ?").run(now, challengeId, workspaceId, type, now);
+    if (result.changes !== 1) {
+      if (row && row.expires_at <= now) fail("challenge_expired", 409, "WebAuthn challenge has expired");
+      fail("challenge_invalid_or_used", 409, "WebAuthn challenge is invalid or already used");
+    }
+    return row!;
+  }
+  private mustBootstrap(workspaceId: string, capability: string, now: number): void {
+    const workspace = this.db.prepare("SELECT bootstrap_capability_hash, bootstrap_expires_at, bootstrap_consumed_at FROM cursus_workspaces WHERE workspace_id = ?").get(workspaceId) as { bootstrap_capability_hash: string; bootstrap_expires_at: number; bootstrap_consumed_at: number | null } | undefined;
+    if (!workspace || workspace.bootstrap_consumed_at || workspace.bootstrap_expires_at <= now || workspace.bootstrap_capability_hash !== tokenHash(capability)) {
+      fail("workspace_bootstrap_denied", 403, "Workspace bootstrap capability is invalid, expired, or already consumed");
+    }
+  }
+
+  private consumeBootstrap(workspaceId: string, capability: string, now: number): void {
+    const result = this.db.prepare("UPDATE cursus_workspaces SET bootstrap_consumed_at = ?, updated_at = ? WHERE workspace_id = ? AND bootstrap_capability_hash = ? AND bootstrap_consumed_at IS NULL AND bootstrap_expires_at > ?").run(now, now, workspaceId, tokenHash(capability), now);
+    if (result.changes !== 1) fail("workspace_bootstrap_denied", 403, "Workspace bootstrap capability is invalid, expired, or already consumed");
+  }
+
+
+  private mustAuthorize(workspaceId: string, authorizationToken: string, now: number): AuthorizationRecord {
+    const authorization = this.db.prepare("SELECT workspace_id, principal_id, credential_id, expires_at, revoked_at FROM cursus_workspace_authorization_sessions WHERE token_hash = ?").get(tokenHash(authorizationToken)) as AuthorizationRecord | undefined;
+    if (!authorization || authorization.workspace_id !== workspaceId || authorization.revoked_at || authorization.expires_at <= now) {
+      fail("workspace_authorization_denied", 403, "Workspace authorization is invalid, expired, or scoped to another workspace");
+    }
+    return authorization;
+  }
+
+  private responseCredentialId(response: unknown): string {
+    if (!response || typeof response !== "object" || !("id" in response)) fail("invalid_request", 400, "Authentication response credential id is required");
+    return requireNonEmpty((response as { id?: unknown }).id, "Authentication response credential id");
+  }
+
+  private sign(receiptId: string): string {
+    return createHmac("sha256", this.config.receiptSigningSecret).update(receiptId).digest("base64url");
+  }
+
+  private signatureMatches(receiptId: string, signature: string): boolean {
+    const expected = Buffer.from(this.sign(receiptId));
+    const provided = Buffer.from(signature);
+    return expected.length === provided.length && timingSafeEqual(expected, provided);
+  }
+}
+
+export function getCursusControlPlane(): CursusControlPlane {
+  return new CursusControlPlane(getDb(), configFromEnvironment());
+}

--- a/src/lib/cursus/control-plane.ts
+++ b/src/lib/cursus/control-plane.ts
@@ -317,10 +317,14 @@ export class CursusControlPlane {
         expectedRPID: this.config.rpID,
       });
     } catch {
+      this.releaseBootstrapClaim(workspaceId, challenge.challenge_id);
       fail("registration_verification_failed", 403, "Passkey registration verification failed");
     }
     const info = verification.verified ? verification.registrationInfo : undefined;
-    if (!info) fail("registration_verification_failed", 403, "Passkey registration verification failed");
+    if (!info) {
+      this.releaseBootstrapClaim(workspaceId, challenge.challenge_id);
+      fail("registration_verification_failed", 403, "Passkey registration verification failed");
+    }
     const now = nowMs();
     try {
       this.db.transaction(() => {
@@ -332,6 +336,7 @@ export class CursusControlPlane {
         this.db.prepare("INSERT INTO cursus_passkey_credentials (credential_id, workspace_id, principal_id, public_key, counter, transports_json, device_type, backed_up, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(info.credentialID, workspaceId, challenge.principal_id, Buffer.from(info.credentialPublicKey), info.counter, info.transports ? JSON.stringify(info.transports) : null, info.credentialDeviceType, info.credentialBackedUp ? 1 : 0, now, now);
       })();
     } catch (error) {
+      this.releaseBootstrapClaim(workspaceId, challenge.challenge_id);
       if (error instanceof CursusControlPlaneError) throw error;
       fail("credential_exists", 409, "Passkey credential already exists");
     }
@@ -463,7 +468,10 @@ export class CursusControlPlane {
     const row = this.db.prepare("SELECT challenge_id, workspace_id, principal_id, display_name, ceremony_type, challenge, expires_at FROM cursus_webauthn_challenges WHERE challenge_id = ? AND workspace_id = ? AND ceremony_type = ?").get(challengeId, workspaceId, type) as ChallengeRecord | undefined;
     const result = this.db.prepare("UPDATE cursus_webauthn_challenges SET consumed_at = ? WHERE challenge_id = ? AND workspace_id = ? AND ceremony_type = ? AND consumed_at IS NULL AND expires_at > ?").run(now, challengeId, workspaceId, type, now);
     if (result.changes !== 1) {
-      if (row && row.expires_at <= now) fail("challenge_expired", 409, "WebAuthn challenge has expired");
+      if (row && row.expires_at <= now) {
+        this.releaseBootstrapClaim(workspaceId, challengeId);
+        fail("challenge_expired", 409, "WebAuthn challenge has expired");
+      }
       fail("challenge_invalid_or_used", 409, "WebAuthn challenge is invalid or already used");
     }
     return row!;
@@ -483,6 +491,9 @@ export class CursusControlPlane {
   private consumeBootstrap(workspaceId: string, capability: string, challengeId: string, now: number): void {
     const result = this.db.prepare("UPDATE cursus_workspaces SET bootstrap_consumed_at = ?, updated_at = ? WHERE workspace_id = ? AND bootstrap_capability_hash = ? AND bootstrap_claim_id = ? AND bootstrap_consumed_at IS NULL AND bootstrap_expires_at > ?").run(now, now, workspaceId, tokenHash(capability), challengeId, now);
     if (result.changes !== 1) fail("workspace_bootstrap_denied", 403, "Workspace bootstrap capability is invalid, expired, already consumed, or not bound to this ceremony");
+  }
+  private releaseBootstrapClaim(workspaceId: string, challengeId: string): void {
+    this.db.prepare("UPDATE cursus_workspaces SET bootstrap_claim_id = NULL, updated_at = ? WHERE workspace_id = ? AND bootstrap_claim_id = ? AND bootstrap_consumed_at IS NULL").run(nowMs(), workspaceId, challengeId);
   }
 
 

--- a/src/lib/cursus/control-plane.ts
+++ b/src/lib/cursus/control-plane.ts
@@ -53,6 +53,68 @@ type AuthorizationRecord = {
   revoked_at: number | null;
 };
 
+const CANONICAL_RUN_STATES: Record<string, true> = {
+  INBOXED: true,
+  SCOPING: true,
+  NEEDS_INTERVIEW: true,
+  GATED: true,
+  RUNNING: true,
+  VERIFYING: true,
+  BLOCKED: true,
+  DONE: true,
+  ARCHIVED: true,
+};
+
+const ALLOWED_RUN_STATE_TRANSITIONS: Record<string, Record<string, true>> = {
+  INBOXED: { SCOPING: true, NEEDS_INTERVIEW: true },
+  SCOPING: { NEEDS_INTERVIEW: true, GATED: true, BLOCKED: true },
+  NEEDS_INTERVIEW: { GATED: true, BLOCKED: true },
+  GATED: { RUNNING: true, BLOCKED: true },
+  RUNNING: { RUNNING: true, VERIFYING: true, BLOCKED: true },
+  VERIFYING: { RUNNING: true, BLOCKED: true, DONE: true },
+  BLOCKED: { SCOPING: true, NEEDS_INTERVIEW: true, GATED: true },
+  DONE: { ARCHIVED: true },
+  ARCHIVED: {},
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readRunState(snapshot: unknown): string | null {
+  if (!isRecord(snapshot) || typeof snapshot.stage !== "string" || !CANONICAL_RUN_STATES[snapshot.stage]) return null;
+  return snapshot.stage;
+}
+
+function validateRunStateTransition(previousSnapshot: unknown, nextSnapshot: unknown): boolean {
+  const previousStage = isRecord(previousSnapshot) && Object.hasOwn(previousSnapshot, "stage") ? previousSnapshot.stage : undefined;
+  const nextStage = isRecord(nextSnapshot) && Object.hasOwn(nextSnapshot, "stage") ? nextSnapshot.stage : undefined;
+  if (previousStage !== undefined && (typeof previousStage !== "string" || !CANONICAL_RUN_STATES[previousStage])) {
+    fail("stored_snapshot_invalid", 500, "Workspace snapshot has an invalid run state");
+  }
+  if (nextStage !== undefined && (typeof nextStage !== "string" || !CANONICAL_RUN_STATES[nextStage])) {
+    fail("run_state_invalid", 400, "Workspace snapshot has an invalid run state");
+  }
+  if (previousStage === nextStage || (previousStage === undefined && nextStage === undefined)) return false;
+  if (previousStage === undefined) {
+    if (nextStage === "INBOXED") return false;
+    fail("run_transition_not_allowed", 409, "A new run must begin in INBOXED");
+  }
+  if (nextStage === undefined || !ALLOWED_RUN_STATE_TRANSITIONS[previousStage][nextStage]) {
+    fail("run_transition_not_allowed", 409, `Cannot move this run from ${previousStage} to ${String(nextStage)}`);
+  }
+  return previousStage === "VERIFYING" && nextStage === "DONE";
+}
+
+function readRunStatus(snapshot: unknown): { state: string | null; verification: "passed" | "pending"; sourceCount: number; artifactCount: number } {
+  const state = readRunState(snapshot);
+  const sources = isRecord(snapshot) && Array.isArray(snapshot.sources) ? snapshot.sources : [];
+  const loopRun = isRecord(snapshot) && isRecord(snapshot.loopRun) ? snapshot.loopRun : null;
+  const artifacts = loopRun && Array.isArray(loopRun.artifacts) ? loopRun.artifacts : [];
+  const verificationPassed = isRecord(snapshot) && isRecord(snapshot.verification) && snapshot.verification.pass === true;
+  return { state, verification: verificationPassed ? "passed" : "pending", sourceCount: sources.length, artifactCount: artifacts.length };
+}
+
 export type CursusControlPlaneConfig = {
   rpID: string;
   allowedOrigins: readonly string[];
@@ -388,10 +450,24 @@ export class CursusControlPlane {
     const expiresAt = nowMs() + this.authorizationTtlMs;
     this.db.transaction(() => {
       const update = this.db.prepare("UPDATE cursus_passkey_credentials SET counter = ?, updated_at = ? WHERE credential_id = ? AND counter = ?").run(newCounter, nowMs(), credential.credential_id, credential.counter);
+
       if (update.changes !== 1) fail("credential_counter_conflict", 409, "Passkey credential changed during authentication");
       this.db.prepare("INSERT INTO cursus_workspace_authorization_sessions (token_hash, workspace_id, principal_id, credential_id, expires_at, created_at) VALUES (?, ?, ?, ?, ?, ?)").run(tokenHash(workspaceAuthorization), workspaceId, credential.principal_id, credential.credential_id, expiresAt, nowMs());
     })();
     return { workspaceAuthorization, expiresAt, principalId: credential.principal_id };
+  }
+
+  readWorkspaceRunStatus(workspaceId: string, authorizationToken: string): { workspaceId: string; revision: number; run: { state: string | null; verification: "passed" | "pending"; sourceCount: number; artifactCount: number } } {
+    this.mustAuthorize(requireNonEmpty(workspaceId, "workspaceId"), requireNonEmpty(authorizationToken, "workspace authorization"), nowMs());
+    const row = this.db.prepare("SELECT revision, snapshot_json FROM cursus_workspaces WHERE workspace_id = ?").get(workspaceId) as { revision: number; snapshot_json: string } | undefined;
+    if (!row) fail("workspace_not_found", 404, "Workspace does not exist");
+    let snapshot: unknown;
+    try {
+      snapshot = JSON.parse(row.snapshot_json);
+    } catch {
+      fail("stored_snapshot_invalid", 500, "Workspace snapshot could not be read");
+    }
+    return { workspaceId, revision: row.revision, run: readRunStatus(snapshot) };
   }
 
   readSnapshot(workspaceId: string, authorizationToken: string): { workspaceId: string; revision: number; snapshot: unknown } {
@@ -413,12 +489,28 @@ export class CursusControlPlane {
       fail("invalid_snapshot", 400, "snapshot must be JSON serializable");
     }
     if (snapshotJson === undefined) fail("invalid_snapshot", 400, "snapshot must be JSON serializable");
-    const result = this.db.prepare("UPDATE cursus_workspaces SET snapshot_json = ?, revision = revision + 1, updated_at = ? WHERE workspace_id = ? AND revision = ?").run(snapshotJson, nowMs(), workspaceId, expectedRevision);
-    if (result.changes !== 1) {
-      const row = this.db.prepare("SELECT revision FROM cursus_workspaces WHERE workspace_id = ?").get(workspaceId) as { revision: number } | undefined;
-      if (!row) fail("workspace_not_found", 404, "Workspace does not exist");
-      fail("revision_conflict", 409, "Workspace snapshot revision is stale", { revision: row.revision });
-    }
+    this.db.transaction(() => {
+      const current = this.db.prepare("SELECT revision, snapshot_json FROM cursus_workspaces WHERE workspace_id = ?").get(workspaceId) as { revision: number; snapshot_json: string } | undefined;
+      if (!current) fail("workspace_not_found", 404, "Workspace does not exist");
+      if (current.revision !== expectedRevision) {
+        fail("revision_conflict", 409, "Workspace snapshot revision is stale", { revision: current.revision });
+      }
+      let previousSnapshot: unknown;
+      try {
+        previousSnapshot = JSON.parse(current.snapshot_json);
+      } catch {
+        fail("stored_snapshot_invalid", 500, "Workspace snapshot could not be read");
+      }
+      const finalizing = validateRunStateTransition(previousSnapshot, input.snapshot);
+      if (finalizing) {
+        const verificationReceipt = isRecord(input.snapshot) && typeof input.snapshot.verificationReceipt === "string"
+          ? input.snapshot.verificationReceipt
+          : "";
+        this.consumeVerificationReceipt(workspaceId, verificationReceipt, current.revision, current.snapshot_json);
+      }
+      const result = this.db.prepare("UPDATE cursus_workspaces SET snapshot_json = ?, revision = revision + 1, updated_at = ? WHERE workspace_id = ? AND revision = ?").run(snapshotJson, nowMs(), workspaceId, expectedRevision);
+      if (result.changes !== 1) fail("revision_conflict", 409, "Workspace snapshot revision is stale");
+    })();
     return { workspaceId, revision: expectedRevision + 1 };
   }
 
@@ -444,23 +536,69 @@ export class CursusControlPlane {
     return { receipt, expiresAt };
   }
 
-  consumeReceipt(input: { workspaceId: string; authorizationToken: string; receipt: string }): { workspaceId: string; principalId: string; action: string; payload: unknown } {
+  issueVerificationReceipt(input: { workspaceId: string; authorizationToken: string; report: unknown; expectedRevision: unknown; snapshotHash: unknown }): { receipt: string; expiresAt: number } {
+    const workspaceId = requireNonEmpty(input.workspaceId, "workspaceId");
+    this.mustAuthorize(workspaceId, requireNonEmpty(input.authorizationToken, "workspace authorization"), nowMs());
+    if (typeof input.expectedRevision !== "number" || !Number.isSafeInteger(input.expectedRevision) || input.expectedRevision < 0 || typeof input.snapshotHash !== "string" || !/^[A-Za-z0-9_-]{43}$/.test(input.snapshotHash)) {
+      fail("verification_receipt_request_invalid", 400, "Verification receipt request is invalid");
+    }
+    const expectedRevision = input.expectedRevision as number;
+    const snapshotHash = input.snapshotHash as string;
+    if (!isRecord(input.report) || input.report.pass !== true || !Array.isArray(input.report.criteria) || input.report.criteria.length === 0 ||
+      input.report.criteria.some((criterion) => !isRecord(criterion) || criterion.pass !== true || typeof criterion.criterion !== "string" || !criterion.criterion.trim() || typeof criterion.evidence !== "string" || !criterion.evidence.trim()) ||
+      (Array.isArray(input.report.unresolved) && input.report.unresolved.length > 0) ||
+      (Array.isArray(input.report.blockers) && input.report.blockers.length > 0)) {
+      fail("verification_report_invalid", 400, "A passing independent verification report is required");
+    }
+    const workspace = this.db.prepare("SELECT revision, snapshot_json FROM cursus_workspaces WHERE workspace_id = ?").get(workspaceId) as { revision: number; snapshot_json: string } | undefined;
+    if (!workspace) fail("workspace_not_found", 404, "Workspace does not exist");
+    if (workspace.revision !== expectedRevision || tokenHash(workspace.snapshot_json) !== snapshotHash) {
+      fail("verification_snapshot_conflict", 409, "Workspace changed before verification receipt issuance");
+    }
+    const reportJson = JSON.stringify(input.report);
+    const receiptId = randomUUID();
+    const receipt = `${receiptId}.${this.sign(receiptId)}`;
+    const expiresAt = nowMs() + this.receiptTtlMs;
+    this.db.prepare("INSERT INTO cursus_verification_receipts (receipt_id, receipt_hash, workspace_id, report_json, snapshot_revision, snapshot_hash, expires_at, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)").run(receiptId, tokenHash(receipt), workspaceId, reportJson, workspace.revision, snapshotHash, expiresAt, nowMs());
+    return { receipt, expiresAt };
+  }
+
+  consumeReceipt(input: { workspaceId: string; authorizationToken: string; receipt: string; expectedAction: string }): { workspaceId: string; principalId: string; action: string; payload: unknown } {
     const workspaceId = requireNonEmpty(input.workspaceId, "workspaceId");
     this.mustAuthorize(workspaceId, requireNonEmpty(input.authorizationToken, "workspace authorization"), nowMs());
     const receipt = requireNonEmpty(input.receipt, "receipt");
+    const expectedAction = requireNonEmpty(input.expectedAction, "expectedAction");
     const [receiptId, signature, ...extra] = receipt.split(".");
     if (!receiptId || !signature || extra.length !== 0 || !this.signatureMatches(receiptId, signature)) fail("invalid_receipt", 403, "Approval receipt is invalid");
     const now = nowMs();
-    const result = this.db.prepare("UPDATE cursus_approval_receipts SET consumed_at = ? WHERE receipt_id = ? AND receipt_hash = ? AND workspace_id = ? AND consumed_at IS NULL AND expires_at > ?").run(now, receiptId, tokenHash(receipt), workspaceId, now);
+    const result = this.db.prepare("UPDATE cursus_approval_receipts SET consumed_at = ? WHERE receipt_id = ? AND receipt_hash = ? AND workspace_id = ? AND action = ? AND consumed_at IS NULL AND expires_at > ?").run(now, receiptId, tokenHash(receipt), workspaceId, expectedAction, now);
     if (result.changes !== 1) {
-      const row = this.db.prepare("SELECT workspace_id, consumed_at, expires_at FROM cursus_approval_receipts WHERE receipt_id = ? AND receipt_hash = ?").get(receiptId, tokenHash(receipt)) as { workspace_id: string; consumed_at: number | null; expires_at: number } | undefined;
+      const row = this.db.prepare("SELECT workspace_id, action, consumed_at, expires_at FROM cursus_approval_receipts WHERE receipt_id = ? AND receipt_hash = ?").get(receiptId, tokenHash(receipt)) as { workspace_id: string; action: string; consumed_at: number | null; expires_at: number } | undefined;
       if (row?.workspace_id !== workspaceId) fail("workspace_authorization_denied", 403, "Approval receipt is not valid for this workspace");
+      if (row?.action !== expectedAction) fail("receipt_action_mismatch", 403, "Approval receipt is not valid for this action");
       if (row?.consumed_at) fail("receipt_already_consumed", 409, "Approval receipt was already consumed");
       if (row && row.expires_at <= now) fail("receipt_expired", 409, "Approval receipt has expired");
       fail("invalid_receipt", 403, "Approval receipt is invalid");
     }
     const row = this.db.prepare("SELECT principal_id, action, payload_json FROM cursus_approval_receipts WHERE receipt_id = ?").get(receiptId) as { principal_id: string; action: string; payload_json: string | null };
     return { workspaceId, principalId: row.principal_id, action: row.action, payload: row.payload_json ? JSON.parse(row.payload_json) : null };
+  }
+
+  private consumeVerificationReceipt(workspaceId: string, receipt: string, snapshotRevision: number, snapshotJson: string): void {
+    const [receiptId, signature, ...extra] = receipt.split(".");
+    if (!receiptId || !signature || extra.length !== 0 || !this.signatureMatches(receiptId, signature)) {
+      fail("verification_receipt_invalid", 403, "Verification receipt is invalid");
+    }
+    const now = nowMs();
+    const result = this.db.prepare("UPDATE cursus_verification_receipts SET consumed_at = ? WHERE receipt_id = ? AND receipt_hash = ? AND workspace_id = ? AND snapshot_revision = ? AND snapshot_hash = ? AND consumed_at IS NULL AND expires_at > ?").run(now, receiptId, tokenHash(receipt), workspaceId, snapshotRevision, tokenHash(snapshotJson), now);
+    if (result.changes !== 1) {
+      const row = this.db.prepare("SELECT workspace_id, snapshot_revision, snapshot_hash, consumed_at, expires_at FROM cursus_verification_receipts WHERE receipt_id = ? AND receipt_hash = ?").get(receiptId, tokenHash(receipt)) as { workspace_id: string; snapshot_revision: number; snapshot_hash: string; consumed_at: number | null; expires_at: number } | undefined;
+      if (row?.workspace_id !== workspaceId) fail("workspace_authorization_denied", 403, "Verification receipt is not valid for this workspace");
+      if (row && (row.snapshot_revision !== snapshotRevision || row.snapshot_hash !== tokenHash(snapshotJson))) fail("verification_snapshot_conflict", 409, "Workspace changed after verification");
+      if (row?.consumed_at) fail("verification_receipt_consumed", 409, "Verification receipt has already been consumed");
+      if (row && row.expires_at <= now) fail("verification_receipt_expired", 409, "Verification receipt has expired");
+      fail("verification_receipt_invalid", 403, "Verification receipt is invalid");
+    }
   }
 
   private consumeChallenge(workspaceId: string, challengeId: string, type: ChallengeType): ChallengeRecord {

--- a/src/lib/cursus/control-plane.ts
+++ b/src/lib/cursus/control-plane.ts
@@ -261,7 +261,7 @@ export class CursusControlPlane {
     const displayName = requireNonEmpty(input.displayName, "displayName");
     const now = nowMs();
 
-    const principal = this.db.transaction(() => {
+    const registration = this.db.transaction(() => {
       const workspace = this.db.prepare("SELECT workspace_id FROM cursus_workspaces WHERE workspace_id = ?").get(workspaceId) as { workspace_id: string } | undefined;
       if (!workspace) fail("workspace_not_found", 404, "Workspace must be created by the Cursus control plane");
       const owner = this.db.prepare("SELECT principal_id FROM cursus_principals WHERE workspace_id = ? AND is_owner = 1").get(workspaceId) as { principal_id: string } | undefined;
@@ -269,7 +269,7 @@ export class CursusControlPlane {
         this.mustBootstrap(workspaceId, requireNonEmpty(input.bootstrapCapability, "workspace bootstrap capability"), now);
         const existing = this.db.prepare("SELECT workspace_id FROM cursus_principals WHERE principal_id = ?").get(principalId) as { workspace_id: string } | undefined;
         if (existing) fail("principal_workspace_mismatch", 409, "Principal already belongs to a workspace");
-        return { principal_id: principalId, workspace_id: workspaceId, is_owner: 1 };
+        return { bootstrap: true, principalId };
       }
       const authorizationToken = requireNonEmpty(input.authorizationToken, "workspace authorization");
       const authorization = this.mustAuthorize(workspaceId, authorizationToken, now);
@@ -280,10 +280,10 @@ export class CursusControlPlane {
       if (!existing) {
         this.db.prepare("INSERT INTO cursus_principals (principal_id, workspace_id, display_name, is_owner, created_at) VALUES (?, ?, ?, 0, ?)").run(principalId, workspaceId, displayName, now);
       }
-      return this.db.prepare("SELECT principal_id, workspace_id, is_owner FROM cursus_principals WHERE principal_id = ? AND workspace_id = ?").get(principalId, workspaceId) as PrincipalRecord;
+      return { bootstrap: false, principalId };
     })();
 
-    const credentials = this.db.prepare("SELECT credential_id, transports_json FROM cursus_passkey_credentials WHERE principal_id = ? AND workspace_id = ?").all(principal.principal_id, workspaceId) as Pick<CredentialRecord, "credential_id" | "transports_json">[];
+    const credentials = this.db.prepare("SELECT credential_id, transports_json FROM cursus_passkey_credentials WHERE principal_id = ? AND workspace_id = ?").all(registration.principalId, workspaceId) as Pick<CredentialRecord, "credential_id" | "transports_json">[];
     const options = await this.webauthn.registrationOptions({
       rpID: this.config.rpID,
       rpName: "Cursus",
@@ -293,7 +293,14 @@ export class CursusControlPlane {
       excludeCredentials: credentials.map((credential) => ({ id: credential.credential_id, transports: parseTransports(credential.transports_json) })),
     });
     const challengeId = randomUUID();
-    this.db.prepare("INSERT INTO cursus_webauthn_challenges (challenge_id, workspace_id, principal_id, display_name, ceremony_type, challenge, expires_at, created_at) VALUES (?, ?, ?, ?, 'registration', ?, ?, ?)").run(challengeId, workspaceId, principalId, displayName, options.challenge, now + this.challengeTtlMs, now);
+    if (registration.bootstrap) {
+      this.db.transaction(() => {
+        this.claimBootstrap(workspaceId, requireNonEmpty(input.bootstrapCapability, "workspace bootstrap capability"), challengeId, now);
+        this.db.prepare("INSERT INTO cursus_webauthn_challenges (challenge_id, workspace_id, principal_id, display_name, ceremony_type, challenge, expires_at, created_at) VALUES (?, ?, ?, ?, 'registration', ?, ?, ?)").run(challengeId, workspaceId, principalId, displayName, options.challenge, now + this.challengeTtlMs, now);
+      })();
+    } else {
+      this.db.prepare("INSERT INTO cursus_webauthn_challenges (challenge_id, workspace_id, principal_id, display_name, ceremony_type, challenge, expires_at, created_at) VALUES (?, ?, ?, ?, 'registration', ?, ?, ?)").run(challengeId, workspaceId, principalId, displayName, options.challenge, now + this.challengeTtlMs, now);
+    }
     return { challengeId, options };
   }
 
@@ -319,7 +326,7 @@ export class CursusControlPlane {
       this.db.transaction(() => {
         const principal = this.db.prepare("SELECT is_owner FROM cursus_principals WHERE principal_id = ? AND workspace_id = ?").get(challenge.principal_id, workspaceId) as { is_owner: number } | undefined;
         if (!principal) {
-          this.consumeBootstrap(workspaceId, requireNonEmpty(input.bootstrapCapability, "workspace bootstrap capability"), now);
+          this.consumeBootstrap(workspaceId, requireNonEmpty(input.bootstrapCapability, "workspace bootstrap capability"), challenge.challenge_id, now);
           this.db.prepare("INSERT INTO cursus_principals (principal_id, workspace_id, display_name, is_owner, created_at) VALUES (?, ?, ?, 1, ?)").run(challenge.principal_id, workspaceId, challenge.display_name ?? challenge.principal_id, now);
         }
         this.db.prepare("INSERT INTO cursus_passkey_credentials (credential_id, workspace_id, principal_id, public_key, counter, transports_json, device_type, backed_up, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(info.credentialID, workspaceId, challenge.principal_id, Buffer.from(info.credentialPublicKey), info.counter, info.transports ? JSON.stringify(info.transports) : null, info.credentialDeviceType, info.credentialBackedUp ? 1 : 0, now, now);
@@ -468,9 +475,14 @@ export class CursusControlPlane {
     }
   }
 
-  private consumeBootstrap(workspaceId: string, capability: string, now: number): void {
-    const result = this.db.prepare("UPDATE cursus_workspaces SET bootstrap_consumed_at = ?, updated_at = ? WHERE workspace_id = ? AND bootstrap_capability_hash = ? AND bootstrap_consumed_at IS NULL AND bootstrap_expires_at > ?").run(now, now, workspaceId, tokenHash(capability), now);
-    if (result.changes !== 1) fail("workspace_bootstrap_denied", 403, "Workspace bootstrap capability is invalid, expired, or already consumed");
+  private claimBootstrap(workspaceId: string, capability: string, challengeId: string, now: number): void {
+    const result = this.db.prepare("UPDATE cursus_workspaces SET bootstrap_claim_id = ?, updated_at = ? WHERE workspace_id = ? AND bootstrap_capability_hash = ? AND bootstrap_claim_id IS NULL AND bootstrap_consumed_at IS NULL AND bootstrap_expires_at > ?").run(challengeId, now, workspaceId, tokenHash(capability), now);
+    if (result.changes !== 1) fail("workspace_bootstrap_denied", 403, "Workspace bootstrap capability is invalid, expired, already consumed, or already claimed");
+  }
+
+  private consumeBootstrap(workspaceId: string, capability: string, challengeId: string, now: number): void {
+    const result = this.db.prepare("UPDATE cursus_workspaces SET bootstrap_consumed_at = ?, updated_at = ? WHERE workspace_id = ? AND bootstrap_capability_hash = ? AND bootstrap_claim_id = ? AND bootstrap_consumed_at IS NULL AND bootstrap_expires_at > ?").run(now, now, workspaceId, tokenHash(capability), challengeId, now);
+    if (result.changes !== 1) fail("workspace_bootstrap_denied", 403, "Workspace bootstrap capability is invalid, expired, already consumed, or not bound to this ceremony");
   }
 
 

--- a/test/cursus-control-plane.test.ts
+++ b/test/cursus-control-plane.test.ts
@@ -185,6 +185,21 @@ test("denies passkey responses from an unconfigured origin", async () => {
   );
 });
 
+test("releases a failed bootstrap ceremony claim so the owner can retry", async () => {
+  const { controlPlane } = createControlPlane();
+  const workspace = controlPlane.createWorkspace();
+  const failed = await controlPlane.beginRegistration({ workspaceId: workspace.workspaceId, principalId: "owner", displayName: "Owner", bootstrapCapability: workspace.bootstrapCapability });
+  await assert.rejects(
+    controlPlane.finishRegistration({ workspaceId: workspace.workspaceId, challengeId: failed.challengeId, response: { origin: "https://attacker.example.test" }, bootstrapCapability: workspace.bootstrapCapability }),
+    (error) => {
+      assertControlError(error, "registration_verification_failed");
+      return true;
+    }
+  );
+  const retry = await controlPlane.beginRegistration({ workspaceId: workspace.workspaceId, principalId: "owner", displayName: "Owner", bootstrapCapability: workspace.bootstrapCapability });
+  await controlPlane.finishRegistration({ workspaceId: workspace.workspaceId, challengeId: retry.challengeId, response: { origin: ORIGIN }, bootstrapCapability: workspace.bootstrapCapability });
+});
+
 test("denies workspace-scoped authorization tokens outside their workspace", async () => {
   const { controlPlane } = createControlPlane();
   const workspace = controlPlane.createWorkspace();

--- a/test/cursus-control-plane.test.ts
+++ b/test/cursus-control-plane.test.ts
@@ -51,6 +51,7 @@ function createControlPlane(): { db: Database.Database; controlPlane: CursusCont
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
   db.exec(readFileSync("server/migrations/002_cursus_control_plane.sql", "utf8"));
+  db.exec(readFileSync("server/migrations/003_cursus_bootstrap_claim.sql", "utf8"));
   return {
     db,
     controlPlane: new CursusControlPlane(db, {
@@ -113,7 +114,7 @@ test("rejects stale workspace snapshot writes atomically", async () => {
   );
 });
 
-test("denies preclaiming arbitrary workspace IDs and allows exactly one bootstrap owner", async () => {
+test("denies preclaiming and binds bootstrap capability to one pending owner ceremony", async () => {
   const { controlPlane, db } = createControlPlane();
   await assert.rejects(
     controlPlane.beginRegistration({ workspaceId: "attacker-chosen", principalId: "attacker", displayName: "Attacker", bootstrapCapability: "not-a-capability" }),
@@ -124,15 +125,25 @@ test("denies preclaiming arbitrary workspace IDs and allows exactly one bootstra
   );
 
   const workspace = controlPlane.createWorkspace();
-  const [first, second] = await Promise.all([
+  const attempts = await Promise.allSettled([
     controlPlane.beginRegistration({ workspaceId: workspace.workspaceId, principalId: "owner-one", displayName: "Owner one", bootstrapCapability: workspace.bootstrapCapability }),
     controlPlane.beginRegistration({ workspaceId: workspace.workspaceId, principalId: "owner-two", displayName: "Owner two", bootstrapCapability: workspace.bootstrapCapability }),
   ]);
-  const completions = await Promise.allSettled([
-    controlPlane.finishRegistration({ workspaceId: workspace.workspaceId, challengeId: first.challengeId, response: { origin: ORIGIN }, bootstrapCapability: workspace.bootstrapCapability }),
-    controlPlane.finishRegistration({ workspaceId: workspace.workspaceId, challengeId: second.challengeId, response: { origin: ORIGIN }, bootstrapCapability: workspace.bootstrapCapability }),
-  ]);
-  assert.equal(completions.filter((completion) => completion.status === "fulfilled").length, 1);
+  assert.equal(attempts.filter((attempt) => attempt.status === "fulfilled").length, 1);
+  const rejected = attempts.find((attempt) => attempt.status === "rejected");
+  assert(rejected && rejected.status === "rejected");
+  assertControlError(rejected.reason, "workspace_bootstrap_denied");
+  const fulfilled = attempts.find((attempt) => attempt.status === "fulfilled");
+  assert(fulfilled && fulfilled.status === "fulfilled");
+
+  await controlPlane.finishRegistration({ workspaceId: workspace.workspaceId, challengeId: fulfilled.value.challengeId, response: { origin: ORIGIN }, bootstrapCapability: workspace.bootstrapCapability });
+  await assert.rejects(
+    controlPlane.beginRegistration({ workspaceId: workspace.workspaceId, principalId: "owner-two", displayName: "Owner two", bootstrapCapability: workspace.bootstrapCapability }),
+    (error) => {
+      assertControlError(error, "invalid_request");
+      return true;
+    }
+  );
   assert.equal((db.prepare("SELECT COUNT(*) AS count FROM cursus_principals WHERE workspace_id = ? AND is_owner = 1").get(workspace.workspaceId) as { count: number }).count, 1);
 });
 

--- a/test/cursus-control-plane.test.ts
+++ b/test/cursus-control-plane.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import Database from "better-sqlite3";
 import { readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 import {
   CursusControlPlane,
   CursusControlPlaneError,
@@ -52,6 +53,7 @@ function createControlPlane(): { db: Database.Database; controlPlane: CursusCont
   db.pragma("foreign_keys = ON");
   db.exec(readFileSync("server/migrations/002_cursus_control_plane.sql", "utf8"));
   db.exec(readFileSync("server/migrations/003_cursus_bootstrap_claim.sql", "utf8"));
+  db.exec(readFileSync("server/migrations/004_cursus_verification_receipts.sql", "utf8"));
   return {
     db,
     controlPlane: new CursusControlPlane(db, {
@@ -111,6 +113,49 @@ test("rejects stale workspace snapshot writes atomically", async () => {
       assertControlError(error, "revision_conflict");
       return true;
     }
+  );
+});
+
+test("enforces canonical run transitions and independent verification before completion", async () => {
+  const { controlPlane } = createControlPlane();
+  const workspace = controlPlane.createWorkspace();
+  await registerOwner(controlPlane, workspace);
+  const authorizationToken = await authorizeOwner(controlPlane, workspace.workspaceId);
+  const write = (expectedRevision: number, snapshot: unknown) => controlPlane.writeSnapshot({
+    workspaceId: workspace.workspaceId, authorizationToken, expectedRevision, snapshot,
+  });
+
+  write(0, { stage: "INBOXED" });
+  write(1, { stage: "SCOPING" });
+  write(2, { stage: "GATED" });
+  write(3, { stage: "RUNNING" });
+  write(4, { stage: "VERIFYING" });
+  assert.throws(
+    () => write(5, { stage: "DONE", verificationReceipt: "forged.receipt" }),
+    (error) => {
+      assertControlError(error, "verification_receipt_invalid");
+      return true;
+    },
+  );
+  const verification = controlPlane.issueVerificationReceipt({
+    workspaceId: workspace.workspaceId,
+    authorizationToken,
+    report: {
+      pass: true,
+      criteria: [{ criterion: "Contract satisfied", pass: true, evidence: "Verified against the declared gate." }],
+      unresolved: [],
+      blockers: [],
+    },
+    expectedRevision: 5,
+    snapshotHash: createHash("sha256").update(JSON.stringify({ stage: "VERIFYING" })).digest("base64url"),
+  });
+  write(5, { stage: "DONE", verificationReceipt: verification.receipt });
+  assert.throws(
+    () => write(6, { stage: "BLOCKED" }),
+    (error) => {
+      assertControlError(error, "run_transition_not_allowed");
+      return true;
+    },
   );
 });
 
@@ -214,25 +259,80 @@ test("denies workspace-scoped authorization tokens outside their workspace", asy
   );
 });
 
+test("returns authenticated run status without exposing workspace contents", async () => {
+  const { controlPlane } = createControlPlane();
+  const workspace = controlPlane.createWorkspace();
+  await registerOwner(controlPlane, workspace);
+  const authorizationToken = await authorizeOwner(controlPlane, workspace.workspaceId);
+  controlPlane.writeSnapshot({
+    workspaceId: workspace.workspaceId,
+    authorizationToken,
+    expectedRevision: 0,
+    snapshot: { stage: "INBOXED" },
+  });
+  controlPlane.writeSnapshot({
+    workspaceId: workspace.workspaceId,
+    authorizationToken,
+    expectedRevision: 1,
+    snapshot: {
+      stage: "SCOPING",
+      captureNote: "confidential work request",
+      sources: [{ content: "private source contents" }, { content: "another private source" }],
+      loopRun: { artifacts: [{ summary: "private artifact" }] },
+      verification: { pass: true, evidence: "private verification evidence" },
+    },
+  });
+
+  const status = controlPlane.readWorkspaceRunStatus(workspace.workspaceId, authorizationToken);
+  assert.deepEqual(status, {
+    workspaceId: workspace.workspaceId,
+    revision: 2,
+    run: { state: "SCOPING", verification: "passed", sourceCount: 2, artifactCount: 1 },
+  });
+  assert.equal(JSON.stringify(status).includes("private"), false);
+});
+
 test("consumes approval receipts only once", async () => {
   const { controlPlane } = createControlPlane();
   const workspace = controlPlane.createWorkspace();
   await registerOwner(controlPlane, workspace);
   const authorizationToken = await authorizeOwner(controlPlane, workspace.workspaceId);
   const issued = controlPlane.issueReceipt({ workspaceId: workspace.workspaceId, authorizationToken, action: "deploy", payload: { revision: 3 } });
-  assert.deepEqual(controlPlane.consumeReceipt({ workspaceId: workspace.workspaceId, authorizationToken, receipt: issued.receipt }), {
+  assert.deepEqual(controlPlane.consumeReceipt({ workspaceId: workspace.workspaceId, authorizationToken, receipt: issued.receipt, expectedAction: "deploy" }), {
     workspaceId: workspace.workspaceId,
     principalId: "owner",
     action: "deploy",
     payload: { revision: 3 },
   });
   assert.throws(
-    () => controlPlane.consumeReceipt({ workspaceId: workspace.workspaceId, authorizationToken, receipt: issued.receipt }),
+    () => controlPlane.consumeReceipt({ workspaceId: workspace.workspaceId, authorizationToken, receipt: issued.receipt, expectedAction: "deploy" }),
     (error) => {
       assertControlError(error, "receipt_already_consumed");
       return true;
     }
   );
+});
+
+test("binds receipt consumption to the approved action", async () => {
+  const { controlPlane } = createControlPlane();
+  const workspace = controlPlane.createWorkspace();
+  await registerOwner(controlPlane, workspace);
+  const authorizationToken = await authorizeOwner(controlPlane, workspace.workspaceId);
+  const issued = controlPlane.issueReceipt({ workspaceId: workspace.workspaceId, authorizationToken, action: "vendor_handoff_review" });
+
+  assert.throws(
+    () => controlPlane.consumeReceipt({ workspaceId: workspace.workspaceId, authorizationToken, receipt: issued.receipt, expectedAction: "stripe_checkout" }),
+    (error) => {
+      assertControlError(error, "receipt_action_mismatch");
+      return true;
+    }
+  );
+  assert.deepEqual(controlPlane.consumeReceipt({ workspaceId: workspace.workspaceId, authorizationToken, receipt: issued.receipt, expectedAction: "vendor_handoff_review" }), {
+    workspaceId: workspace.workspaceId,
+    principalId: "owner",
+    action: "vendor_handoff_review",
+    payload: null,
+  });
 });
 
 test("persists the verified passkey signature counter update", async () => {

--- a/test/cursus-control-plane.test.ts
+++ b/test/cursus-control-plane.test.ts
@@ -1,0 +1,218 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import Database from "better-sqlite3";
+import { readFileSync } from "node:fs";
+import {
+  CursusControlPlane,
+  CursusControlPlaneError,
+  type WebAuthnOperations,
+  type WorkspaceBootstrap,
+} from "@/lib/cursus/control-plane";
+const ORIGIN = "https://cursus.example.test";
+function fakeWebAuthn(): WebAuthnOperations {
+  let nextChallenge = 0;
+  return {
+    async registrationOptions() {
+      nextChallenge += 1;
+      return { challenge: `registration-${nextChallenge}`, rp: { id: "cursus.example.test" } };
+    },
+    async authenticationOptions() {
+      nextChallenge += 1;
+      return { challenge: `authentication-${nextChallenge}`, rpId: "cursus.example.test" };
+    },
+    async verifyRegistration(input) {
+      const response = input.response;
+      if (!response || typeof response !== "object" || !("origin" in response) || typeof response.origin !== "string" || !input.expectedOrigin.includes(response.origin)) {
+        throw new Error("unexpected origin");
+      }
+      return {
+        verified: true,
+        registrationInfo: {
+          credentialID: "credential-owner",
+          credentialPublicKey: Uint8Array.from([1, 2, 3]),
+          counter: 5,
+          credentialDeviceType: "singleDevice",
+          credentialBackedUp: false,
+          transports: ["internal"],
+        },
+      };
+    },
+    async verifyAuthentication(input) {
+      const response = input.response;
+      if (!response || typeof response !== "object" || !("origin" in response) || typeof response.origin !== "string" || !input.expectedOrigin.includes(response.origin)) {
+        throw new Error("unexpected origin");
+      }
+      return { verified: true, authenticationInfo: { newCounter: input.credential.counter + 7 } };
+    },
+  };
+}
+
+function createControlPlane(): { db: Database.Database; controlPlane: CursusControlPlane } {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  db.exec(readFileSync("server/migrations/002_cursus_control_plane.sql", "utf8"));
+  return {
+    db,
+    controlPlane: new CursusControlPlane(db, {
+      rpID: "cursus.example.test",
+      allowedOrigins: [ORIGIN],
+      receiptSigningSecret: "test-only-receipt-signing-secret",
+      challengeTtlMs: 1_000,
+      authorizationTtlMs: 10_000,
+      receiptTtlMs: 10_000,
+    }, fakeWebAuthn()),
+  };
+}
+
+async function registerOwner(controlPlane: CursusControlPlane, workspace: WorkspaceBootstrap): Promise<void> {
+  const ceremony = await controlPlane.beginRegistration({
+    workspaceId: workspace.workspaceId,
+    principalId: "owner",
+    displayName: "Owner",
+    bootstrapCapability: workspace.bootstrapCapability,
+  });
+  await controlPlane.finishRegistration({
+    workspaceId: workspace.workspaceId,
+    challengeId: ceremony.challengeId,
+    response: { origin: ORIGIN },
+    bootstrapCapability: workspace.bootstrapCapability,
+  });
+}
+
+async function authorizeOwner(controlPlane: CursusControlPlane, workspaceId: string): Promise<string> {
+  const ceremony = await controlPlane.beginAuthentication({ workspaceId });
+  const authenticated = await controlPlane.finishAuthentication({
+    workspaceId,
+    challengeId: ceremony.challengeId,
+    response: { id: "credential-owner", origin: ORIGIN },
+  });
+  return authenticated.workspaceAuthorization;
+}
+
+function assertControlError(error: unknown, code: string): void {
+  assert(error instanceof CursusControlPlaneError);
+  assert.equal(error.code, code);
+}
+
+test("rejects stale workspace snapshot writes atomically", async () => {
+  const { controlPlane } = createControlPlane();
+  const workspace = controlPlane.createWorkspace();
+  await registerOwner(controlPlane, workspace);
+  const authorizationToken = await authorizeOwner(controlPlane, workspace.workspaceId);
+
+  assert.deepEqual(controlPlane.writeSnapshot({ workspaceId: workspace.workspaceId, expectedRevision: 0, snapshot: { state: "first" }, authorizationToken }), {
+    workspaceId: workspace.workspaceId,
+    revision: 1,
+  });
+  assert.throws(
+    () => controlPlane.writeSnapshot({ workspaceId: workspace.workspaceId, expectedRevision: 0, snapshot: { state: "stale" }, authorizationToken }),
+    (error) => {
+      assertControlError(error, "revision_conflict");
+      return true;
+    }
+  );
+});
+
+test("denies preclaiming arbitrary workspace IDs and allows exactly one bootstrap owner", async () => {
+  const { controlPlane, db } = createControlPlane();
+  await assert.rejects(
+    controlPlane.beginRegistration({ workspaceId: "attacker-chosen", principalId: "attacker", displayName: "Attacker", bootstrapCapability: "not-a-capability" }),
+    (error) => {
+      assertControlError(error, "workspace_not_found");
+      return true;
+    }
+  );
+
+  const workspace = controlPlane.createWorkspace();
+  const [first, second] = await Promise.all([
+    controlPlane.beginRegistration({ workspaceId: workspace.workspaceId, principalId: "owner-one", displayName: "Owner one", bootstrapCapability: workspace.bootstrapCapability }),
+    controlPlane.beginRegistration({ workspaceId: workspace.workspaceId, principalId: "owner-two", displayName: "Owner two", bootstrapCapability: workspace.bootstrapCapability }),
+  ]);
+  const completions = await Promise.allSettled([
+    controlPlane.finishRegistration({ workspaceId: workspace.workspaceId, challengeId: first.challengeId, response: { origin: ORIGIN }, bootstrapCapability: workspace.bootstrapCapability }),
+    controlPlane.finishRegistration({ workspaceId: workspace.workspaceId, challengeId: second.challengeId, response: { origin: ORIGIN }, bootstrapCapability: workspace.bootstrapCapability }),
+  ]);
+  assert.equal(completions.filter((completion) => completion.status === "fulfilled").length, 1);
+  assert.equal((db.prepare("SELECT COUNT(*) AS count FROM cursus_principals WHERE workspace_id = ? AND is_owner = 1").get(workspace.workspaceId) as { count: number }).count, 1);
+});
+
+test("denies expired and reused WebAuthn challenges", async () => {
+  const { controlPlane, db } = createControlPlane();
+  const expiredWorkspace = controlPlane.createWorkspace();
+  const expired = await controlPlane.beginRegistration({ workspaceId: expiredWorkspace.workspaceId, principalId: "owner", displayName: "Owner", bootstrapCapability: expiredWorkspace.bootstrapCapability });
+  db.prepare("UPDATE cursus_webauthn_challenges SET expires_at = 0 WHERE challenge_id = ?").run(expired.challengeId);
+  await assert.rejects(
+    controlPlane.finishRegistration({ workspaceId: expiredWorkspace.workspaceId, challengeId: expired.challengeId, response: { origin: ORIGIN }, bootstrapCapability: expiredWorkspace.bootstrapCapability }),
+    (error) => {
+      assertControlError(error, "challenge_expired");
+      return true;
+    }
+  );
+
+  const freshWorkspace = controlPlane.createWorkspace();
+  const fresh = await controlPlane.beginRegistration({ workspaceId: freshWorkspace.workspaceId, principalId: "owner-b", displayName: "Owner B", bootstrapCapability: freshWorkspace.bootstrapCapability });
+  await controlPlane.finishRegistration({ workspaceId: freshWorkspace.workspaceId, challengeId: fresh.challengeId, response: { origin: ORIGIN }, bootstrapCapability: freshWorkspace.bootstrapCapability });
+  await assert.rejects(
+    controlPlane.finishRegistration({ workspaceId: freshWorkspace.workspaceId, challengeId: fresh.challengeId, response: { origin: ORIGIN }, bootstrapCapability: freshWorkspace.bootstrapCapability }),
+    (error) => {
+      assertControlError(error, "challenge_invalid_or_used");
+      return true;
+    }
+  );
+});
+
+test("denies passkey responses from an unconfigured origin", async () => {
+  const { controlPlane } = createControlPlane();
+  const workspace = controlPlane.createWorkspace();
+  const ceremony = await controlPlane.beginRegistration({ workspaceId: workspace.workspaceId, principalId: "owner", displayName: "Owner", bootstrapCapability: workspace.bootstrapCapability });
+  await assert.rejects(
+    controlPlane.finishRegistration({ workspaceId: workspace.workspaceId, challengeId: ceremony.challengeId, response: { origin: "https://attacker.example.test" }, bootstrapCapability: workspace.bootstrapCapability }),
+    (error) => {
+      assertControlError(error, "registration_verification_failed");
+      return true;
+    }
+  );
+});
+
+test("denies workspace-scoped authorization tokens outside their workspace", async () => {
+  const { controlPlane } = createControlPlane();
+  const workspace = controlPlane.createWorkspace();
+  await registerOwner(controlPlane, workspace);
+  const authorizationToken = await authorizeOwner(controlPlane, workspace.workspaceId);
+  assert.throws(
+    () => controlPlane.readSnapshot("other-workspace", authorizationToken),
+    (error) => {
+      assertControlError(error, "workspace_authorization_denied");
+      return true;
+    }
+  );
+});
+
+test("consumes approval receipts only once", async () => {
+  const { controlPlane } = createControlPlane();
+  const workspace = controlPlane.createWorkspace();
+  await registerOwner(controlPlane, workspace);
+  const authorizationToken = await authorizeOwner(controlPlane, workspace.workspaceId);
+  const issued = controlPlane.issueReceipt({ workspaceId: workspace.workspaceId, authorizationToken, action: "deploy", payload: { revision: 3 } });
+  assert.deepEqual(controlPlane.consumeReceipt({ workspaceId: workspace.workspaceId, authorizationToken, receipt: issued.receipt }), {
+    workspaceId: workspace.workspaceId,
+    principalId: "owner",
+    action: "deploy",
+    payload: { revision: 3 },
+  });
+  assert.throws(
+    () => controlPlane.consumeReceipt({ workspaceId: workspace.workspaceId, authorizationToken, receipt: issued.receipt }),
+    (error) => {
+      assertControlError(error, "receipt_already_consumed");
+      return true;
+    }
+  );
+});
+
+test("persists the verified passkey signature counter update", async () => {
+  const { controlPlane, db } = createControlPlane();
+  const workspace = controlPlane.createWorkspace();
+  await registerOwner(controlPlane, workspace);
+  await authorizeOwner(controlPlane, workspace.workspaceId);
+  assert.equal((db.prepare("SELECT counter FROM cursus_passkey_credentials WHERE credential_id = ?").get("credential-owner") as { counter: number }).counter, 12);
+});


### PR DESCRIPTION
## Behavior

Adds a server-side Cursus control plane backed by Cabinet storage:

- workspace bootstrap capabilities bound to a single initial passkey ceremony
- WebAuthn owner authentication and workspace-scoped authorization sessions
- atomic revision-checked snapshots with canonical run-state transition enforcement
- server-signed, single-use approval receipts
- verification receipts required for VERIFYING to DONE
- authenticated, content-minimized run-status endpoint

## Verification

`npx tsx --test test/cursus-control-plane.test.ts` — 11 passing tests covering stale-write rejection, canonical state transitions, verification evidence, bootstrap replay/expiry, WebAuthn origin handling, workspace isolation, status redaction, one-time receipt consumption, and signature-counter persistence.

No secrets or deployment configuration are included.