### PR TITLE
feat(rooms): per-room root font size (room.fontSize in the .cabinet manifest)

### DIFF
--- a/src/app/api/rooms/route.ts
+++ b/src/app/api/rooms/route.ts
@@ -31,6 +31,7 @@ export async function PATCH(req: NextRequest) {
       icon?: unknown;
       theme?: unknown;
       color?: unknown;
+      fontSize?: unknown;
     };
 
     if (typeof body.path !== "string") {
@@ -56,6 +57,12 @@ export async function PATCH(req: NextRequest) {
           ? null
           : typeof body.color === "string"
             ? body.color
+            : undefined,
+      fontSize:
+        body.fontSize === null
+          ? null
+          : typeof body.fontSize === "string"
+            ? body.fontSize
             : undefined,
     });
 

--- a/src/components/layout/room-theme-sync.tsx
+++ b/src/components/layout/room-theme-sync.tsx
@@ -40,6 +40,9 @@ export function RoomThemeSync() {
       applyTheme(def);
       setTheme(def.type);
     }
+    // Per-room root font size: the UI is rem-based, so scaling the root
+    // scales everything. Empty string falls back to the stylesheet default.
+    document.documentElement.style.fontSize = room?.fontSize ?? "";
   }, [cabinetPath, rooms, setTheme]);
 
   return null;

--- a/src/lib/cabinets/rooms.ts
+++ b/src/lib/cabinets/rooms.ts
@@ -18,6 +18,7 @@ import { ROOT_CABINET_PATH, normalizeCabinetPath } from "@/lib/cabinets/paths";
  *     icon: briefcase     # key into ROOM_ICONS (src/lib/cabinets/room-icons)
  *     color: "#7c3aed"    # accent CSS color (null → auto from path)
  *     theme: paper        # theme name from src/lib/themes (null → global)
+ *     fontSize: 14px      # root font size (CSS length; null → stylesheet default)
  *
  * The manifest is written lazily the first time a user customizes the room
  * (see `updateRoomMeta`). Manifest writes are atomic (temp + rename) so a
@@ -34,6 +35,12 @@ export interface RoomMeta {
   theme: string | null;
   /** Accent color (CSS color string), or null to auto-derive from the path. */
   color: string | null;
+  /**
+   * Root font size for the room (CSS length like "14px" or "0.9rem"), or
+   * null for the stylesheet default. Applied to `document.documentElement`,
+   * so the whole rem-based UI scales with it.
+   */
+  fontSize: string | null;
   /** Carried for client/back-compat. Always false in v3 — no room is "root". */
   isRoot: boolean;
 }
@@ -87,7 +94,20 @@ function roomFromManifest(
   const icon = room && typeof room.icon === "string" ? room.icon : null;
   const theme = room && typeof room.theme === "string" ? room.theme : null;
   const color = room && typeof room.color === "string" ? room.color : null;
-  return { path: cabinetPath, name, icon, theme, color, isRoot: false };
+  const fontSize =
+    room && typeof room.fontSize === "string" && isValidFontSize(room.fontSize)
+      ? room.fontSize
+      : null;
+  return { path: cabinetPath, name, icon, theme, color, fontSize, isRoot: false };
+}
+
+/**
+ * Accept only plain CSS lengths ("14px", "0.9rem", "95%"). The value ends up
+ * on an inline style of `document.documentElement`, so free-form strings are
+ * rejected rather than sanitized.
+ */
+export function isValidFontSize(value: string): boolean {
+  return /^\d+(\.\d+)?(px|pt|rem|em|%)$/.test(value.trim());
 }
 
 /**
@@ -304,6 +324,7 @@ export async function updateRoomMeta(
     icon?: string | null;
     theme?: string | null;
     color?: string | null;
+    fontSize?: string | null;
   }
 ): Promise<RoomMeta> {
   const normalized =
@@ -347,6 +368,11 @@ export async function updateRoomMeta(
   if (patch.color !== undefined) {
     if (patch.color === null) delete room.color;
     else room.color = patch.color;
+  }
+  if (patch.fontSize !== undefined) {
+    if (patch.fontSize === null) delete room.fontSize;
+    else if (isValidFontSize(patch.fontSize)) room.fontSize = patch.fontSize.trim();
+    else throw new Error("invalid: fontSize must be a CSS length like 14px or 0.9rem");
   }
   manifest.room = room;
 

--- a/src/stores/rooms-store.ts
+++ b/src/stores/rooms-store.ts
@@ -7,6 +7,8 @@ export interface RoomMetaClient {
   icon: string | null;
   theme: string | null;
   color: string | null;
+  /** Root font size (CSS length) applied by RoomThemeSync, or null. */
+  fontSize: string | null;
   isRoot: boolean;
 }
 

--- a/test/rooms-font-size.test.ts
+++ b/test/rooms-font-size.test.ts
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+// Per-room fontSize (room.fontSize in the .cabinet manifest) — validation,
+// round-trip through updateRoomMeta, and clearing back to null.
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cabinet-fontsize-"));
+process.env.CABINET_DATA_DIR = tempRoot;
+
+function roomsModule() {
+  return import("../src/lib/cabinets/rooms");
+}
+
+function scaffoldRoom(slug: string) {
+  const dir = path.join(tempRoot, slug);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, ".cabinet"),
+    ["schemaVersion: 1", `name: ${slug}`, "kind: room", "entry: index.md"].join("\n"),
+    "utf-8"
+  );
+}
+
+test("isValidFontSize accepts CSS lengths and rejects free-form strings", async () => {
+  const { isValidFontSize } = await roomsModule();
+  for (const ok of ["12px", "0.9rem", "14pt", "1.1em", "95%"]) {
+    assert.equal(isValidFontSize(ok), true, ok);
+  }
+  for (const bad of ["12", "calc(1rem + 2px)", "12px; color: red", "url(x)", ""]) {
+    assert.equal(isValidFontSize(bad), false, bad);
+  }
+});
+
+test("updateRoomMeta round-trips fontSize through the manifest", async () => {
+  const { updateRoomMeta, listRooms } = await roomsModule();
+  scaffoldRoom("roomA");
+  const updated = await updateRoomMeta("roomA", { fontSize: "12px" });
+  assert.equal(updated.fontSize, "12px");
+
+  const listed = (await listRooms()).find((r) => r.path === "roomA");
+  assert.equal(listed?.fontSize, "12px");
+});
+
+test("updateRoomMeta rejects a non-length fontSize", async () => {
+  const { updateRoomMeta } = await roomsModule();
+  scaffoldRoom("roomB");
+  await assert.rejects(
+    () => updateRoomMeta("roomB", { fontSize: "12px; position: fixed" }),
+    /invalid: fontSize/
+  );
+});
+
+test("fontSize: null clears the field", async () => {
+  const { updateRoomMeta } = await roomsModule();
+  scaffoldRoom("roomC");
+  await updateRoomMeta("roomC", { fontSize: "0.9rem" });
+  const cleared = await updateRoomMeta("roomC", { fontSize: null });
+  assert.equal(cleared.fontSize, null);
+});


### PR DESCRIPTION
## Motivation

Themes carry a font family (`font` / `headingFont`) but no size, and the rest of the UI's sizing is hard-coded in the app CSS. Self-hosters who want a smaller or larger UI have no supported way to get one that survives an app update.

## What this does

Adds an optional `room.fontSize` to the room's `.cabinet` manifest — so the setting lives in the **data directory** and persists across app updates, same as the per-room theme:

```yaml
room:
  theme: paper
  fontSize: 14px
```

- `rooms.ts`: `RoomMeta.fontSize` + parse + `updateRoomMeta` patch support. Values are validated as plain CSS lengths (`14px`, `0.9rem`, `95%`) and rejected otherwise — the value lands on an inline style of `document.documentElement`, so free-form strings are refused rather than sanitized.
- `PATCH /api/rooms`: passes `fontSize` through (null clears).
- `RoomThemeSync`: applies the active room's `fontSize` to the root element; since the UI is rem-based, the whole room scales. Unset falls back to the stylesheet default, and each window applies its own room's size (multi-window safe, same as theme).

## Validation

- New `test/rooms-font-size.test.ts`: validator accept/reject, manifest round-trip, invalid-value rejection, null-clears. Verified red without the implementation (0/4) and green with it (4/4).
- Full unit suite: 414/414 pass. ESLint clean on touched files.

## Not included (happy to follow up)

A font-size picker in the room-edit dialog — this PR is the schema + apply path; the field is editable via the manifest or `PATCH /api/rooms`. If you'd like the UI in the same PR, tell me and I'll add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)