### PR TITLE
fix: Codex command output grouping

### DIFF
--- a/src/lib/agents/adapters/codex-local.test.ts
+++ b/src/lib/agents/adapters/codex-local.test.ts
@@ -4,6 +4,13 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { codexLocalAdapter } from "./codex-local";
+import {
+  stripToolOutput,
+  TOOL_OUTPUT_CLOSE,
+  TOOL_OUTPUT_OPEN,
+  wrapToolOutput,
+} from "../tool-output-markers";
+import { parseTranscript } from "../transcript-parser";
 
 async function createExecutableScript(source: string): Promise<string> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "cabinet-codex-local-test-"));
@@ -44,7 +51,12 @@ printf '%s\n' \
 
   assert.ok(result);
   assert.equal(result.exitCode, 0);
-  assert.equal(result.output, "Running pwd now.\n\n$ /bin/zsh -lc pwd\n/Users/jane/cabinet\nOK");
+  assert.equal(
+    result.output,
+    `Running pwd now.\n${wrapToolOutput(
+      "$ /bin/zsh -lc pwd\n/Users/jane/cabinet"
+    )}OK`
+  );
   assert.equal(result.summary, "OK");
   assert.equal(result.provider, "codex-cli");
   assert.equal(result.model, "gpt-5.4");
@@ -56,9 +68,24 @@ printf '%s\n' \
     cachedInputTokens: 10,
   });
   assert.deepEqual(chunks, [
-    { stream: "stdout", chunk: "Running pwd now.\n\n$ /bin/zsh -lc pwd\n/Users/jane/cabinet\nOK\n" },
+    {
+      stream: "stdout",
+      chunk: `Running pwd now.\n${wrapToolOutput(
+        "$ /bin/zsh -lc pwd\n/Users/jane/cabinet"
+      )}OK\n`,
+    },
     { stream: "stderr", chunk: "Meaningful stderr line\n" },
   ]);
+
+  const blocks = parseTranscript(result.output || "");
+  assert.deepEqual(
+    blocks.map((block) => block.type),
+    ["text", "tool", "text"]
+  );
+  const tool = blocks.find((block) => block.type === "tool");
+  assert.ok(tool?.type === "tool");
+  assert.match(tool.content, /^\$ \/bin\/zsh -lc pwd/m);
+  assert.match(tool.content, /\/Users\/jane\/cabinet/);
 });
 
 test("codexLocalAdapter surfaces in-stream {type:error} events as errorMessage and classifies model_unavailable", async () => {
@@ -81,6 +108,7 @@ cat >/dev/null
 cat <<'JSONLOG'
 {"type":"thread.started","thread_id":"thread-err"}
 {"type":"turn.started"}
+{"type":"item.started","item":{"id":"item_cmd","type":"command_execution","command":"/bin/zsh -lc pwd"}}
 {"type":"error","message":${JSON.stringify(innerJson)}}
 {"type":"turn.failed","error":{"message":${JSON.stringify(innerJson)}}}
 JSONLOG
@@ -102,6 +130,13 @@ exit 1
     result.errorMessage,
     "The 'gpt-5.2-codex' model is not supported when using Codex with a ChatGPT account."
   );
+  assert.ok(result.output?.includes(TOOL_OUTPUT_OPEN));
+  assert.ok(result.output?.includes(TOOL_OUTPUT_CLOSE));
+  assert.match(stripToolOutput(result.output || ""), /not supported/);
+  assert.ok(!result.summary?.includes(TOOL_OUTPUT_OPEN));
+  assert.ok(!result.summary?.includes(TOOL_OUTPUT_CLOSE));
+  assert.ok(!result.errorMessage?.includes(TOOL_OUTPUT_OPEN));
+  assert.ok(!result.errorMessage?.includes(TOOL_OUTPUT_CLOSE));
 
   // Classifier should now short-circuit to model_unavailable when the
   // stream-captured message is threaded in (mirrors what the runner does
@@ -150,4 +185,32 @@ printf '%s\n' \
     { stream: "stdout", chunk: "CEO online.\n" },
   ]);
   assert.ok(!JSON.stringify(chunks).includes("short-form-video"));
+});
+
+test("codexLocalAdapter does not derive summary or error text from a dangling command", async () => {
+  const scriptPath = await createExecutableScript(`#!/bin/sh
+cat >/dev/null
+printf '%s\n' \\
+  '{"type":"thread.started","thread_id":"thread-aborted"}' \\
+  '{"type":"item.started","item":{"id":"item_cmd","type":"command_execution","command":"/bin/zsh -lc pwd"}}'
+exit 1
+`);
+
+  const result = await codexLocalAdapter.execute?.({
+    runId: "run-aborted",
+    adapterType: "codex_local",
+    config: { command: scriptPath, model: "gpt-5.4" },
+    prompt: "hi",
+    cwd: process.cwd(),
+    onLog: async () => {},
+  });
+
+  assert.ok(result);
+  assert.equal(result.exitCode, 1);
+  assert.equal(result.summary, null);
+  assert.equal(result.errorMessage, "Codex local execution failed.");
+  assert.ok(result.output?.startsWith(TOOL_OUTPUT_OPEN));
+  assert.ok(result.output?.endsWith(TOOL_OUTPUT_CLOSE));
+  assert.ok(!result.errorMessage?.includes(TOOL_OUTPUT_OPEN));
+  assert.ok(!result.errorMessage?.includes(TOOL_OUTPUT_CLOSE));
 });

--- a/src/lib/agents/adapters/codex-local.ts
+++ b/src/lib/agents/adapters/codex-local.ts
@@ -17,6 +17,7 @@ import { readStringConfig, readEffortConfig } from "./_shared/cli-args";
 import type { AdapterSessionCodec, AgentExecutionAdapter } from "./types";
 import type { ConversationErrorClassification } from "@/types/conversations";
 import { getAdapterRuntimePath, runChildProcess } from "./utils";
+import { stripToolOutput } from "../tool-output-markers";
 
 /**
  * Match codex's backend-rejection events for "this model isn't available on
@@ -200,8 +201,11 @@ export const codexLocalAdapter: AgentExecutionAdapter = {
 
     const filteredStderr = filterCodexStderr(result.stderr);
     const output = stdoutAccumulator.display.trim() || null;
+    const plainOutput = stripToolOutput(output || "").trim();
     const summaryLine =
-      firstNonEmptyLine(stdoutAccumulator.lastAgentMessage || output || "")?.slice(0, 300) || null;
+      firstNonEmptyLine(
+        stripToolOutput(stdoutAccumulator.lastAgentMessage || plainOutput)
+      )?.slice(0, 300) || null;
     const streamError = stdoutAccumulator.errorMessage?.trim() || null;
     const synthesizedExitCode =
       streamError && (result.exitCode ?? 0) === 0 && !result.timedOut
@@ -218,7 +222,7 @@ export const codexLocalAdapter: AgentExecutionAdapter = {
           : streamError
             || filteredStderr
             || result.stderr.trim()
-            || output
+            || plainOutput
             || "Codex local execution failed.",
       usage: stdoutAccumulator.usage,
       sessionId: stdoutAccumulator.threadId,

--- a/src/lib/agents/adapters/codex-stream.ts
+++ b/src/lib/agents/adapters/codex-stream.ts
@@ -1,4 +1,9 @@
 import type { AdapterUsageSummary } from "./types";
+import {
+  TOOL_OUTPUT_CLOSE,
+  TOOL_OUTPUT_OPEN,
+  wrapToolOutput,
+} from "../tool-output-markers";
 
 interface CodexTurnCompletedPayload {
   type?: string;
@@ -58,6 +63,12 @@ function appendDisplay(
   return text;
 }
 
+function closeActiveToolFence(accumulator: CodexStreamAccumulator): string {
+  if (accumulator.startedCommands.size === 0) return "";
+  accumulator.startedCommands.clear();
+  return TOOL_OUTPUT_CLOSE;
+}
+
 function normalizeAgentMessage(text: string): string {
   const trimmed = text.trim();
   if (!trimmed) return "";
@@ -67,7 +78,7 @@ function normalizeAgentMessage(text: string): string {
 function normalizeCommandStart(command: string): string {
   const trimmed = command.trim();
   if (!trimmed) return "";
-  return `\n$ ${trimmed}\n`;
+  return `$ ${trimmed}\n`;
 }
 
 function normalizeCommandOutput(output: string): string {
@@ -154,14 +165,22 @@ function consumeCodexEvent(
       if (!accumulator.errorMessage) {
         accumulator.errorMessage = message;
       }
-      return message ? appendDisplay(accumulator, `${message}\n`) : "";
+      const close = closeActiveToolFence(accumulator);
+      return appendDisplay(
+        accumulator,
+        `${close}${message ? `${message}\n` : ""}`
+      );
     }
     if (payload.type === "turn.failed") {
       const message = extractErrorMessage(payload.error?.message);
       if (!accumulator.errorMessage) {
         accumulator.errorMessage = message;
       }
-      return message ? appendDisplay(accumulator, `${message}\n`) : "";
+      const close = closeActiveToolFence(accumulator);
+      return appendDisplay(
+        accumulator,
+        `${close}${message ? `${message}\n` : ""}`
+      );
     }
 
     if (!payload.item) {
@@ -172,10 +191,13 @@ function consumeCodexEvent(
 
     if (payload.type === "item.started" && payload.item.type === "command_execution") {
       if (!itemId) return "";
+      const command = normalizeCommandStart(payload.item.command || "");
+      if (!command) return "";
+      const opensToolFence = accumulator.startedCommands.size === 0;
       accumulator.startedCommands.add(itemId);
       return appendDisplay(
         accumulator,
-        normalizeCommandStart(payload.item.command || "")
+        `${opensToolFence ? TOOL_OUTPUT_OPEN : ""}${command}`
       );
     }
 
@@ -183,19 +205,36 @@ function consumeCodexEvent(
       const text = normalizeAgentMessage(payload.item.text || "");
       if (!text) return "";
       accumulator.lastAgentMessage = payload.item.text?.trim() || null;
-      return appendDisplay(accumulator, text);
+      const display = accumulator.startedCommands.size > 0
+        ? `${TOOL_OUTPUT_CLOSE}${text}${TOOL_OUTPUT_OPEN}`
+        : text;
+      return appendDisplay(accumulator, display);
     }
 
     if (payload.type === "item.completed" && payload.item.type === "command_execution") {
-      let display = "";
-      if (itemId && !accumulator.startedCommands.has(itemId)) {
-        display += normalizeCommandStart(payload.item.command || "");
-      }
+      const commandStarted = Boolean(
+        itemId && accumulator.startedCommands.has(itemId)
+      );
       if (itemId) {
         accumulator.startedCommands.delete(itemId);
       }
 
-      display += normalizeCommandOutput(payload.item.aggregated_output || "");
+      const output = normalizeCommandOutput(payload.item.aggregated_output || "");
+      let display: string;
+      if (commandStarted) {
+        const closesToolFence = accumulator.startedCommands.size === 0;
+        display = closesToolFence
+          ? `${output.trimEnd()}${TOOL_OUTPUT_CLOSE}`
+          : output;
+      } else {
+        const completedCommand = `${normalizeCommandStart(
+          payload.item.command || ""
+        )}${output}`;
+        if (!completedCommand.trim()) return "";
+        display = accumulator.startedCommands.size > 0
+          ? completedCommand
+          : wrapToolOutput(completedCommand.trimEnd());
+      }
       return appendDisplay(accumulator, display);
     }
   } catch {
@@ -236,13 +275,15 @@ export function consumeCodexJsonStream(
 export function flushCodexJsonStream(
   accumulator: CodexStreamAccumulator
 ): string {
-  if (!accumulator.buffer) {
-    return "";
+  let display = "";
+  if (accumulator.buffer) {
+    const buffered = accumulator.buffer;
+    accumulator.buffer = "";
+    display += consumeCodexEvent(accumulator, buffered);
   }
 
-  const buffered = accumulator.buffer;
-  accumulator.buffer = "";
-  return consumeCodexEvent(accumulator, buffered);
+  display += appendDisplay(accumulator, closeActiveToolFence(accumulator));
+  return display;
 }
 
 const CODEX_STDERR_NOISE_PATTERNS = [

--- a/test/tool-output-fencing.test.ts
+++ b/test/tool-output-fencing.test.ts
@@ -7,6 +7,11 @@ import {
   TOOL_OUTPUT_CLOSE,
 } from "@/lib/agents/tool-output-markers";
 import { parseTranscript } from "@/lib/agents/transcript-parser";
+import {
+  consumeCodexJsonStream,
+  createCodexStreamAccumulator,
+  flushCodexJsonStream,
+} from "@/lib/agents/adapters/codex-stream";
 
 test("markers are non-control, non-whitespace PUA codepoints", () => {
   assert.equal(TOOL_OUTPUT_OPEN.charCodeAt(0), 0xe000);
@@ -98,4 +103,192 @@ test("transcript with no markers parses exactly as before", () => {
   const blocks = parseTranscript("Just a normal answer.\n\nWith two paragraphs.");
   assert.equal(blocks.length, 1);
   assert.equal(blocks[0].type, "text");
+});
+
+test("Codex command events stream into one collapsible tool block", () => {
+  const accumulator = createCodexStreamAccumulator();
+  const prose = consumeCodexJsonStream(
+    accumulator,
+    '{"type":"item.completed","item":{"id":"msg_1","type":"agent_message","text":"I will inspect the folder."}}\n'
+  );
+  const started = consumeCodexJsonStream(
+    accumulator,
+    '{"type":"item.started","item":{"id":"cmd_1","type":"command_execution","command":"/bin/zsh -lc ls"}}\n'
+  );
+
+  assert.equal(prose, "I will inspect the folder.\n");
+  assert.ok(started.startsWith(TOOL_OUTPUT_OPEN));
+  assert.ok(!started.includes(TOOL_OUTPUT_CLOSE));
+
+  const liveBlocks = parseTranscript(accumulator.display);
+  assert.deepEqual(
+    liveBlocks.map((block) => block.type),
+    ["text", "tool"]
+  );
+
+  const completed = consumeCodexJsonStream(
+    accumulator,
+    '{"type":"item.completed","item":{"id":"cmd_1","type":"command_execution","command":"/bin/zsh -lc ls","aggregated_output":"index.md\\nnotes.md\\n","exit_code":0,"status":"completed"}}\n'
+  );
+  const answer = consumeCodexJsonStream(
+    accumulator,
+    '{"type":"item.completed","item":{"id":"msg_2","type":"agent_message","text":"I found both files."}}\n'
+  );
+
+  assert.ok(completed.endsWith(TOOL_OUTPUT_CLOSE));
+  assert.equal(answer, "I found both files.\n");
+  const blocks = parseTranscript(accumulator.display);
+  assert.deepEqual(
+    blocks.map((block) => block.type),
+    ["text", "tool", "text"]
+  );
+  const tool = blocks.find((block) => block.type === "tool");
+  assert.ok(tool?.type === "tool");
+  assert.equal(tool.steps, 1);
+  assert.match(tool.content, /^\$ \/bin\/zsh -lc ls/m);
+  assert.match(tool.content, /index\.md/);
+  const text = blocks.filter((block) => block.type === "text");
+  assert.ok(
+    text.every(
+      (block) => block.type === "text" && !block.content.includes("index.md")
+    )
+  );
+});
+
+test("Codex completed commands are fenced even when the start event was missed", () => {
+  const accumulator = createCodexStreamAccumulator();
+  const display = consumeCodexJsonStream(
+    accumulator,
+    '{"type":"item.completed","item":{"id":"cmd_late","type":"command_execution","command":"pwd","aggregated_output":"/tmp/project\\n","exit_code":0,"status":"completed"}}\n'
+  );
+
+  assert.ok(display.startsWith(TOOL_OUTPUT_OPEN));
+  assert.ok(display.endsWith(TOOL_OUTPUT_CLOSE));
+  const [block] = parseTranscript(display);
+  assert.ok(block?.type === "tool");
+  assert.match(block.content, /^\$ pwd/m);
+  assert.match(block.content, /\/tmp\/project/);
+});
+
+test("Codex terminal errors close active tool output before visible error prose", () => {
+  const terminalEvents = [
+    '{"type":"error","message":"usage limit reached"}\n',
+    '{"type":"turn.failed","error":{"message":"usage limit reached"}}\n',
+  ];
+
+  for (const terminalEvent of terminalEvents) {
+    const accumulator = createCodexStreamAccumulator();
+    consumeCodexJsonStream(
+      accumulator,
+      '{"type":"item.started","item":{"id":"cmd_1","type":"command_execution","command":"long-running-command"}}\n'
+    );
+    consumeCodexJsonStream(accumulator, terminalEvent);
+    consumeCodexJsonStream(
+      accumulator,
+      '{"type":"item.completed","item":{"id":"msg_final","type":"agent_message","text":"Try again after the limit resets."}}\n'
+    );
+
+    assert.equal(accumulator.startedCommands.size, 0);
+    assert.equal(accumulator.display.split(TOOL_OUTPUT_OPEN).length - 1, 1);
+    assert.equal(accumulator.display.split(TOOL_OUTPUT_CLOSE).length - 1, 1);
+    assert.deepEqual(
+      parseTranscript(accumulator.display).map((block) => block.type),
+      ["tool", "text"]
+    );
+    const visible = stripToolOutput(accumulator.display);
+    assert.match(visible, /usage limit reached/);
+    assert.match(visible, /Try again after the limit resets/);
+    assert.doesNotMatch(visible, /long-running-command/);
+  }
+});
+
+test("Codex flush closes a command left active by an abnormal process exit", () => {
+  const accumulator = createCodexStreamAccumulator();
+  consumeCodexJsonStream(
+    accumulator,
+    '{"type":"item.started","item":{"id":"cmd_1","type":"command_execution","command":"pwd"}}\n'
+  );
+
+  const flushed = flushCodexJsonStream(accumulator);
+  assert.equal(flushed, TOOL_OUTPUT_CLOSE);
+  assert.equal(accumulator.startedCommands.size, 0);
+  assert.equal(accumulator.display.split(TOOL_OUTPUT_OPEN).length - 1, 1);
+  assert.equal(accumulator.display.split(TOOL_OUTPUT_CLOSE).length - 1, 1);
+  assert.equal(stripToolOutput(accumulator.display), "");
+  assert.equal(flushCodexJsonStream(accumulator), "");
+});
+
+test("overlapping Codex commands share one balanced outer tool fence", () => {
+  const accumulator = createCodexStreamAccumulator();
+  consumeCodexJsonStream(
+    accumulator,
+    '{"type":"item.started","item":{"id":"cmd_a","type":"command_execution","command":"command-a"}}\n'
+  );
+  consumeCodexJsonStream(
+    accumulator,
+    '{"type":"item.started","item":{"id":"cmd_b","type":"command_execution","command":"command-b"}}\n'
+  );
+  consumeCodexJsonStream(
+    accumulator,
+    '{"type":"item.completed","item":{"id":"cmd_a","type":"command_execution","command":"command-a","aggregated_output":"out-a\\n","exit_code":0,"status":"completed"}}\n'
+  );
+  consumeCodexJsonStream(
+    accumulator,
+    '{"type":"item.completed","item":{"id":"cmd_b","type":"command_execution","command":"command-b","aggregated_output":"out-b\\n","exit_code":0,"status":"completed"}}\n'
+  );
+  consumeCodexJsonStream(
+    accumulator,
+    '{"type":"item.completed","item":{"id":"msg_1","type":"agent_message","text":"Both commands finished."}}\n'
+  );
+
+  assert.equal(accumulator.startedCommands.size, 0);
+  assert.equal(accumulator.display.split(TOOL_OUTPUT_OPEN).length - 1, 1);
+  assert.equal(accumulator.display.split(TOOL_OUTPUT_CLOSE).length - 1, 1);
+  const blocks = parseTranscript(accumulator.display);
+  assert.deepEqual(
+    blocks.map((block) => block.type),
+    ["tool", "text"]
+  );
+  const tool = blocks.find((block) => block.type === "tool");
+  assert.ok(tool?.type === "tool");
+  assert.match(tool.content, /command-a/);
+  assert.match(tool.content, /command-b/);
+  assert.match(tool.content, /out-a/);
+  assert.match(tool.content, /out-b/);
+  assert.equal(stripToolOutput(accumulator.display), "Both commands finished.");
+});
+
+test("Codex agent prose remains visible while a command is in flight", () => {
+  const accumulator = createCodexStreamAccumulator();
+  consumeCodexJsonStream(
+    accumulator,
+    '{"type":"item.started","item":{"id":"cmd_1","type":"command_execution","command":"npm test"}}\n'
+  );
+  consumeCodexJsonStream(
+    accumulator,
+    '{"type":"item.completed","item":{"id":"msg_progress","type":"agent_message","text":"Tests are running, this may take a while."}}\n'
+  );
+
+  assert.equal(accumulator.startedCommands.size, 1);
+
+  consumeCodexJsonStream(
+    accumulator,
+    '{"type":"item.completed","item":{"id":"cmd_1","type":"command_execution","command":"npm test","aggregated_output":"ok\\n","exit_code":0,"status":"completed"}}\n'
+  );
+  consumeCodexJsonStream(
+    accumulator,
+    '{"type":"item.completed","item":{"id":"msg_final","type":"agent_message","text":"All green."}}\n'
+  );
+
+  assert.equal(accumulator.startedCommands.size, 0);
+  assert.equal(accumulator.display.split(TOOL_OUTPUT_OPEN).length - 1, 2);
+  assert.equal(accumulator.display.split(TOOL_OUTPUT_CLOSE).length - 1, 2);
+  assert.deepEqual(
+    parseTranscript(accumulator.display).map((block) => block.type),
+    ["tool", "text", "tool", "text"]
+  );
+  const visible = stripToolOutput(accumulator.display);
+  assert.match(visible, /Tests are running, this may take a while\./);
+  assert.match(visible, /All green\./);
+  assert.doesNotMatch(visible, /npm test|ok/);
 });


### PR DESCRIPTION
# Before:
<img width="773" height="702" alt="cabinet-before" src="https://github.com/user-attachments/assets/cf59bb67-7f43-4e00-9c4c-8fc700ee90df" />


# After:
<img width="753" height="691" alt="cabinet-after" src="https://github.com/user-attachments/assets/a12bb149-c3ec-4dd6-bc2c-4cbbd3ebdb3b" />


## Summary

- Group Codex command executions into collapsible tool-output blocks
- Keep agent prose and terminal errors visible while commands are running
- Handle overlapping commands, abnormal exits, missed starts, and incomplete streams without malformed output
- Exclude command output from task summaries and fallback error messages
- Add regression coverage for normal, overlapping, interrupted, and interleaved command streams

## Testing

- Focused Codex/tool-output suite: 19/19 passed
- TypeScript compilation passed with `tsc --noEmit`
- Changed-file linting passed without errors
- `git diff --check` passed
- Full suite: 416/418 passed
  - One provider timeout passed when rerun in isolation
  - One unrelated conversation-store cleanup race remains (`ENOTEMPTY` while removing its temporary directory)

## UI verification

Verified locally that command output renders inside a collapsed “Ran a command” disclosure and expands into a readable monospace output block.