### PR TITLE
fix(settings): add a way back to Settings from the Integrations hub

### DIFF
--- a/src/components/integrations/hub/integrations-hub-page.tsx
+++ b/src/components/integrations/hub/integrations-hub-page.tsx
@@ -11,7 +11,8 @@ import {
 } from "@/lib/integrations/preview-catalog";
 import { IntegrationDetailPage } from "@/components/integrations/hub/integration-detail-page";
 import { LayoutGallery } from "@/components/integrations/hub/layouts/layout-gallery";
-import { useAppStore } from "@/stores/app-store";
+import { useAppStore, type SelectedSection } from "@/stores/app-store";
+import { ReturnToChip } from "@/components/layout/return-to-chip";
 import { CliMcpSection } from "@/components/settings/cli-mcp-section";
 import { ApiKeysSection } from "@/components/settings/api-keys-section";
 import { BuiltInToolsSection } from "@/components/settings/built-in-tools-section";
@@ -47,7 +48,13 @@ export function IntegrationsHubPage() {
   const selectedVia = useAppStore((s) =>
     s.section.type === "integrations" ? s.section.integrationVia ?? null : null,
   );
-  const setSection = useAppStore((s) => s.setSection);
+  // Intra-hub navigation (gallery ↔ connector detail). Plain setSection would
+  // clear `returnTo` and lose the "Back to Settings" chip, so re-push it.
+  const navigateWithinHub = (section: SelectedSection) => {
+    const { returnTo, pushSection, setSection } = useAppStore.getState();
+    if (returnTo) pushSection(section, returnTo);
+    else setSection(section);
+  };
 
   // Which connectors (and suites) are actually connected — drives the only badge
   // we show. Re-checked when returning from a detail (a connect may have landed).
@@ -110,7 +117,7 @@ export function IntegrationsHubPage() {
       <IntegrationDetailPage
         item={selected}
         via={selectedVia}
-        onBack={() => setSection({ type: "integrations" })}
+        onBack={() => navigateWithinHub({ type: "integrations" })}
       />
     );
   }
@@ -121,6 +128,7 @@ export function IntegrationsHubPage() {
         <div className="mx-auto max-w-6xl px-6 pt-5">
           <div className="flex items-start justify-between gap-4">
             <div className="min-w-0">
+              <ReturnToChip />
               <h1 className="text-xl font-semibold tracking-tight text-foreground">
                 Integrations
               </h1>
@@ -185,7 +193,7 @@ export function IntegrationsHubPage() {
                 id === "google-drive" || id === "gmail"
                   ? id
                   : connectTargetFor(id);
-              setSection({
+              navigateWithinHub({
                 type: "integrations",
                 slug,
                 // Remember the actual card when it routes to a suite, so the

--- a/src/components/settings/settings-page.tsx
+++ b/src/components/settings/settings-page.tsx
@@ -770,7 +770,9 @@ export function SettingsPage() {
           id: "integrations" as Tab,
           label: t("settings:tabs.integrations"),
           icon: <Blocks className="h-3.5 w-3.5" />,
-          onSelect: () => useAppStore.getState().setSection({ type: "integrations" }),
+          // pushSection (not setSection) so the hub's ReturnToChip can bring
+          // the user back to the settings tab they left from.
+          onSelect: () => useAppStore.getState().pushSection({ type: "integrations" }, { type: "settings", slug: tab }),
         },
         { id: "skills", label: t("settings:tabs.skills"), icon: <Asterisk className="h-3.5 w-3.5" /> },
         { id: "storage", label: t("settings:tabs.storage"), icon: <HardDrive className="h-3.5 w-3.5" /> },
@@ -828,7 +830,7 @@ export function SettingsPage() {
               {group.items.map((t) => (
                 <a
                   key={t.id}
-                  href={t.onSelect ? "/integrations" : `#/settings/${t.id}`}
+                  href={t.onSelect ? "#/integrations" : `#/settings/${t.id}`}
                   aria-current={tab === t.id ? "page" : undefined}
                   onClick={(e) => {
                     e.preventDefault();
@@ -857,7 +859,7 @@ export function SettingsPage() {
             {tabGroups.flatMap((g) => g.items).map((t) => (
               <a
                 key={t.id}
-                href={t.onSelect ? "/integrations" : `#/settings/${t.id}`}
+                href={t.onSelect ? "#/integrations" : `#/settings/${t.id}`}
                 aria-current={tab === t.id ? "page" : undefined}
                 onClick={(e) => {
                   e.preventDefault();


### PR DESCRIPTION
Clicking "Integrations" in the settings sidebar jumps to the top-level Integrations hub with no way back to Settings, which is confusing and poor UX.

Since the hub is deliberately its own section (#250), this doesn't move it back under Settings - it just remembers where you came from. The settings item now uses pushSection, and the hub header shows the existing ReturnToChip, which returns you to the exact tab you left. The chip stays hidden when you arrive from the sidebar, home, or mobile nav, and persists when you drill into a connector detail. Also fixed the item's href (/integrations -> #/integrations) so middle-click / open-in-new-tab works.
