### PR TITLE
fix: restore the broken star history chart in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,10 +325,10 @@ MIT License
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=cabinetai%2Fcabinet&type=date&legend=top-left" target="_blank" rel="noopener noreferrer">
+<a href="https://star-history.dera.page/#cabinetai/cabinet&type=date" target="_blank" rel="noopener noreferrer">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=cabinetai/cabinet&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=cabinetai/cabinet&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=cabinetai/cabinet&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=cabinetai/cabinet&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=cabinetai/cabinet&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=cabinetai/cabinet&type=date&legend=top-left" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart in the README is currently broken and does not render. GitHub's stargazer API restrictions broke the provider we relied on. This PR moves the chart to a working provider that reads from a different data source requiring no API token, so the chart renders correctly again. The wrapping link now points at a hash-based URL and the chart image is served over SVG.